### PR TITLE
[#3708] Add a new contact us section for asking for help writing a request

### DIFF
--- a/lib/views/help/_contact_form.html.erb
+++ b/lib/views/help/_contact_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_for :contact,
-             :url => help_contact_path + '#wdtk',
+             :url => help_contact_path + '#' +  form_id,
              :html => {:class => 'contact-form'} do |f| %>
 
     <p class="contact-form__understand">
@@ -15,7 +15,9 @@
         <p>
             <label class="form_label" for="contact_name">My name:</label>
             <%= f.text_field :name, :size => 20 %>
-            (or <%= link_to "sign in", signin_url(:r => request.fullpath + '#wdtk') %>)
+            (or <%= link_to "sign in",
+                            signin_url(
+                              :r => request.fullpath + '#' + form_id) %>)
         </p>
 
         <p>
@@ -63,6 +65,7 @@
                 $('#contact_understand').removeAttr('required');
             }
         //--></script>
+        <%= hidden_field_tag(:current_form, form_id) %>
         <%= hidden_field_tag(:submitted_contact_form, 1) %>
         <%= submit_tag "Send message to WhatDoTheyKnow volunteers", :data => { :disable_with => "Sending..." } %>
     </div>

--- a/lib/views/help/_contact_form.html.erb
+++ b/lib/views/help/_contact_form.html.erb
@@ -14,7 +14,7 @@
     <% if not @user %>
         <p>
             <label class="form_label" for="contact_name">My name:</label>
-            <%= f.text_field :name, :size => 20 %>
+            <%= f.text_field :name, :size => 20, :required => true %>
             (or <%= link_to "sign in",
                             signin_url(
                               :r => request.fullpath + '#' + form_id) %>)
@@ -28,14 +28,17 @@
 
     <p>
         <label class="form_label" for="contact_subject">My message is about:</label>
-        <%= f.text_field :subject, :size => 50, :class => "message-subject" %>
+        <%= f.text_field :subject,
+                         :size => 50,
+                         :required => true,
+                         :class => "message-subject" %>
     </p>
 
     <p>
         <label class="form_label" for="contact_message">
             My message to the WhatDoTheyKnow volunteers:
         </label>
-        <%= f.text_area :message, :rows => 10, :cols => 60 %>
+        <%= f.text_area :message, :rows => 10, :cols => 60, :required => true %>
     </p>
 
     <p style="display:none;">
@@ -61,8 +64,11 @@
     <div class="form_button">
         <script><!--
             if (!!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/)) {
-                $('#contact_email').removeAttr('required');
                 $('#contact_understand').removeAttr('required');
+                $('#contact_name').removeAttr('required');
+                $('#contact_email').removeAttr('required');
+                $('#contact_subject').removeAttr('required');
+                $('#contact_message').removeAttr('required');
             }
         //--></script>
         <%= hidden_field_tag(:current_form, form_id) %>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -66,6 +66,29 @@
         </ul>
     </div>
 
+
+    <h2 class="contact-page__goal" id="writing-help">
+        <label class="houdini-label" for="goal4">
+            I need <strong>help writing a freedom of information request</strong>.
+        </label>
+    </h2>
+
+    <input class="houdini-input" type="radio" name="goals" id="goal4"
+        <% if params["contact"] && params[:current_form] == 'writing-help' %>checked<% end %>>
+    <div class="houdini-target contact-page__options">
+        <ul>
+            <li>
+                Directly contact the volunteers who run WhatDoTheyKnow:
+
+                <%= foi_error_messages_for :contact %>
+
+                <%= render :partial => "help/contact_form",
+                           :locals => { :form_id => 'writing-help' } %>
+            </li>
+        </ul>
+    </div>
+
+
     <h2 class="contact-page__goal" id="wdtk">
         <label class="houdini-label" for="goal3">
             I have another issue, or feedback relating to the
@@ -75,7 +98,7 @@
     </h2>
 
     <input class="houdini-input" type="radio" name="goals" id="goal3"
-        <% if params["contact"] %>checked<% end %>>
+        <% if params["contact"] && params[:current_form] == 'wdtk' %>checked<% end %>>
     <div class="houdini-target contact-page__options">
         <ul>
             <li>
@@ -94,7 +117,8 @@
 
                 <%= foi_error_messages_for :contact %>
 
-                <%= render :partial => "help/contact_form" %>
+                <%= render :partial => "help/contact_form",
+                           :locals => { :form_id => 'wdtk' } %>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
With the new section, the page will look like:

![screen shot 2017-05-19 at 16 14 30](https://cloud.githubusercontent.com/assets/27760/26254390/56cb45ec-3cae-11e7-8a71-afd76d6f37ee.png)

And with the section open:

![contact us - whatdotheyknow 20170519](https://cloud.githubusercontent.com/assets/27760/26254947/1abd5836-3cb0-11e7-9023-7f4032d2db04.png)

A bit of a non-ideal solution as now we have 2 copies of the form on the page but I can't think of how to fix that :(

Fixes mysociety/alaveteli#3708