### PR TITLE
Link to ICO guidance pdf in outgoing email

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -6,4 +6,8 @@ Rails.application.routes.draw do
         root :to => 'user#survey', :as => :survey
         match '/reset' => 'user#survey_reset', :as => :survey_reset
     end
+
+    match "/help/ico-guidance-for-authorities" => redirect("https://ico.org.uk/media/for-organisations/documents/how-to-disclose-information-safely-removing-personal-data-from-information-requests-and-datasets/1432979/how-to-disclose-information-safely.pdf
+"),
+    	:as => :ico_guidance
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -1,7 +1,7 @@
 Rails.configuration.to_prepare do
     UserController.class_eval do
         require 'survey'
-        
+
         def survey
         end
 

--- a/lib/views/outgoing_mailer/_followup_footer.text.erb
+++ b/lib/views/outgoing_mailer/_followup_footer.text.erb
@@ -1,0 +1,7 @@
+<%= _('Disclaimer: This message and any reply that you make will be published on the internet. Our privacy and copyright policies:')%>
+<%= help_officers_url %>
+
+<%= _('For more detailed guidance on safely disclosing information, read the latest advice from the ICO:') %>
+<%= ico_guidance_url %>
+
+<%= _('If you find this service useful as an FOI officer, please ask your web manager to link to us from your organisation\'s FOI page.')%>


### PR DESCRIPTION
Link added to https://ico.org.uk/media/for-organisations/documents/how-to-disclose-information-safely-removing-personal-data-from-information-requests-and-datasets/1432979/how-to-disclose-information-safely.pdf

Have added a WDTK route for the pdf as the direct link is too long for a plaintext email and wraps awkwardly

Fixes #279 