### PR TITLE
Removed link to archived justice.gov.uk page

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -98,8 +98,7 @@ that section 8.1.b of the FOI Act asks for an "address for correspondence",
 and that the email address you are using is sufficient.
 </p>
 <p>
-The Ministry of Justice has <a href="http://www.justice.gov.uk/information-access-rights/foi-guidance-for-practitioners/procedural-guidance/foi-what-constitutes">guidance
-on this</a> &ndash;
+The Ministry of Justice has guidance on this&ndash;
 <em>"As well as hard copy written correspondence, requests that are
 transmitted electronically (for example, in emails) are acceptable
 ... If a request is received by email and no postal address is given, the email


### PR DESCRIPTION
Removed the link to the now-archived http://www.justice.gov.uk/information-access-rights/foi-guidance-for-practitioners/procedural-guidance/foi-what-constitutes, leaving just the original text.

Closes #270 