### PR TITLE
Update public_body_categories_en.rb

### DIFF
--- a/lib/public_body_categories_en.rb
+++ b/lib/public_body_categories_en.rb
@@ -36,6 +36,7 @@ PublicBodyCategories.add(:en, [
             [ "udc", "Urban Development Company", "an urban development company" ],
             [ "vjb", "Valuation joint boards (Scotland)", "a valuation joint board" ],
             [ "companies_owned_by_local_gov", "Companies owned by local government", "a company owned by local government" ],
+            [ "bodies_funded_by_local_gov", "bodies funded by local government", "a body funded by local government" ],
         "Education",
             [ "university", "Universities", "a university" ],
             [ "university_college", "University colleges", "a university college" ],


### PR DESCRIPTION
An extension to FOISA came into force recently on Tuesday 1 April.  

My understanding of it is that it makes bodies established or created solely by one or more local authorities whose functions on behalf of any of those authorities (include developing and/or delivering recreational, sporting, cultural or social facilities and activities) and which in carrying out those functions is financed wholly or in part by any of those authorities subject to the Freedom of Information (Scotland) Act 2002.

<!---
@huboard:{"order":1363.5,"custom_state":""}
-->
