### PR TITLE
[pro#235] Missing cautionary text

### DIFF
--- a/lib/views/alaveteli_pro/info_requests/_new_request_advice.html.erb
+++ b/lib/views/alaveteli_pro/info_requests/_new_request_advice.html.erb
@@ -1,4 +1,9 @@
 <p>
+  <%= _("<strong>Can I request information about myself?</strong> " \
+        "<a href=\"{{url}}\">No!</a>",
+        :url => help_requesting_path(:anchor => "data_protection").html_safe) %>
+</p>
+<p>
   <strong>
     <%= _("Are you sure the information you’re after isn’t available " \
        "elsewhere?") %>
@@ -57,4 +62,11 @@
             ) %>
   <% end %>
   </strong>
+</p>
+<p>
+  <%= _('Once the privacy period ends, everything that you enter on ' \
+        'this page, including <strong>your name</strong>, will be ' \
+        '<strong><a href="{{url}}">displayed publicly</a></strong> on this ' \
+        'website.',
+        :url => help_privacy_path(:anchor => "public_request").html_safe) %>
 </p>


### PR DESCRIPTION
Copy the sidebar helper text about your message being public (with a modification to account for embargoes) to the pro sidebar template

![screen shot 2017-10-20 at 14 06 10](https://user-images.githubusercontent.com/27760/31822214-ea1a319a-b59f-11e7-859a-636d75d3a036.png)


Connects to mysociety/alaveteli-professional#235
