### PR TITLE
[#416] Add redirect for /london authorities

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -1,6 +1,8 @@
 # Here you can override or add to the pages in the core website
 
 Rails.application.routes.draw do
+  get '/london' => redirect('/body?tag=london', status: 302)
+
   # Add a route for the survey
   scope '/profile/survey' do
     root :to => 'user#survey', :as => :survey


### PR DESCRIPTION
This mirrors the behaviour of `GET /local/london`.

Eventually we'll want to make `/london` a landing page in its own right,
but this just makes the URL accessible in case we want to get it out in
to marketing material.

See https://github.com/mysociety/whatdotheyknow-theme/issues/416.