### PR TITLE
Add honeypot spam protection to contact form

### DIFF
--- a/lib/views/help/contact.cy.html.erb
+++ b/lib/views/help/contact.cy.html.erb
@@ -58,6 +58,11 @@ neu anfonwch e-bost at <a href="mailto:<%=@contact_email%>"><%=@contact_email%><
         <%= f.text_area :message, :rows => 10, :cols => 60 %>
     </p>
 
+    <p style="display:none;">
+        <%= f.label :comment, "Peidiwch â llenwi'r yn y maes hwn" %>
+        <%= f.text_field :comment %>
+    </p>
+
     <% if !@last_request.nil? %>
         <p>
             <label class="form_label" for="contact_message">Include link to request:</label>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -72,6 +72,11 @@
         <%= f.text_area :message, :rows => 10, :cols => 60 %>
     </p>
 
+    <p style="display:none;">
+        <%= f.label :comment, 'Do not fill in this field' %>
+        <%= f.text_field :comment %>
+    </p>
+
     <% if !@last_request.nil? %>
         <p>
             <label class="form_label" for="contact_message">Include link to request:</label>


### PR DESCRIPTION
Requires mysociety/alaveteli@6fbaed8b841d081681fe970abab38b648fed5253
Original: mysociety/alaveteli#1410

Intercepts the request and redirects to the homepage if the comment
field is filled in on the contact form.
