### PR TITLE
Add charity links to public bodies

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -1,0 +1,27 @@
+<h2><%= _('More about this authority')%></h2>
+
+<% if !public_body.calculated_home_page.nil? %>
+    <%= link_to _('Home page of authority'), public_body.calculated_home_page %><br>
+<% end %>
+
+<% if !public_body.publication_scheme.empty? %>
+    <%= link_to _('Publication scheme'), public_body.publication_scheme %><br>
+<% end %>
+
+<% unless public_body.disclosure_log.empty? %>
+    <%= link_to _('Disclosure log'), public_body.disclosure_log %><br>
+<% end %>
+
+<% if public_body.has_tag?('charity') %>
+    <% public_body.get_tag_values('charity').each do |tag_value| %>
+        <% if tag_value.match(/^SC/) %>
+            <%= link_to _('Charity registration'), "http://www.oscr.org.uk/CharityIndexDetails.aspx?id=#{ tag_value }" %><br>
+        <% else %>
+            <%= link_to _('Charity registration'), "http://www.charity-commission.gov.uk/SHOWCHARITY/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=#{ tag_value }" %><br>
+        <% end %>
+    <% end %>
+<% end %>
+
+<%= link_to _('View FOI email address'), view_public_body_email_path(public_body.url_name) %><br>
+
+<%= link_to _("Ask us to update FOI email"), new_change_request_path(:body => public_body.url_name) %><br>


### PR DESCRIPTION
Requires https://github.com/mysociety/alaveteli/pull/1917

If the body is a charity, provide a link to its registration info
