### PR TITLE
Fix broken ICO URL on /help/privacy

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -48,7 +48,7 @@ to publish your full name.
 
 <dd>
 <p>Technically, you must use your real name for your request to be a valid Freedom of Information request in law. See this
-<a href="http://www.ico.org.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/name_of_applicant_fop083_v1.pdf">guidance from the Information Commissioner</a> (January 2009).
+<a href="http://ico.org.uk/for_organisations/guidance_index/~/media/documents/library/Freedom_of_Information/Detailed_specialist_guides/MOTIVE_BLIND_V1.ashx">guidance from the Information Commissioner</a> (October 2007).
 </p>
 
 <p>However, the same guidance also says it is good practice for the public


### PR DESCRIPTION
Fixes #163 

At https://www.whatdotheyknow.com/help/privacy#real_name the link
http://www.ico.org.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/name_of_applicant_fop083_v1.pdf no longer works.

This could be replaced with a link to http://ico.org.uk/for_organisations/guidance_index/~/media/documents/library/Freedom_of_Information/Detailed_specialist_guides/MOTIVE_BLIND_V1.ashx
which is an October 2007 document which contains the material the
described as being available at the link.

via @RichardTaylor
