### PR TITLE
[#401] Remove foi-regitser link

### DIFF
--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -30,7 +30,7 @@
   <p>Peidiwch â cheisio dynwared rhywun arall.</p> </dd>
   <dt id="anonymous">Pam mae ceisiadau dienw ar y safle? <a href="#anonymous">#</a> </dt>
   <dd>
-  Mae rhai awdurdodau cyhoeddus yn defnyddio <a href="https://github.com/mysociety/foi-register"> meddalwedd mySociety yn FOI Cofrestru </a> er mwyn defnyddio WhatDoTheyKnow fel log datgelu ar gyfer eu holl weithgarwch Rhyddid Gwybodaeth.   Pan fydd pobl yn gwneud cais i'r awdurdod y bydd eu henwau fel arfer yn cael ei ddal yn ôl rhag eu cyhoeddi union fel y byddent mewn log datgelu awdurdod ar wefan yr awdurdod.
+  Mae rhai awdurdodau cyhoeddus yn defnyddio meddalwedd mySociety yn FOI Cofrestru er mwyn defnyddio WhatDoTheyKnow fel log datgelu ar gyfer eu holl weithgarwch Rhyddid Gwybodaeth.   Pan fydd pobl yn gwneud cais i'r awdurdod y bydd eu henwau fel arfer yn cael ei ddal yn ôl rhag eu cyhoeddi union fel y byddent mewn log datgelu awdurdod ar wefan yr awdurdod.
   </dd>
   <dt id="full_address">Maen nhw wedi gofyn am fy nghyfeiriad post! <a href="#full_address">#</a> </dt>
   <dd>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -69,7 +69,7 @@
     </dd>
     <dt id="anonymous">Why are there anonymous requests on the site? <a href="#anonymous">#</a> </dt>
     <dd>
-    Some public authorities were using mySociety's <a href="https://github.com/mysociety/foi-register">FOI Register</a> software in order to use WhatDoTheyKnow as a disclosure log for all their FOI activity.   When people make requests to the authority their names will usually be withheld from publication just as they would in an authority disclosure log on an authority website.
+    Some public authorities were using mySociety's FOI Register software in order to use WhatDoTheyKnow as a disclosure log for all their FOI activity. When people make requests to the authority their names will usually be withheld from publication just as they would in an authority disclosure log on an authority website.
     </dd>
     <dt id="full_address">They've asked for my postal address! <a href="#full_address">#</a> </dt>
     <dd>


### PR DESCRIPTION
A user commented that the link is dead. The repo is private, so
will appear broken to anyone other than mySociety staff.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/401