### PR TITLE
Update requesting.html.erb

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -136,7 +136,7 @@ annotations after submitting the request).
 acknowledgement messages saying they &ldquo;may&rdquo; charge a fee. Ignore such notices.
 They hardly ever will actually charge a fee. If they do, they can only charge you if
 you have specifically agreed in advance to pay. <a
-    href="http://www.ico.gov.uk/upload/documents/library/freedom_of_information/practical_application/chargingafee.pdf">More
+    href="http://www.ico.org.uk/upload/documents/library/freedom_of_information/practical_application/chargingafee.pdf">More
     details</a> from the Information Commissioner.
 </p>
 


### PR DESCRIPTION
ICO now use ICO.org.uk rather than ICO.gov.uk
