### PR TITLE
A/B test responsive theme

### DIFF
--- a/lib/views/general/_before_head_end.html.erb
+++ b/lib/views/general/_before_head_end.html.erb
@@ -1,18 +1,21 @@
-<!-- Google Analytics Content Experiment code -->
-<script>function utmx_section(){}function utmx(){}(function(){var
-k='48388638-0',d=document,l=d.location,c=d.cookie;
-if(l.search.indexOf('utm_expid='+k)>0)return;
-function f(n){if(c){var i=c.indexOf(n+'=');if(i>-1){var j=c.
-indexOf(';',i);return escape(c.substring(i+n.length+1,j<0?c.
-length:j))}}}var x=f('__utmx'),xx=f('__utmxx'),h=l.hash;d.write(
-'<sc'+'ript src="'+'http'+(l.protocol=='https:'?'s://ssl':
-'://www')+'.google-analytics.com/ga_exp.js?'+'utmxkey='+k+
-'&utmx='+(x?x:'')+'&utmxx='+(xx?xx:'')+'&utmxtime='+new Date().
-valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
-'" type="text/javascript" charset="utf-8"><\/sc'+'ript>')})();
-</script><script>utmx('url','A/B');</script>
-<!-- End of Google Analytics Content Experiment code -->
+<!-- Load the Content Experiment JavaScript API client for the experiment -->
+<script src="//www.google-analytics.com/cx/api.js?experiment=aAMRer1_RLyfIayGP3A1EA"></script>
 
+<script>
+  // Ask Google Analytics which variation to show the user.
+  var chosenVariation = cxApi.chooseVariation();
+</script>
 
+<script type="text/javascript">
+if (chosenVariation == 1){
+  var responsive_stylesheets = "<%= escape_javascript(render :partial => 'general/responsive_stylesheet_includes') %>";
+  var responsive_header = "<%= escape_javascript(render :partial => 'general/responsive_header', :locals => { :responsive => true }) %>";
+  var responsive_footer = "<%= escape_javascript(render :partial => 'general/responsive_footer') %>";
+  $('.main-stylesheet').attr('disabled', 'disabled');
+  document.write('<meta name="viewport" content="width=device-width, initial-scale=1.0" />');
+  document.write(responsive_stylesheets);
+}
+</script>
 <script type="text/javascript" src="//use.typekit.net/csi1ugd.js"></script>
 <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+

--- a/lib/views/general/_locale_switcher.html.erb
+++ b/lib/views/general/_locale_switcher.html.erb
@@ -1,4 +1,4 @@
-<% if AlaveteliConfiguration::responsive_styling || params[:responsive] %>
+<% if AlaveteliConfiguration::responsive_styling || params[:responsive] || local_assigns[:responsive] == true %>
 <div class="ms-header__logo">
   <a href="http://mysociety.org">mySociety</a>
 </div>

--- a/lib/views/general/_responsive_header.html.erb
+++ b/lib/views/general/_responsive_header.html.erb
@@ -1,0 +1,31 @@
+<div id="banner">
+  <div id="banner_inner">
+    <div id="banner_content">
+      <div id="logo_wrapper">
+        <%= link_to image_tag('logo.png'), frontpage_path, :id => 'logo' %>
+      </div>
+      <div class="rsp_menu_button">
+        <a href="#banner" class="open"> <i class="icon-menu"></i> Menu </a>
+        <a href="#" class="close"> <i class="icon-menu"></i> Close </a>
+      </div>
+      <%= render :partial => 'general/locale_switcher', :locals => { :responsive => local_assigns[:responsive] } %>
+      <% if ! (controller.action_name == 'signin' or controller.action_name == 'signup') %>
+        <div id="logged_in_bar">
+          <div id="logged_in_links">
+          <% if @user %>
+            <span class="greeting"><%= _('Hello, {{username}}!', :username => @user.name) %></span>
+            <%=link_to _("My requests"), show_user_requests_path(:url_name => @user.url_name) %>
+            <%=link_to _("My profile"), show_user_profile_path(:url_name => @user.url_name) %>
+            <%=link_to _("My wall"), show_user_wall_path(:url_name => @user.url_name) %>
+            <%= link_to _("Sign out"), signout_path(:r => request.fullpath) %>
+          <% else %>
+               <%= link_to _("Sign in or sign up"), signin_path(:r => request.fullpath) %>
+          <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <%= render :partial => 'general/responsive_topnav' %>
+  </div>
+</div>
+

--- a/lib/views/general/_responsive_stylesheet_includes.html.erb
+++ b/lib/views/general/_responsive_stylesheet_includes.html.erb
@@ -1,0 +1,15 @@
+<%- if @render_to_file %>
+  <style>
+  <%= Rails.application.assets["responsive/application.css"].to_s %>
+  <%= Rails.application.assets["responsive/print.css"].to_s %>
+  </style>
+<%- else %>
+  <%= render :partial => 'general/responsive_stylesheets' %>
+  <%= stylesheet_link_tag 'responsive/print', :rel => "stylesheet", :media => "print"  %>
+  <% if !params[:print_stylesheet].nil? %>
+  <%= stylesheet_link_tag 'responsive/print', :rel => "stylesheet", :media => "all"  %>
+  <% end %>
+  <% if AlaveteliConfiguration::force_registration_on_new_request %>
+  <%= stylesheet_link_tag 'fancybox.css', :rel => "stylesheet"  %>
+  <% end %>
+<% end %>

--- a/lib/views/general/_stylesheet_includes.html.erb
+++ b/lib/views/general/_stylesheet_includes.html.erb
@@ -1,0 +1,27 @@
+
+<% if AlaveteliConfiguration::responsive_styling || params[:responsive] %>
+  <%= render :partial => 'general/responsive_stylesheet_includes' %>
+<% else %>
+  <%- if @render_to_file %>
+    <style>
+    <%= Rails.application.assets["main.css"].to_s %>
+    <%= Rails.application.assets["print.css"].to_s %>
+    </style>
+  <%- else %>
+    <%= stylesheet_link_tag 'application', :title => "Main", :rel => "stylesheet", :media => "all", :class => 'main-stylesheet' %>
+    <%= stylesheet_link_tag 'fonts', :rel => "stylesheet", :media => "all",  :class => 'main-stylesheet' %>
+    <%= stylesheet_link_tag 'print', :rel => "stylesheet", :media => "print", :class => 'main-stylesheet'  %>
+    <% if !params[:print_stylesheet].nil? %>
+    <%= stylesheet_link_tag 'print', :rel => "stylesheet", :media => "all", :class => 'main-stylesheet' %>
+    <% end %>
+    <!--[if LT IE 7]>
+    <%= stylesheet_link_tag 'ie6.css', :class => 'main-stylesheet' %>
+    <![endif]-->
+    <!--[if LT IE 8]>
+    <%= stylesheet_link_tag 'ie7.css', :class => 'main-stylesheet' %>
+    <![endif]-->
+    <% if AlaveteliConfiguration::force_registration_on_new_request %>
+    <%= stylesheet_link_tag 'fancybox.css', :rel => "stylesheet", :class => 'main-stylesheet'  %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/lib/views/layouts/default.html.erb
+++ b/lib/views/layouts/default.html.erb
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+    <head>
+        <meta charset="utf-8">
+        <%= csrf_meta_tags %>
+
+        <title>
+        <% if @title %>
+            <%=@title%> - <%= site_name %>
+        <% else %>
+            <%= site_name %> - <%= _('Make and browse Freedom of Information (FOI) requests') %>
+        <% end %>
+        </title>
+
+        <%= render :partial => 'layouts/favicon' %>
+
+
+        <%= render :partial => 'general/stylesheet_includes' %>
+
+        <% if is_admin? %>
+          <%= stylesheet_link_tag "admin", :title => "Main", :rel => "stylesheet" %>
+        <% end %>
+
+        <%= javascript_include_tag "application" %>
+        <% if @profile_photo_javascript %>
+            <%= javascript_include_tag "profile-photos" %>
+            <%= stylesheet_link_tag "jquery.Jcrop.css" %>
+        <% end %>
+
+        <% if @feed_autodetect %>
+            <% for feed in @feed_autodetect %>
+                <link rel="alternate" type="application/atom+xml" title="<%=h feed[:title] %>" href="<%=h feed[:url]%>">
+                <% if feed[:has_json] %>
+                    <link rel="alternate" type="application/json" title="JSON version of <%=h feed[:title] %>" href="<%=h feed[:url]%>.json">
+                <% end %>
+            <% end %>
+        <% end %>
+        <% if @has_json %>
+            <link rel="alternate" type="application/json" title="JSON version of this page" href="<%=h url_for(request.params.merge(:format => 'json')) %>">
+        <% end %>
+
+        <% if @no_crawl %>
+            <meta name="robots" content="noindex, nofollow">
+        <% end %>
+        <% if AlaveteliConfiguration::responsive_styling || params[:responsive] %>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <% end %>
+        <%= render :partial => 'general/before_head_end' %>
+    </head>
+    <body class="<%= 'front' if params[:action] == 'frontpage' %>">
+    <% if AlaveteliConfiguration::force_registration_on_new_request && !@user %>
+    <%= javascript_include_tag 'fancybox.js' %>
+    <script type="text/javascript">
+        $(document).ready(function() {
+            $("#make-request-link").fancybox({
+                'modal': false,
+                'width': 950,
+                'height': 400,
+                'type': 'iframe',
+                'href': '/<%= FastGettext.locale %>/profile/sign_in?modal=1',
+                'onClosed': function() {
+                    // modal_signin_successful variable set by modal dialog box
+                    if (typeof modal_signin_successful != 'undefined' ) {
+                        window.location.href = '<%= select_authority_url %>';
+                    }
+                }
+            });
+        });
+    </script>
+    <% end %>
+
+<% if is_admin? %>
+  <%= render :partial => 'admin_general/admin_navbar' %>
+<% end %>
+
+<div class="entirebody">
+    <% popup_banner = render(:partial => "general/popup_banner").strip %>
+    <% if popup_banner.present? and  ! @render_to_file %>
+    <div id="everypage" class="popup">
+      <span class="popup-content">
+      <%= raw popup_banner %>
+      </span>
+      <span class="popup-close"><a href="#top" ><%= _('Close') %></a></span>
+    </div>
+    <% end %>
+    <div id="other-country-notice" class="popup">
+      <span class="popup-content">
+      </span>
+      <span class="popup-close"><a href="#top" ><%= _('Close') %></a></span>
+    </div>
+    <% if AlaveteliConfiguration::responsive_styling || params[:responsive] %>
+        <%= render :partial => 'general/responsive_header' %>
+    <% else %>
+        <%= render :partial => 'general/header' %>
+    <% end %>
+    <script type="text/javascript">
+      if (chosenVariation == 1){
+        var newHeader = document.createElement('div');
+        newHeader.innerHTML = responsive_header;
+        document.getElementById('banner').innerHTML = newHeader.firstChild.innerHTML;
+      }
+    </script>
+    <div id="wrapper">
+        <div id="content">
+            <% if flash[:notice] %>
+                <div id="notice"><%= flash[:notice] %></div>
+            <% end %>
+            <% if flash[:error] %>
+                <div id="error"><%= flash[:error] %></div>
+            <% end %>
+
+            <div id="<%= controller.controller_name + "_" + controller.action_name %>" class="controller_<%= controller.controller_name %>">
+            <%= yield :layout %>
+            </div>
+            <div style="clear:both"></div>
+        </div>
+    </div>
+    <%= render :partial => 'general/footer' %>
+    <script type="text/javascript">
+      if (chosenVariation == 1){
+        var newFooter = document.createElement('div');
+        newFooter.innerHTML = responsive_footer;
+        document.getElementById('footer').innerHTML = newFooter.firstChild.innerHTML;
+      }
+    </script>
+
+</div>
+<div id="link_box"><span class="close-button">X</span>
+<%= _("Paste this link into emails, tweets, and anywhere else:") %>
+<br />
+<input type="text">
+</div>
+    <%
+      unless AlaveteliConfiguration::ga_code.empty? || (@user && @user.super?) %>
+        <script type="text/javascript">
+          var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+          document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+        </script>
+        <script type="text/javascript">
+          var pageTracker = _gat._getTracker("<%= AlaveteliConfiguration::ga_code %>");
+          pageTracker._trackPageview();
+        </script>
+
+      <% end %>
+
+      <%= render :partial => 'general/before_body_end' %>
+    </body>
+</html>


### PR DESCRIPTION
Redirects proved to be problematic for a) speed and b) form posts, so this code uses the Content Experiment API as described in https://developers.google.com/analytics/solutions/experiments-client-side to swap the styleseets to the responsive ones and rewrite the header and footer as the document is written if the responsive arm of the content experiment is selected. 

Closes https://github.com/mysociety/alaveteli/issues/1244
