### PR TITLE
Update lib/views/help/credits.rhtml

### DIFF
--- a/lib/views/help/credits.rhtml
+++ b/lib/views/help/credits.rhtml
@@ -43,8 +43,20 @@
     The amazing team of volunteers who run the site, answer your support
     emails, maintain the database of public authorities and 
     <a href="http://www.mysociety.org/2009/10/13/behind-whatdotheyknow/">so much more</a>.
-    Thanks to Helen Cross, John Cross, Ben Harris, Adam McGreggor, Ganesh Sittampalam, Alex Skene,
-    Richard Taylor.
+    Thanks to 
+    <a href="http://www.whatdotheyknow.com/user/helen_cross_2">Helen Cross</a>, 
+
+    <a href="http://www.whatdotheyknow.com/user/john_cross">John Cross</a>, 
+
+    <a href="http://www.whatdotheyknow.com/user/ben_harris">Ben Harris</a>, 
+
+    <a href="http://www.whatdotheyknow.com/user/adam_mcgreggor">Adam McGreggor</a>, 
+
+    <a href="http://www.whatdotheyknow.com/user/ganesh_sittampalam">Ganesh Sittampalam</a>, 
+
+    <a href="http://www.whatdotheyknow.com/user/alex_skene">Alex Skene</a>,
+    
+    <a href="http://www.whatdotheyknow.com/user/richard_taylor">Richard Taylor</a>.
 </li>
 <li>
     Volunteers who have provided patches to the code – thanks Peter Collingbourne,


### PR DESCRIPTION
adding hyperlinks to the accounts of the volunteers who answer support emails.

This partly address issue 30: https://github.com/mysociety/whatdotheyknow-theme/issues/30
