### PR TITLE
Remove custom error page

### DIFF
--- a/lib/views/general/exception_caught.html.erb
+++ b/lib/views/general/exception_caught.html.erb
@@ -12,14 +12,9 @@
              <%= submit_tag _("Search") %>
       <% end %>
   </li>
-  </ul>  
+  </ul>
  <% else %>
   <h1><%= _("Sorry, there was a problem processing this page") %></h1>
   <p><%= _('You have found a bug.  Please <a href="{{contact_url}}">contact us</a> to tell us about the problem', :contact_url => help_contact_path) %></p>
-
  <% end %>
-  <!-- Technical details
-  <p><strong><%=h(@exception_class ? @exception_class : _("Unknown"))%></strong></p>
-  <p><strong><%=h(@exception_message) %></strong></p>
-  -->
 </div>


### PR DESCRIPTION
To be merged once main error page does not include error info.