### PR TITLE
Calculate the number of registered users on the about page

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -50,7 +50,7 @@ Interesting things that we know because of WhatDoTheyKnow</a>.
 
 <dt id="how_many">How many people use the site? <a href="#how_many">#</a> </dt>
 <dd>
-We have over 30,000 registered users and around 15% to 20% of requests to UK Central Government are made through the site.
+We have over <%= number_with_delimiter(User.count.round(-4), :locale => @locale) %> registered users and around 15% to 20% of requests to UK Central Government are made through the site.
 </dd>
 
 <dt id="who">Who makes WhatDoTheyKnow? <a href="#who">#</a> </dt>


### PR DESCRIPTION
Changes the line in the help/about page from a hardcoded - and currently out of date - number to a calculation on the actual user count, rounded to the nearest thousand.

While not relevant to WDTK, the commit message contains a warning about what happens if you have fewer than 1000 users when using this code change (my dev box has 11, which rounded down to 0).

There's probably something cleverer we could do to make sure we're rounding the number appropriately (possibly as a class method on User?) but it's not needed here.

Fixes #266 