### PR TITLE
Mention batch requests in multiple requests help section

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -312,9 +312,8 @@ authority has a duty to work out if the Environmental Information Regulations
 <dd>We ask you to first send a test version of your request to a few
 authorities. Their responses will help you improve the wording of your request,
 so that you get the best information when you send the request to all of
-the authorities. There is currently no automated system for sending the request
-to the other authorities, you must copy and paste it by hand.
-
+the authorities. Once you’re ready to do that <%= link_to "contact us", help_contact_path %>
+and we’ll enable batch requests for your account.
 </dd>
 
 <dt id="offsite">I made a request off the site, how do I upload it to the archive?<a href="#offsite">#</a> </dt>


### PR DESCRIPTION
Previously it erroneously said there was no automated way to send batch
requests.
