### PR TITLE
Fix broken links in help pages

### DIFF
--- a/lib/views/help/about.cy.html.erb
+++ b/lib/views/help/about.cy.html.erb
@@ -23,11 +23,11 @@
 
 <dt id="who">Pwy sy'n gwneud WhatDoTheyKnow? <a href="#who">#</a> </dt>
 
-<dd>Cafodd WhatDoTheyKnow ei greu gan <a href="http://www.mysociety.org">mySociety</a> ac mae'n cael ei gynnal ganddi. Ar y dechrau cafodd <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/">ei ariannu gan Ymddiriedolaeth Elusennol JRSST</a> . Mae mySociety yn brosiect yr elusen gofrestredig <a href="http://www.ukcod.org.uk/UK_Citizens_Online_Democracy">Democratiaeth Dinasyddion Ar-lein y DG</a> . Os ydych yn hoffi'r hyn rydym yn ei wneud, yna gallwch <a href="https://secure.mysociety.org/donate/">roi rhodd</a> . </dd>
+<dd>Cafodd WhatDoTheyKnow ei greu gan <a href="http://www.mysociety.org">mySociety</a> ac mae'n cael ei gynnal ganddi. Ar y dechrau cafodd <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/">ei ariannu gan Ymddiriedolaeth Elusennol JRSST</a>. Mae mySociety yn brosiect yr elusen gofrestredig <a href="https://www.mysociety.org/about/structure-and-governance/">Democratiaeth Dinasyddion Ar-lein y DG</a>. Os ydych yn hoffi'r hyn rydym yn ei wneud, yna gallwch <a href="https://secure.mysociety.org/donate/">roi rhodd</a>. </dd>
 
 <dt id="updates">Sut y gallaf gadw i fyny gyda newyddion am WhatDoTheyKnow?<a href="#updates">#</a> </dt>
 
-<dd>Mae gennym <a href="<%= blog_path %>">flog</a> a <a href="http://www.twitter.com/whatdotheyknow">ffrwd twitter</a> . </dd> </dl>
+<dd>Mae gennym <a href="<%= blog_path %>">flog</a> a <a href="http://www.twitter.com/whatdotheyknow">ffrwd twitter</a>. </dd> </dl>
 
 <p><strong>Nesaf,</strong> darllenwch am <a href="<%= help_requesting_path %>">wneud ceisiadau</a> -&gt;
 

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -57,16 +57,15 @@ We have over 30,000 registered users and around 15% to 20% of requests to UK Cen
 <dd>
 <p>
 WhatDoTheyKnow is run and maintained by
-<a href="http://www.ukcod.org.uk/Contact">UK Citizens Online
-Democracy</a> (UKCOD) as part of its
+UK Citizens Online Democracy (UKCOD) as part of its
 <a href="http://www.mysociety.org">mySociety</a> project.
 UKCOD is a registered charity in England and Wales (no.
-<a href="http://www.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityWithoutPartB.aspx?RegisteredCharityNumber=1076346&SubsidiaryNumber=0">1076346</a>).
+<a href="http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityWithPartB.aspx?RegisteredCharityNumber=1076346&SubsidiaryNumber=0">1076346</a>).
 UKCOD is also a limited company registered in England and Wales (no.
 <a href="http://opencorporates.com/companies/gb/03277032">03277032</a>)
 and a registered data controller (no.
 <a href="http://www.ico.org.uk/ESDWebPages/DoSearch?reg=182425">Z9602302</a>).
-The <a href="http://www.ukcod.org.uk/UKCOD_Trustees">UKCOD trustees</a> form the governing body of the charity
+The <a href="https://www.mysociety.org/about/structure-and-governance/">UKCOD trustees</a> form the governing body of the charity
 and are ultimately responsible for controlling the management and administration of the charity. UKCOD's registered
 office is 483 Green Lanes, London, N13 4BS. UKCOD is not a public body.
 </p>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -75,7 +75,7 @@ A spreadsheet file listing every body in WhatDoTheyKnow is available:
 <h2> 5. Write API </h2>
 
 <p>
-The write API is designed to be used by authorities to create their own requests in the system. The API is currently used by mySociety's <a href="https://github.com/mysociety/foi-register">FOI Register software</a> to support using Alaveteli as a disclosure log for all FOI activity at a particular public body. More technical information about the write API is available on the <a href="https://github.com/mysociety/alaveteli/wiki/API#write-api">Alaveteli wiki</a>.
+The write API is designed to be used by authorities to create their own requests in the system. The API is currently used by mySociety's <a href="https://github.com/mysociety/foi-register">FOI Register software</a> to support using Alaveteli as a disclosure log for all FOI activity at a particular public body. More technical information about the write API is available on the <a href="http://alaveteli.org/docs/developers/api/">Alaveteli.org site</a>.
 </p>
 
 <hr>

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -71,7 +71,7 @@ could do the complex mixture of design and coding to build what you see today.
 </li>
 <li>
     We couldn't do any of this without those
-    <a href="http://www.ukcod.org.uk/UKCOD_Trustees">crazy people (UKCOD Trustees)</a> who volunteer,
+    <a href="https://www.mysociety.org/about/structure-and-governance/">crazy people (UKCOD Trustees)</a> who volunteer,
     amongst many other things, to do the accounts and fill in our VAT return.
 </li>
 <li>

--- a/lib/views/help/officers.cy.html.erb
+++ b/lib/views/help/officers.cy.html.erb
@@ -116,11 +116,11 @@
       Mae ysgolion hefyd yn achos arbennig, y mae WhatDoTheyKnow yn ei arddangos yn wahanol.
     </p>
     <ul>
-      <li>Ers mis Mehefin 2009, mae gan <strong>ysgolion</strong> "20 diwrnod gwaith gan anwybyddu unrhyw ddiwrnod gwaith nad yw'n ddiwrnod ysgol, neu 60 diwrnod gwaith, pa un bynnag yw'r cyntaf" ( <a href="http://www.opsi.gov.uk/si/si2009/draft/ukdsi_9780111477632_en_1">Rhyddid Gwybodaeth (Amser ar gyfer Cydymffurfio â Chais) 2009</a> ). Mae WhatDoTheyKnow yn nodi ar geisiadau i ysgolion fod y terfyn o 20 diwrnod yn berthnasol yn unig yn ystod y tymor, ac yn dangos bod y ceisiadau'n bendant yn hwyr ar ôl 60 diwrnod gwaith.
+      <li>Ers mis Mehefin 2009, mae gan <strong>ysgolion</strong> "20 diwrnod gwaith gan anwybyddu unrhyw ddiwrnod gwaith nad yw'n ddiwrnod ysgol, neu 60 diwrnod gwaith, pa un bynnag yw'r cyntaf" ( <a href="http://www.legislation.gov.uk/uksi/2009/1369/contents/made">Rhyddid Gwybodaeth (Amser ar gyfer Cydymffurfio â Chais) 2009</a> ). Mae WhatDoTheyKnow yn nodi ar geisiadau i ysgolion fod y terfyn o 20 diwrnod yn berthnasol yn unig yn ystod y tymor, ac yn dangos bod y ceisiadau'n bendant yn hwyr ar ôl 60 diwrnod gwaith.
       </li>
     </ul>
     <p>
-      Os ydych wir eisiau gwybod y manylion technegol, darllenwch <a href="http://www.ico.gov.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/timeforcompliance.pdf">canllawiau manwl Swyddfa'r Comisiynydd Gwybodaeth</a> . Yn y cyfamser, cofiwch fod y gyfraith yn dweud bod rhaid i awdurdodau ymateb yn <strong>brydlon.</strong> Dyna sy wir yn bwysig.
+      Os ydych wir eisiau gwybod y manylion technegol, darllenwch <a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">canllawiau manwl Swyddfa'r Comisiynydd Gwybodaeth</a> . Yn y cyfamser, cofiwch fod y gyfraith yn dweud bod rhaid i awdurdodau ymateb yn <strong>brydlon.</strong> Dyna sy wir yn bwysig.
     </p>
     <dl>
       <dt id="public_interest_test">
@@ -128,7 +128,7 @@
       </dt>
     </dl>
     <p>
-      Mae'r Ddeddf Rhyddid Gwybodaeth yn gadael i awdurdodau wneud cais am estyniad amser amhenodol wrth ystyried <strong>prawf budd y cyhoedd.</strong> Dywed Canllawiau'r Comisiynydd Gwybodaeth na ddylai gael ei ddefnyddio ond mewn achosion "eithriadol o gymhleth" ( <a href="http://www.ico.gov.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/foi_good_practice_guidance_4.pdf">Canllawiau Arfer Da Rhyddid Gwybodaeth Rhif 4</a> ). Nid WhatDoTheyKnow yn trin yr achos hwn mewn ffordd arbennig, a dyna pam rydym yn defnyddio yr ymadrodd "Fel arfer, dylai ... wedi ymateb erbyn" pan eir heibio i'r terfyn 20 diwrnod gwaith.
+      Mae'r Ddeddf Rhyddid Gwybodaeth yn gadael i awdurdodau wneud cais am estyniad amser amhenodol wrth ystyried <strong>prawf budd y cyhoedd.</strong> Dywed Canllawiau'r Comisiynydd Gwybodaeth na ddylai gael ei ddefnyddio ond mewn achosion "eithriadol o gymhleth" ( <a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">Canllawiau Arfer Da Rhyddid Gwybodaeth Rhif 4</a> ). Nid WhatDoTheyKnow yn trin yr achos hwn mewn ffordd arbennig, a dyna pam rydym yn defnyddio yr ymadrodd "Fel arfer, dylai ... wedi ymateb erbyn" pan eir heibio i'r terfyn 20 diwrnod gwaith.
     </p>
     <p>
       Mae'r un canllawiau yn dweud, hyd yn oed mewn achosion eithriadol o gymhleth, na ddylai yr un cais Rhyddid Gwybodaeth gymryd mwy na <strong>40 diwrnod gwaith</strong> i ateb. Mae WhatDoTheyKnow yn arddangos ceisiadau sy mor hwyr â hynny gyda geiriad cryfach i ddangos eu bod yn bendant yn hwyr.

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -153,12 +153,12 @@ one case which is not normal, see the next question about
 <ul>
 <li>Since June 2009, <strong>schools</strong> have "20 working days
 disregarding any working day which is not a school day, or 60 working days,
-whichever is first" (<a href="http://www.opsi.gov.uk/si/si2009/draft/ukdsi_9780111477632_en_1">FOI (Time for Compliance with Request) Regulations 2009</a>). WhatDoTheyKnow indicates on requests to schools that the 20 day deadline is only
+whichever is first" (<a href="http://www.legislation.gov.uk/uksi/2009/1369/contents/made">FOI (Time for Compliance with Request) Regulations 2009</a>). WhatDoTheyKnow indicates on requests to schools that the 20 day deadline is only
 during term time, and shows them as definitely overdue after 60 working days
 </li>
 </ul>
 
-<p>If you're getting really nerdy about all this, read the <a href="http://www.ico.org.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/timeforcompliance.pdf">detailed ICO guidance</a>.
+<p>If you're getting really nerdy about all this, read the <a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">detailed ICO guidance</a>.
 Meanwhile, remember that the law says authorities must respond
 <strong>promptly</strong>. That's really what matters.</p>
 
@@ -170,9 +170,8 @@ Meanwhile, remember that the law says authorities must respond
 
 <p>The Freedom of Information Act lets authorities claim an indefinite time
 extension when applying a <strong>public interest test</strong>.  Information
-Commissioner guidance says that it should only be used in "exceptionally
-complex" cases
-(<a href="http://www.ico.org.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/foi_good_practice_guidance_4.pdf">FOI Good Practice Guidance No. 4</a>).
+Commissioner guidance says that it should only be used in cases where there are "exceptional levels of complexity"
+(<a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">FOI Time for Compliance Guidance, paragraph 62</a>).
 WhatDoTheyKnow doesn't specifically handle this case, which is why we use the
 phrase "should normally have responded by" when the 20 working day time is
 exceeded.

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -168,20 +168,17 @@ Meanwhile, remember that the law says authorities must respond
 
 <dd>
 
-<p>The Freedom of Information Act lets authorities claim an indefinite time
-extension when applying a <strong>public interest test</strong>.  Information
-Commissioner guidance says that it should only be used in cases where there are "exceptional levels of complexity"
-(<a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">FOI Time for Compliance Guidance, paragraph 62</a>).
-WhatDoTheyKnow doesn't specifically handle this case, which is why we use the
-phrase "should normally have responded by" when the 20 working day time is
-exceeded.
-</p>
+<p>The Freedom of Information Act lets authorities claim an <strong>indefinite time
+extension</strong> when applying a public interest test. As WhatDoTheyKnow doesn't
+specifically handle such extensions we use the phrase "should normally have responded
+promptly by" when the 20 working day time is exceeded. Once 40 working days have elapsed we
+use much stronger wording as we consider that all requests should have received a response
+by that point.</p>
 
-<p>The same guidance says that, even in exceptionally complex cases, no
-Freedom of Information request should take more than <strong>40 working days</strong>
-to answer.  WhatDoTheyKnow displays requests which are overdue by that much
-with stronger wording to indicate they are definitely late.
-</p>
+<p><a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">
+Guidance from the Commissioner</a> suggests extensions beyond 40 working days may be acceptable
+in exceptional cases such as where a body is under extreme pressure due to a major incident or
+where a public interest test involves "exceptional levels of complexity".</p>
 
 <p>The Freedom of Information (Scotland) Act does not allow such a public
 interest extension. WhatDoTheyKnow would like to see the law changed to either

--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -128,7 +128,7 @@ Cof a CPU defnydd ar y gweinyddion sy'n rhedeg y safle.
 </ul>
 <p> Data Sampl am ymholiadau cronfa ddata, ceisiadau unigol ar gyfer tudalennau yn cael ei storio gan New crair am 7 diwrnod, data cyfanredol yn cael ei storio am uchafswm o 90 diwrnod. </p>
 <p> <a href="http://try.newrelic.com/rs/newrelic/images/NewRelic-Security.pdf"> Mae rhagor o wybodaeth gan New crair ar breifatrwydd a diogelwch </a> </p>
-  <p> <a href="http://www.mysociety.org/privacy-online/"> gwybodaeth fwy cyffredinol ar sut trydydd parti gwasanaethau gwaith </a> </p>
+  <p> <a href="https://www.mysociety.org/privacy/"> gwybodaeth fwy cyffredinol ar sut trydydd parti gwasanaethau gwaith </a> </p>
 
 <p> <strong> Ein logio hun </strong> </p>
 
@@ -165,9 +165,13 @@ am 28 diwrnod.
 <p>Os yw'n wybodaeth bersonol sensitif sydd wedi cael ei phostio ar ddamwain, yna byddwn fel arfer yn ei dileu. Fel arfer, ni fyddwn ond yn ystyried ceisiadau i gael gwared ar wybodaeth bersonol a ddaw oddi wrth yr unigolyn dan sylw, ond am wybodaeth sensitif byddem yn gwerthfawrogi pe bai unrhyw un yn tynnu ein sylw ati.</p>
 
 <p>Mae gennych hawl o dan <a
-href="http://www.legislation.gov.uk/ukpga/1998/29/section/10">adran 10 y Ddeddf Ddiogelu Data</a> i ofyn i ni ddileu eich gwybodaeth bersonol ar y sail ei bod yn achosi difrod neu ofid sylweddol a diangen i chi. Byddwn ni'n ystyried unrhyw hysbysiad o'r fath, nad oes rhaid iddo'n sôn yn benodol am y Ddeddf, ac yn ei gydbwyso yn erbyn unrhyw fudd a ddeuai i'r cyhoedd o gyhoeddi'r deunydd. Ceir peth arweiniad ar yr hysbysiadau hyn <a
-href="http://ico.org.uk/for_organisations/data_protection/the_guide/principle_6/
-damage_or_distress">ar wefan y ICO</a>.
+href="http://www.legislation.gov.uk/ukpga/1998/29/section/10">adran 10 y Ddeddf Ddiogelu Data</a>
+i ofyn i ni ddileu eich gwybodaeth bersonol ar y sail ei bod yn achosi difrod neu ofid sylweddol a
+diangen i chi. Byddwn ni'n ystyried unrhyw hysbysiad o'r fath, nad oes rhaid iddo'n sôn yn benodol
+am y Ddeddf, ac yn ei gydbwyso yn erbyn unrhyw fudd a ddeuai i'r cyhoedd o gyhoeddi'r deunydd.
+Ceir peth arweiniad ar yr hysbysiadau hyn <a
+href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/damage-or-distress/">
+ar wefan y ICO</a>.
 
 </dd>
 

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -187,7 +187,7 @@ Memory and CPU usage on the servers that run the site.
 </ul>
 <p>Sample data about database queries, individual requests for pages is stored by New Relic for 7 days, aggregate data is stored for a maximum of 90 days.</p>
 <p><a href="http://try.newrelic.com/rs/newrelic/images/NewRelic-Security.pdf">Further information from New Relic on privacy and security</a></p>
-  <p><a href="http://www.mysociety.org/privacy-online/">More general information on how third party services work</a></p>
+  <p><a href="https://www.mysociety.org/privacy/">More general information on how third party services work</a></p>
 
 <p><strong>Our own logging</strong></p>
 
@@ -247,8 +247,7 @@ the grounds that it is causing you substantial and unwarranted damage or
 distress. We will consider any such notice, which does not need to explicitly
 mention the Act, and balance it against any public interest in publishing the
 material. There is some guidance on these notices <a
-href="http://ico.org.uk/for_organisations/data_protection/the_guide/principle_6/
-damage_or_distress">on the ICO’s website</a>.</p>
+href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/damage-or-distress/">on the ICO’s website</a>.</p>
 
 </dd>
 

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -184,12 +184,12 @@ Gweler <a href="<%= help_officers_path(:anchor => 'copyright') %>">ein polisi ar
 <dt id="ico_help">Allwch chi ddweud mwy wrthyf am fanion y broses o wneud ceisiadau? <a href="#ico_help">#</a> </dt>
 
 <dd>
-<p>Edrychwch ar dudalennau  <a href="http://www.ico.org.uk/for_the_public/access_to_official_information.aspx">mynediad
+<p>Edrychwch ar dudalennau  <a href="https://ico.org.uk/for-the-public/official-information/">mynediad
 i wybodaeth swyddogol</a> ar wefan y Comisiynydd Gwybodaeth.</p>
 
 <p>Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus
 yn yr Alban, mae'r broses yn debyg iawn. Mae gwahaniaethau o gwmpas y
-terfynau amser ar gyfer cydymffurfio. Gweler <a href="http://www.itspublicknowledge.info/nmsruntime/saveasdialog.asp?lID=1858&amp;sID=321">canllawiau
+terfynau amser ar gyfer cydymffurfio. Gweler <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">canllawiau
 Comisiynydd Gwybodaeth yr Alban</a> am fanylion.</p>
 
 </dd>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -57,7 +57,7 @@ organisations:</p>
   defined group)</li>
   <li> Those which voluntarily comply with the FOI Act</li>
   <li> Those which aren&rsquo;t subject to the Act
-  <a href="http://www.mysociety.org/2012/03/13/network-rail/">but we think should be</a>,
+  <a href="https://www.whatdotheyknow.com/body/edexcel">but we think should be</a>,
   on grounds
   such as them having significant public responsibilities.
   </li>
@@ -245,13 +245,13 @@ Government Licence</a> but there are some conditions.
 
 <dd>
 <p>Have a look at the
-<a href="http://www.ico.org.uk/for_the_public/access_to_official_information.aspx">access to official information</a>
+<a href="https://ico.org.uk/for-the-public/official-information/">access to official information</a>
 pages on the Information Commissioner&rsquo;s website.</p>
 
 <p>If you&rsquo;re requesting information from a Scottish public authority,
 the process is very similar. There are differences around time
 limits for compliance.
-See the <a href="http://www.itspublicknowledge.info/nmsruntime/saveasdialog.asp?lID=1858&amp;sID=321">Scottish
+See the <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">Scottish
 Information Commissioner&rsquo;s guidance</a> for details.</p>
 </dd>
 
@@ -264,7 +264,7 @@ individual.</p>
 
 <p>If you would like to know what information a public
 authority holds about yourself, you should make a &ldquo;Subject Access Request&rdquo; in private using Data Protection law.
- <a href="http://www.ico.org.uk/for_the_public/personal_information.aspx">The
+ <a href="https://ico.org.uk/for-the-public/personal-information/">The
 Information Commissioner&rsquo;s website</a> provides advice on accessing your
 own personal information</p>
 


### PR DESCRIPTION
Fixes most of the broken links - including the matching links (but not the link text) on the Welsh pages.

The trickier problem posed by the archiving of http://www.justice.gov.uk/information-access-rights/foi-guidance-for-practitioners/procedural-guidance/foi-what-constitutes link is not addressed here but has been documented in #270 

Fixes #267
Fixes #268 