### PR TITLE
Update about.html.erb

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -65,7 +65,7 @@ UKCOD is a registered charity in England and Wales (no.
 UKCOD is also a limited company registered in England and Wales (no.
 <a href="http://opencorporates.com/companies/gb/03277032">03277032</a>)
 and a registered data controller (no.
-<a href="http://www.ico.gov.uk/ESDWebPages/Search.asp?Registration=Z9602302">Z9602302</a>).
+<a href="http://www.ico.org.uk/ESDWebPages/DoSearch?reg=182425">Z9602302</a>).
 The <a href="http://www.ukcod.org.uk/UKCOD_Trustees">UKCOD trustees</a> form the governing body of the charity
 and are ultimately responsible for controlling the management and administration of the charity. UKCOD's registered
 office is 483 Green Lanes, London, N13 4BS. UKCOD is not a public body.


### PR DESCRIPTION
The ICO now has a .org.uk web address replacing the .gov.uk.
