### PR TITLE
[#358] implement the action menu

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -41,6 +41,35 @@
     See also: <a href="http://www.guardian.co.uk/news/datablog/2012/mar/20/freedom-of-information-foi">366
     Interesting things that we know because of WhatDoTheyKnow</a>.
     </dd>
+
+    <dt id="reporting">What if I see a request I feel to be inappropriate? <a href="#reporting">#</a></dt>
+    <dd>
+      <p>
+        Requests for personal information and vexatious requests are not considered valid for FOI purposes (read more).
+      </p>
+
+      <p>
+        If you believe a request is not suitable, you can report it for attention by the site administrators.
+      </p>
+    </dd>
+
+    <dt id="reporting_unavailable">Why won't it let me report some requests? <a href="#reporting_unavailable">#</a></dt>
+    <dd>
+      <p>
+        If a request has already been reported to the site administrators, you
+        can't report it a second time - this is to prevent the administrators
+        being notified multiple times about the same issue before they've had
+        a chance to conduct a review.
+      </p>
+
+      <p>
+        Where a request has been previously reported but an administrator has
+        chosen not to hide it from public view, you can use the form in the
+        sidebar of the request page to contact the administrators if you still
+        think it should be hidden.
+      </p>
+    </dd>
+
     <dt id="how_many">How many people use the site? <a href="#how_many">#</a> </dt>
     <dd>
     We have over <%= number_with_delimiter(User.count.round(-4), :locale => @locale) %> registered users and around 15% to 20% of requests to UK Central Government are made through the site.

--- a/lib/views/request/_sidebar.html.erb
+++ b/lib/views/request/_sidebar.html.erb
@@ -6,57 +6,33 @@
     <a href="https://www.mysociety.org/donate?utm_source=whatdotheyknow.com&utm_content=request+sidebar+donate+now&utm_medium=link&utm_campaign=donation_drive_2016" class="button sidebar__donate-cta__button">Donate now</a>
   </div>
   <% end %>
-  <div id="track-request" class="track-request">
-    <h2><%= _('Follow this request') %></h2>
 
-    <p>
-      <%= n_("There is {{count}} person following this request",
-             "There are {{count}} people following this request",
-             @follower_count,
-             :count => @follower_count) %>
-    </p>
-    <%= render :partial => 'track/tracking_links', :locals => { :track_thing => @track_thing, :own_request => @info_request.user && @info_request.user == @user, :location => 'sidebar' } %>
-    <%= render :partial => 'track/rss_feed', :locals => { :track_thing => @track_thing, :location => 'sidebar' } %>
-  </div>
-
-  <% if @info_request.described_state != "attention_requested" %>
-    <h2><%= _('Offensive? Unsuitable?') %></h2>
-      <% if @info_request.attention_requested %>
-        <% if @info_request.prominence == 'hidden' %>
-          <p>
-            <%= _("This request has prominence 'hidden'. You can only see it " \
-                  "because you are logged in as a super user.") %>
-          </p>
-        <% elsif @info_request.prominence == 'requester_only' %>
-          <%# The eccentric formatting of the following string is in order that it be identical
-              to the corresponding string in request/show.html.erb %>
-          <p><%= _('This request is hidden, so that only you the requester ' \
-                      'can see it. Please <a href="{{url}}">contact us</a> ' \
-                      'if you are not sure why.',
-                   :url => help_requesting_path.html_safe) %></p>
-        <% else %>
-          <p><%= _('This request has been marked for review by the site ' \
-                     'administrators, who have not hidden it at this time. ' \
-                     'If you believe it should be hidden, please ' \
-                     '<a href="{{url}}">contact us</a>.',
-                   :url => help_requesting_path.html_safe) %></p>
-        <% end %>
-      <% else %>
-        <p><%= _('Requests for personal information and vexatious requests ' \
-                    'are not considered valid for FOI purposes ' \
-                    '(<a href="/help/about">read more</a>).') %></p>
-        <p><%= _('If you believe this request is not suitable, you can report ' \
-                    'it for attention by the site administrators') %></p>
-        <%= link_to _("Report this request"), new_request_report_path(:request_id => @info_request.url_title), :class => 'report-this-request' %>
-      <% end %>
-  <% else %>
-    <p><%= _('Requests for personal information and vexatious requests are ' \
-                'not considered valid for FOI purposes ' \
-                '(<a href="/help/about">read more</a>).') %></p>
-    <p><%= _('If you believe this request is not suitable, you can report it ' \
-                'for attention by the site administrators') %></p>
-    <%= link_to _("Report this request"), new_request_report_path(:request_id => @info_request.url_title) %>
+  <div class="request__special-status">
+  <% if @info_request.attention_requested %>
+    <% if @info_request.prominence == 'hidden' %>
+      <h2><%= _('Request hidden') %></h2>
+      <p>
+        <%= _("This request has prominence 'hidden'. You can only see it " \
+              "because you are logged in as a super user.") %>
+      </p>
+    <% elsif @info_request.prominence == 'requester_only' %>
+      <h2><%= _('Request hidden') %></h2>
+      <%# The eccentric formatting of the following string is in order that it be identical
+          to the corresponding string in request/show.html.erb %>
+      <p><%= _('This request is hidden, so that only you the requester ' \
+                  'can see it. Please <a href="{{url}}">contact us</a> ' \
+                  'if you are not sure why.',
+               :url => help_requesting_path.html_safe) %></p>
+    <% elsif @info_request.described_state != "attention_requested" %>
+      <h2><%= _('Offensive? Unsuitable?') %></h2>
+      <p><%= _('This request has been marked for review by the site ' \
+               'administrators, who have not hidden it at this time. ' \
+               'If you believe it should be hidden, please ' \
+               '<a href="{{url}}">contact us</a>.',
+              :url => help_requesting_path.html_safe) %></p>
+    <% end %>
   <% end %>
+  </div>
 
   <%= render :partial => 'request/act' %>
   <%= render :partial => 'request/next_actions' %>
@@ -93,5 +69,5 @@
 
   <!-- this link with this wording is here for legal reasons, discuss with
     board and our lawyer before changing or removing it -->
-  <p><small><%= link_to _('Are you the owner of any commercial copyright on this page?'), help_officers_path(:anchor => "copyright") %></small></p>
+  <p class="copyright-notice"><small><%= link_to _('Are you the owner of any commercial copyright on this page?'), help_officers_path(:anchor => "copyright") %></small></p>
 </div>

--- a/lib/views/request/select_authority.html.erb
+++ b/lib/views/request/select_authority.html.erb
@@ -8,6 +8,10 @@
       // Do a type ahead search and display results
       $("#typeahead_response").load("<%= search_ahead_bodies_url %>?query="+encodeURI(this.value));
     }));
+
+    if (!!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/)) {
+      $('#query').removeAttr('required');
+    }
   });
   </script>
 <% end %>
@@ -31,6 +35,7 @@
       <label for="query" class="visually-hidden"><%=_('Authority name')%></label>
       <%= text_field_tag :query, params[:query], { :size => 30,
                                                    :title => _('type your search term here'),
+                                                   :required => true,
                                                    :placeholder => _('e.g. Ministry of Defence') } %>
       <%= hidden_field_tag :bodies, 1 %>
       <%= submit_tag _('Search') %>

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -76,146 +76,160 @@
   </div>
 <% end %>
 
-<div id="left_column" class="left_column">
-  <h1><%=h(@info_request.title)%></h1>
+<div class="request-header">
+  <div class="row">
+    <h1><%=h(@info_request.title)%></h1>
 
-  <% if !@info_request.is_external? && @info_request.user.profile_photo && !@render_to_file %>
-    <p class="user_photo_on_request">
-      <img src="<%= get_profile_photo_url(:url_name => @info_request.user.url_name) %>" alt="">
-    </p>
-  <% end %>
-
-  <p class="subtitle">
-    <% if !@user.nil? && @user.admin_page_links? %>
-      <%= _('{{user}} ({{user_admin_link}}) made this {{law_used_full}} request (<a href="{{request_admin_url}}">admin</a>) to {{public_body_link}} (<a href="{{public_body_admin_url}}">admin</a>)',
-            :user => request_user_link(@info_request, _('An anonymous user')),
-            :law_used_full => h(@info_request.law_used_human(:full)),
-            :user_admin_link => user_admin_link_for_request(
-              @info_request, _('external'), _('admin')),
-            :request_admin_url => admin_request_url(@info_request),
-            :public_body_link => public_body_link(@info_request.public_body),
-            :public_body_admin_url => admin_body_url(@info_request.public_body)) %>
-    <% else %>
-      <%= _('{{user}} made this {{law_used_full}} request',
-            :user=>request_user_link(@info_request, _('An anonymous user')),
-            :law_used_full=>h(@info_request.law_used_human(:full))) %>
-      <%= _('to {{public_body}}',:public_body=>public_body_link(@info_request.public_body)) %>
-    <% end %>
-  </p>
-
-  <p id="request_status" class="request-status-message request_icon_line icon_<%= @info_request.calculate_status %>">
-    <% if @info_request.awaiting_description %>
-      <% if @is_owning_user && !@info_request.is_external? && !@render_to_file %>
-        <%= n_('Please <strong>answer the question above</strong> so we know ' \
-                  'whether the recent response contains useful information.',
-               'Please <strong>answer the question above</strong> so we know ' \
-                  'whether the recent responses contain useful information.',
-               @new_responses_count) %>
-      <% else %>
-        <%= _('This request has an <strong>unknown status</strong>.') %>
-
-        <% if @old_unclassified %>
-          <%= n_("We're waiting for someone to read a recent response and " \
-                    "update the status accordingly. Perhaps " \
-                    "<strong>you</strong> might like to help out by doing that?",
-                 "We're waiting for someone to read recent responses and " \
-                    "update the status accordingly. Perhaps " \
-                    "<strong>you</strong> might like to help out by doing that?",
+    <div class="request-header__action-bar-container">
+      <div class="request-header__action-bar">
+        <% if !@info_request.is_external? && @info_request.user.profile_photo && !@render_to_file %>
+          <div class=" request-header__profile-photo user_photo_on_request">
+            <img src="<%= get_profile_photo_url(:url_name => @info_request.user.url_name) %>" alt="">
+          </div>
+        <% end %>
+        <p class="request-header__subtitle <% if !@info_request.is_external? && @info_request.user.profile_photo && !@render_to_file %>request-header__subtitle--narrow<% end %>">
+          <% if !@user.nil? && @user.admin_page_links? %>
+            <%= _('{{user}} ({{user_admin_link}}) made this {{law_used_full}} request (<a href="{{request_admin_url}}">admin</a>) to {{public_body_link}} (<a href="{{public_body_admin_url}}">admin</a>)',
+                  :user => request_user_link(@info_request, _('An anonymous user')),
+                  :law_used_full => h(@info_request.law_used_human(:full)),
+                  :user_admin_link => user_admin_link_for_request(
+                    @info_request, _('external'), _('admin')),
+                  :request_admin_url => admin_request_url(@info_request),
+                  :public_body_link => public_body_link(@info_request.public_body),
+                  :public_body_admin_url => admin_body_url(@info_request.public_body)) %>
+          <% else %>
+            <%= _('{{user}} made this {{law_used_full}} request',
+                  :user=>request_user_link(@info_request, _('An anonymous user')),
+                  :law_used_full=>h(@info_request.law_used_human(:full))) %>
+            <%= _('to {{public_body}}',:public_body=>public_body_link(@info_request.public_body)) %>
+          <% end %>
+        </p>
+        <% unless @render_to_file %>
+          <div class="request-header__action-bar__actions <% if !@info_request.is_external? && @info_request.user.profile_photo && !@render_to_file %>request-header__action-bar__actions--narrow<% end %>">
+            <%= render :partial => 'after_actions' %>
+            <%= render :partial => 'track/tracking_links_simple', :locals => { :track_thing => @track_thing, :own_request => @info_request.user && @info_request.user == @user, :location => 'toolbar ' } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="request-status">
+      <p id="request_status" class="request-status-message request_icon_line icon_<%= @info_request.calculate_status %>">
+      <% if @info_request.awaiting_description %>
+        <% if @is_owning_user && !@info_request.is_external? && !@render_to_file %>
+          <%= n_('Please <strong>answer the question above</strong> so we know ' \
+                    'whether the recent response contains useful information.',
+                 'Please <strong>answer the question above</strong> so we know ' \
+                    'whether the recent responses contain useful information.',
                  @new_responses_count) %>
         <% else %>
-          <%= n_("We're waiting for {{user}} to read a recent response and update the status.",
-                 "We're waiting for {{user}} to read recent responses and update the status.",
-                 @new_responses_count,
-                 :user => user_link_for_request(@info_request)) %>
+          <%= _('This request has an <strong>unknown status</strong>.') %>
+
+          <% if @old_unclassified %>
+            <%= n_("We're waiting for someone to read a recent response and " \
+                      "update the status accordingly. Perhaps " \
+                      "<strong>you</strong> might like to help out by doing that?",
+                   "We're waiting for someone to read recent responses and " \
+                      "update the status accordingly. Perhaps " \
+                      "<strong>you</strong> might like to help out by doing that?",
+                   @new_responses_count) %>
+          <% else %>
+            <%= n_("We're waiting for {{user}} to read a recent response and update the status.",
+                   "We're waiting for {{user}} to read recent responses and update the status.",
+                   @new_responses_count,
+                   :user => user_link_for_request(@info_request)) %>
+          <% end %>
         <% end %>
-      <% end %>
-    <% elsif @status == 'waiting_response' %>
-      <%= _('Currently <strong>waiting for a response</strong> from {{public_body_link}}, they must respond promptly and', :public_body_link=> public_body_link(@info_request.public_body)) %>
+      <% elsif @status == 'waiting_response' %>
+        <%= _('Currently <strong>waiting for a response</strong> from {{public_body_link}}, they must respond promptly and', :public_body_link=> public_body_link(@info_request.public_body)) %>
 
-      <% if @info_request.public_body.is_school? %>
-        <%= _('in term time') %>
-      <% else %>
-        <%= _('normally') %>
-      <% end %>
+        <% if @info_request.public_body.is_school? %>
+          <%= _('in term time') %>
+        <% else %>
+          <%= _('normally') %>
+        <% end %>
 
-      <%= _('no later than') %> <strong><%= simple_date(@info_request.date_response_required_by) %></strong>
-      (<%= link_to _("details"), "/help/requesting#quickly_response" %>).
-    <% elsif @status == 'waiting_response_overdue' %>
-      <%= _('Response to this request is <strong>delayed</strong>.') %>
-      <%= _('By law, {{public_body_link}} should normally have responded <strong>promptly</strong> and',:public_body_link=>public_body_link(@info_request.public_body)) %>
+        <%= _('no later than') %> <strong><%= simple_date(@info_request.date_response_required_by) %></strong>
+        (<%= link_to _("details"), "/help/requesting#quickly_response" %>).
+      <% elsif @status == 'waiting_response_overdue' %>
+        <%= _('Response to this request is <strong>delayed</strong>.') %>
+        <%= _('By law, {{public_body_link}} should normally have responded <strong>promptly</strong> and',:public_body_link=>public_body_link(@info_request.public_body)) %>
 
-      <% if @info_request.public_body.is_school? %>
-        <%= _('in term time') %>
-      <% end %>
+        <% if @info_request.public_body.is_school? %>
+          <%= _('in term time') %>
+        <% end %>
 
-      <%= _('by') %> <strong><%= simple_date(@info_request.date_response_required_by) %></strong>
-      (<%= link_to _('details'), help_requesting_path(:anchor => 'quickly_response') %>)
-    <% elsif @status == 'waiting_response_very_overdue' %>
-      <%= _('Response to this request is <strong>long overdue</strong>.') %>
-      <%= _('By law, under all circumstances, {{public_body_link}} should have responded by now',:public_body_link => public_body_link(@info_request.public_body)) %>
-      (<%= link_to _('details'), help_requesting_path(:anchor => 'quickly_response') %>).
+        <%= _('by') %> <strong><%= simple_date(@info_request.date_response_required_by) %></strong>
+        (<%= link_to _('details'), help_requesting_path(:anchor => 'quickly_response') %>)
+      <% elsif @status == 'waiting_response_very_overdue' %>
+        <%= _('Response to this request is <strong>long overdue</strong>.') %>
+        <%= _('By law, under all circumstances, {{public_body_link}} should have responded by now',:public_body_link => public_body_link(@info_request.public_body)) %>
+        (<%= link_to _('details'), help_requesting_path(:anchor => 'quickly_response') %>).
 
-      <% if !@info_request.is_external? %>
-        <%= _('You can <strong>complain</strong> by') %>
-        <%= link_to _("requesting an internal review"), new_request_followup_path(:request_id => @info_request.id) + "?internal_review=1#followup" %>.
-      <% end %>
-    <% elsif @status == 'not_held' %>
-      <%= _('{{authority_name}} <strong>did not have</strong> the information ' \
-               'requested.',
-            :authority_name => public_body_link(@info_request.public_body)) %>
-    <% elsif @status == 'rejected' %>
-      <%= _('The request was <strong>refused</strong> by {{authority_name}}.',
-            :authority_name => public_body_link(@info_request.public_body)) %>
-    <% elsif @status == 'successful' %>
-      <%= _('The request was <strong>successful</strong>.') %>
-    <% elsif @status == 'partially_successful' %>
-      <%= _('The request was <strong>partially successful</strong>.') %>
-    <% elsif @status == 'waiting_clarification' %>
-      <% if @is_owning_user && !@info_request.is_external? %>
-        <%= _('{{authority_name}} is <strong>waiting for your clarification</strong>.',
-              :authority_name => h(@info_request.public_body.name)) %>
-        <%= _('Please') %>
-        <%= link_to _("send a follow up message"), respond_to_last_path(@info_request, :anchor => 'followup') %>.
-      <% else %>
-        <%= _('The request is <strong>waiting for clarification</strong>.') %>
         <% if !@info_request.is_external? %>
-          <%= _('If you are {{user_link}}, please',
-                :user_link=>user_link_for_request(@info_request)) %>
-          <%= link_to _("sign in"), signin_path(:r => request.fullpath) %>
-          <%= _('to send a follow up message.') %>
+          <%= _('You can <strong>complain</strong> by') %>
+          <%= link_to _("requesting an internal review"), new_request_followup_path(:request_id => @info_request.id) + "?internal_review=1#followup" %>.
         <% end %>
+      <% elsif @status == 'not_held' %>
+        <%= _('{{authority_name}} <strong>did not have</strong> the information ' \
+                 'requested.',
+              :authority_name => public_body_link(@info_request.public_body)) %>
+      <% elsif @status == 'rejected' %>
+        <%= _('The request was <strong>refused</strong> by {{authority_name}}.',
+              :authority_name => public_body_link(@info_request.public_body)) %>
+      <% elsif @status == 'successful' %>
+        <%= _('The request was <strong>successful</strong>.') %>
+      <% elsif @status == 'partially_successful' %>
+        <%= _('The request was <strong>partially successful</strong>.') %>
+      <% elsif @status == 'waiting_clarification' %>
+        <% if @is_owning_user && !@info_request.is_external? %>
+          <%= _('{{authority_name}} is <strong>waiting for your clarification</strong>.',
+                :authority_name => h(@info_request.public_body.name)) %>
+          <%= _('Please') %>
+          <%= link_to _("send a follow up message"), respond_to_last_path(@info_request, :anchor => 'followup') %>.
+        <% else %>
+          <%= _('The request is <strong>waiting for clarification</strong>.') %>
+          <% if !@info_request.is_external? %>
+            <%= _('If you are {{user_link}}, please',
+                  :user_link=>user_link_for_request(@info_request)) %>
+            <%= link_to _("sign in"), signin_path(:r => request.fullpath) %>
+            <%= _('to send a follow up message.') %>
+          <% end %>
+        <% end %>
+      <% elsif @status == 'gone_postal' %>
+        <%= _('The authority would like to / has <strong>responded by ' \
+                 'post</strong> to this request.') %>
+      <% elsif @status == 'internal_review' %>
+        <%= _('Waiting for an <strong>internal review</strong> by {{public_body_link}} of their handling of this request.',:public_body_link=>public_body_link(@info_request.public_body)) %>
+      <% elsif @status == 'error_message' %>
+        <%= _('There was a <strong>delivery error</strong> or similar, which ' \
+                 'needs fixing by the {{site_name}} team.',
+              :site_name=>site_name) %>
+      <% elsif @status == 'requires_admin' %>
+        <%= _('This request has had an unusual response, and <strong>requires ' \
+                'attention</strong> from the {{site_name}} team.',
+              :site_name=>site_name) %>
+      <% elsif @status == 'user_withdrawn' %>
+        <%= _('This request has been <strong>withdrawn</strong> by the person ' \
+                 'who made it. There may be an explanation in the correspondence below.') %>
+      <% elsif @status == 'attention_requested' %>
+        <%= _('This request has been <strong>reported</strong> as needing ' \
+                 'administrator attention (perhaps because it is vexatious, or a ' \
+                 'request for personal information)') %>
+      <% elsif @status == 'vexatious' %>
+        <%= _('This request has been <strong>hidden</strong> from the site, ' \
+                 'because an administrator considers it vexatious') %>
+      <% elsif @status == 'not_foi' %>
+        <%= _('This request has been <strong>hidden</strong> from the site, ' \
+                 'because an administrator considers it not to be an FOI request') %>
+      <% else %>
+        <%= render :partial => 'general/custom_state_descriptions', :locals => { :status => @status } %>
       <% end %>
-    <% elsif @status == 'gone_postal' %>
-      <%= _('The authority would like to / has <strong>responded by ' \
-               'post</strong> to this request.') %>
-    <% elsif @status == 'internal_review' %>
-      <%= _('Waiting for an <strong>internal review</strong> by {{public_body_link}} of their handling of this request.',:public_body_link=>public_body_link(@info_request.public_body)) %>
-    <% elsif @status == 'error_message' %>
-      <%= _('There was a <strong>delivery error</strong> or similar, which ' \
-               'needs fixing by the {{site_name}} team.',
-            :site_name=>site_name) %>
-    <% elsif @status == 'requires_admin' %>
-      <%= _('This request has had an unusual response, and <strong>requires ' \
-              'attention</strong> from the {{site_name}} team.',
-            :site_name=>site_name) %>
-    <% elsif @status == 'user_withdrawn' %>
-      <%= _('This request has been <strong>withdrawn</strong> by the person ' \
-               'who made it. There may be an explanation in the correspondence below.') %>
-    <% elsif @status == 'attention_requested' %>
-      <%= _('This request has been <strong>reported</strong> as needing ' \
-               'administrator attention (perhaps because it is vexatious, or a ' \
-               'request for personal information)') %>
-    <% elsif @status == 'vexatious' %>
-      <%= _('This request has been <strong>hidden</strong> from the site, ' \
-               'because an administrator considers it vexatious') %>
-    <% elsif @status == 'not_foi' %>
-      <%= _('This request has been <strong>hidden</strong> from the site, ' \
-               'because an administrator considers it not to be an FOI request') %>
-    <% else %>
-      <%= render :partial => 'general/custom_state_descriptions', :locals => { :status => @status } %>
-    <% end %>
-  </p>
+    </p>
+  </div>
+  </div>
+</div>
 
+<div id="left_column" class="left_column">
   <% for info_request_event in @info_request_events %>
     <% if info_request_event.visible %>
       <%= render :partial => 'correspondence', :locals => { :info_request_event => info_request_event } %>


### PR DESCRIPTION
Alters the overrides to allow the action menus to work properly (and the link to appear at the top rather than the foot of the page).

Closes #358 