### PR TITLE
Tidy up help pages

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1205,6 +1205,18 @@ p.ui-dropdown-list-trigger {
      */
     width: 32.1%;
   }
+  h2{
+    margin-top: 1em;
+    font-size: 0.777777778em; //14px
+    text-transform: uppercase;
+    color: #333;
+    margin-bottom: 1em;
+    font-weight: 600;
+  }
+  ul {
+    list-style: none outside none;
+    padding: 0;
+  }
 }
 
 .controller_help {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1193,3 +1193,23 @@ p.ui-dropdown-list-trigger {
 .learn-more-foi__link {
 
 }
+
+/* Help pages */
+.help-sidebar {
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    position: absolute;
+    left: -39.1%;
+    /* Tricky maths here - we want the side bar to be roughly 25% of the total width
+       but our context here is .controller-help, which is 72% width already. So to get
+       ~25% of the width, we need ~35% of the context. Same applies to the positioning above
+     */
+    width: 32.1%;
+  }
+}
+
+.controller_help {
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    position: relative;
+    margin-left: 28%;
+  }
+}

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -1219,8 +1219,13 @@ p.ui-dropdown-list-trigger {
 
 dt {
   color: $heading-color;
-  font-weight: 700;
+  font-weight: 600;
+  line-height: 1.5em;
   @include respond-min( $main_menu-mobile_menu_cutoff ){
-    font-size: 2em;
+    font-size: 1.3125em;
   }
+}
+
+dd {
+  margin-left: 0;
 }

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -702,16 +702,6 @@ a.link_to_this {
   }
 }
 
-/* Help pages */
-
-dt {
-  color: $heading-color;
-  font-weight: 700;
-  @include respond-min( $main_menu-mobile_menu_cutoff ){
-    font-size: 2em;
-  }
-}
-
 /* Authority page */
 .action-bar__follower-count {
   padding: 3px;
@@ -1195,6 +1185,7 @@ p.ui-dropdown-list-trigger {
 }
 
 /* Help pages */
+
 .help-sidebar {
   @include respond-min($main_menu-mobile_menu_cutoff) {
     position: absolute;
@@ -1223,5 +1214,13 @@ p.ui-dropdown-list-trigger {
   @include respond-min($main_menu-mobile_menu_cutoff) {
     position: relative;
     margin-left: 28%;
+  }
+}
+
+dt {
+  color: $heading-color;
+  font-weight: 700;
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    font-size: 2em;
   }
 }

--- a/lib/views/help/_sidebar.cy.html.erb
+++ b/lib/views/help/_sidebar.cy.html.erb
@@ -1,18 +1,20 @@
-<div id="about_sidebar">
-    <h1>Tudalennau cymorth</h1>
-    <ul>
-        <li><%= link_to_unless_current "Cyflwyniad", help_about_path %></li>
-        <li><%= link_to_unless_current "Gwneud ceisiadau", help_requesting_path %></li>
-        <li><%= link_to_unless_current "Eich preifatrwydd", help_privacy_path %></li>
-        <li><%= link_to_unless_current "Swyddogion Rhyddid Gwybodaeth", help_officers_path %></li>
-        <li><%= link_to_unless_current "Credydau", help_credits_path %></li>
-        <li><%= link_to_unless_current "API Rhaglenwyr", help_api_path %></li>
-        <li><%= link_to_unless_current "Chwiliad manwl", advanced_search_path %></li>
-        <li><%= link_to_unless_current "Alaveteli", help_alaveteli_path %></li>
-    </ul>
+<div class="help-sidebar">
+    <div id="about_sidebar">
+        <h1>Tudalennau cymorth</h1>
+        <ul>
+            <li><%= link_to_unless_current "Cyflwyniad", help_about_path %></li>
+            <li><%= link_to_unless_current "Gwneud ceisiadau", help_requesting_path %></li>
+            <li><%= link_to_unless_current "Eich preifatrwydd", help_privacy_path %></li>
+            <li><%= link_to_unless_current "Swyddogion Rhyddid Gwybodaeth", help_officers_path %></li>
+            <li><%= link_to_unless_current "Credydau", help_credits_path %></li>
+            <li><%= link_to_unless_current "API Rhaglenwyr", help_api_path %></li>
+            <li><%= link_to_unless_current "Chwiliad manwl", advanced_search_path %></li>
+            <li><%= link_to_unless_current "Alaveteli", help_alaveteli_path %></li>
+        </ul>
 
-    <h1 id="contact">Cysylltwch â ni</h1>
-    <p>Os nad yw eich cwestiwn yn cael ei ateb yma, neu eich bod jyst eisiau
-gadael i ni wybod rhywbeth am y wefan, <a href="<%= help_contact_path %>">cysylltwch â ni</a>.
-    </p>
+        <h1 id="contact">Cysylltwch â ni</h1>
+        <p>Os nad yw eich cwestiwn yn cael ei ateb yma, neu eich bod jyst eisiau
+    gadael i ni wybod rhywbeth am y wefan, <a href="<%= help_contact_path %>">cysylltwch â ni</a>.
+        </p>
+    </div>
 </div>

--- a/lib/views/help/_sidebar.cy.html.erb
+++ b/lib/views/help/_sidebar.cy.html.erb
@@ -1,6 +1,6 @@
 <div class="help-sidebar">
     <div id="about_sidebar">
-        <h1>Tudalennau cymorth</h1>
+        <h2>Tudalennau cymorth</h2>
         <ul>
             <li><%= link_to_unless_current "Cyflwyniad", help_about_path %></li>
             <li><%= link_to_unless_current "Gwneud ceisiadau", help_requesting_path %></li>
@@ -12,7 +12,7 @@
             <li><%= link_to_unless_current "Alaveteli", help_alaveteli_path %></li>
         </ul>
 
-        <h1 id="contact">Cysylltwch â ni</h1>
+        <h2 id="contact">Cysylltwch â ni</h2>
         <p>Os nad yw eich cwestiwn yn cael ei ateb yma, neu eich bod jyst eisiau
     gadael i ni wybod rhywbeth am y wefan, <a href="<%= help_contact_path %>">cysylltwch â ni</a>.
         </p>

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div class="help-sidebar">
     <div id="about_sidebar">
-        <h1>Help pages</h1>
+        <h2>Help pages</h2>
         <ul>
             <li><%= link_to_unless_current "Introduction", help_about_path %></li>
             <li><%= link_to_unless_current "Making requests", help_requesting_path %></li>
@@ -12,7 +12,7 @@
             <li><%= link_to_unless_current "Alaveteli", help_alaveteli_path %></li>
         </ul>
 
-        <h1 id="contact">Contact us</h1>
+        <h2 id="contact">Contact us</h2>
         <p>If your question isn't answered here, or you just wanted to let us know
         something about the site, <a href="<%= help_contact_path %>">contact&nbsp;us</a>.
         </p>

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -1,20 +1,22 @@
-<div id="about_sidebar">
-    <h1>Help pages</h1>
-    <ul>
-        <li><%= link_to_unless_current "Introduction", help_about_path %></li>
-        <li><%= link_to_unless_current "Making requests", help_requesting_path %></li>
-        <li><%= link_to_unless_current "Your privacy", help_privacy_path %></li>
-        <li><%= link_to_unless_current "FOI officers", help_officers_path %></li>
-        <li><%= link_to_unless_current "Credits", help_credits_path %></li>
-        <li><%= link_to_unless_current "Programmers API", help_api_path %></li>
-        <li><%= link_to_unless_current "Advanced search", advanced_search_path %></li>
-        <li><%= link_to_unless_current "Alaveteli", help_alaveteli_path %></li>
-    </ul>
+<div class="help-sidebar">
+    <div id="about_sidebar">
+        <h1>Help pages</h1>
+        <ul>
+            <li><%= link_to_unless_current "Introduction", help_about_path %></li>
+            <li><%= link_to_unless_current "Making requests", help_requesting_path %></li>
+            <li><%= link_to_unless_current "Your privacy", help_privacy_path %></li>
+            <li><%= link_to_unless_current "FOI officers", help_officers_path %></li>
+            <li><%= link_to_unless_current "Credits", help_credits_path %></li>
+            <li><%= link_to_unless_current "Programmers API", help_api_path %></li>
+            <li><%= link_to_unless_current "Advanced search", advanced_search_path %></li>
+            <li><%= link_to_unless_current "Alaveteli", help_alaveteli_path %></li>
+        </ul>
 
-    <h1 id="contact">Contact us</h1>
-    <p>If your question isn't answered here, or you just wanted to let us know
-    something about the site, <a href="<%= help_contact_path %>">contact&nbsp;us</a>.
-    </p>
+        <h1 id="contact">Contact us</h1>
+        <p>If your question isn't answered here, or you just wanted to let us know
+        something about the site, <a href="<%= help_contact_path %>">contact&nbsp;us</a>.
+        </p>
+    </div>
 </div>
 
 


### PR DESCRIPTION
This adds a more traditional layout to the help pages, with a sidebar, and tidies up the typography

### before
![screen shot 2015-06-12 at 10 54 08](https://cloud.githubusercontent.com/assets/2292925/8127799/73d08da4-10f1-11e5-9d89-66a813794c1c.png)

### after 
![screen shot 2015-06-12 at 10 54 45](https://cloud.githubusercontent.com/assets/2292925/8127800/73d24126-10f1-11e5-9077-54ba22866f8e.png)