### PR TITLE
Add popup informing users of upcoming maintenance

### DIFF
--- a/lib/views/general/_popup_banner.html.erb
+++ b/lib/views/general/_popup_banner.html.erb
@@ -1,0 +1,1 @@
+WhatDoTheyKnow will be down for scheduled maintenance on Monday 16th October between 18:00 and 21:00 BST. Responses from authorities will be queued and added to your requests when we're back online. Thanks for your patience.


### PR DESCRIPTION
For https://github.com/mysociety/alaveteli-project/issues/19.

Anything else we should say?

<img width="1038" alt="screen shot 2017-10-12 at 09 56 26" src="https://user-images.githubusercontent.com/282788/31487821-a304128e-af33-11e7-9677-4c14981bec85.png">
