### PR TITLE
[#414] Remove foi-regitser link

### DIFF
--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -59,7 +59,7 @@
     </p>
     <h2> 5. Write API </h2>
     <p>
-      The write API is designed to be used by authorities to create their own requests in the system. The API was used by mySociety's <a href="https://github.com/mysociety/foi-register">FOI Register software</a> to support using Alaveteli as a disclosure log for all FOI activity at a particular public body. More technical information about the write API is available on the <a href="http://alaveteli.org/docs/developers/api/">Alaveteli.org site</a>.
+      The write API is designed to be used by authorities to create their own requests in the system. The API was used by mySociety's FOI Register software to support using Alaveteli as a disclosure log for all FOI activity at a particular public body. More technical information about the write API is available on the <a href="http://alaveteli.org/docs/developers/api/">Alaveteli.org site</a>.
     </p>
     <hr>
     <p>Please <a href="<%= help_contact_path %>">contact us</a> if you need an API feature that isn't there yet. It's


### PR DESCRIPTION
A user commented that the link is dead. The repo is private, so
will appear broken to anyone other than mySociety staff.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/414.