### PR TITLE
Update hack to add extra alert type

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -15,10 +15,22 @@ Rails.configuration.to_prepare do
         end
     end
 
-    # Now patch the validator for UserInfoRequestSentAlert.alert_type
-    # to permit 'survey_1' as a new alert type.
-
-    UserInfoRequestSentAlert._validate_callbacks[0].options[:in] << 'survey_1'
+    # HACK: Now patch the validator for UserInfoRequestSentAlert.alert_type
+    # to permit 'survey_1' as a new alert type. This uses unstable internal
+    # methods.
+    #
+    # TODO: This looks like its just adding another option to
+    # `validates_inclusion_of :alert_type, :in => ALERT_TYPES`. This would be
+    # better done by a `cattr_reader` so that themes could set the options on
+    # app boot in an initializer:
+    #
+    #    UserInfoRequestSentAlert.alert_types = %w(custom set of alerts)
+    #
+    # The validation macro would then be:
+    #
+    #    validates_inclusion_of :alert_type, :in => alert_types
+    #
+    UserInfoRequestSentAlert._validate_callbacks.first.filter.options[:in] << 'survey_1'
 
     InfoRequest.class_eval do
         def email_subject_request(opts = {})


### PR DESCRIPTION
The original hack fails in Rails 4.1 with a NoMethodError:

    UserInfoRequestSentAlert._validate_callbacks[0].options[:in] << 'survey_1'
    NoMethodError: undefined method `[]' for #<ActiveSupport::Callbacks::CallbackChain:0x000000094002a0>

I figured out what to change by comparing the objects in Rails 4.1.16 vs 4.0.13.

    Loading development environment (Rails 4.0.13)

    UserInfoRequestSentAlert._validate_callbacks
    # => [#<ActiveSupport::Callbacks::Callback:0x00000008c3e3c8
    # =>  @chain=[...],
    # =>  @compiled_options="true",
    # =>  @filter="_callback_before_55",
    # =>  @kind=:before,
    # =>  @klass=UserInfoRequestSentAlert(id: integer, user_id: integer, info_request_id: integer, alert_type: string, info_request_event_id: integer),
    # =>  @options=
    # =>   {:in=>["overdue_1", "very_overdue_1", "new_response_reminder_1", "new_response_reminder_2", "new_response_reminder_3", "not_clarified_1", "comment_1", "embargo_expiring_1"],
    # =>    :if=>[],
    # =>    :unless=>[]},
    # =>  @raw_filter=
    # =>   #<ActiveModel::Validations::InclusionValidator:0x00000008c3ed78
    # =>    @attributes=[:alert_type],
    # =>    @delimiter=
    # =>     ["overdue_1", "very_overdue_1", "new_response_reminder_1", "new_response_reminder_2", "new_response_reminder_3", "not_clarified_1", "comment_1", "embargo_expiring_1"],
    # =>    @options=
    # =>     {:in=>["overdue_1", "very_overdue_1", "new_response_reminder_1", "new_response_reminder_2", "new_response_reminder_3", "not_clarified_1", "comment_1", "embargo_expiring_1"]}>>]

    Loading development environment (Rails 4.1.16)

    UserInfoRequestSentAlert._validate_callbacks
    # => #<ActiveSupport::Callbacks::CallbackChain:0x000000092829c8
    # => @callbacks=nil,
    # => @chain=
    # =>  [#<ActiveSupport::Callbacks::Callback:0x00000009282db0
    # =>    @chain_config={:scope=>:name},
    # =>    @filter=
    # =>     #<ActiveModel::Validations::InclusionValidator:0x00000009283198
    # =>      @attributes=[:alert_type],
    # =>      @delimiter=
    # =>       ["overdue_1", "very_overdue_1", "new_response_reminder_1", "new_response_reminder_2", "new_response_reminder_3", "not_clarified_1", "comment_1", "embargo_expiring_1"],
    # =>      @options=
    # =>       {:in=>
    # =>         ["overdue_1", "very_overdue_1", "new_response_reminder_1", "new_response_reminder_2", "new_response_reminder_3", "not_clarified_1", "comment_1", "embargo_expiring_1"]}>,
    # =>    @if=[],
    # =>    @key=
    # =>     #<ActiveModel::Validations::InclusionValidator:0x00000009283198
    # =>      @attributes=[:alert_type],
    # =>      @delimiter=
    # =>       ["overdue_1", "very_overdue_1", "new_response_reminder_1", "new_response_reminder_2", "new_response_reminder_3", "not_clarified_1", "comment_1", "embargo_expiring_1"],
    # =>      @options=
    # =>       {:in=>
    # =>         ["overdue_1", "very_overdue_1", "new_response_reminder_1", "new_response_reminder_2", "new_response_reminder_3", "not_clarified_1", "comment_1", "embargo_expiring_1"]}>,
    # =>    @kind=:before,
    # =>    @name=:validate,
    # =>    @unless=[]>],
    # => @config={:scope=>:name},
    # => @mutex=#<Mutex:0x00000009282950>,
    # => @name=:validate>

* The Rails 4.0 version returns an Array, hence the broken `[0]` call.
* Call `#first` instead to get the first callback from `@chain`.
* Have a look what methods that has:

```
    UserInfoRequestSentAlert._validate_callbacks.first.methods - Object.methods
    # => [:kind, :kind=, :name=, :chain_config, :filter, :raw_filter, :merge, :matches?, :duplicates?, :apply]
```

* Try `#filter` to get the `InclusionValidator`.
* Append the new option as before.
* Tests pass :)

Also added some notes about how I think we can avoid futzing with Rails' internals.