### PR TITLE
[#433] Use the donation_url config in footer

### DIFF
--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -29,7 +29,7 @@
         <div class="col-sm-3">
             <div class="mysoc-footer__donate">
                 <p>Your donations keep this site and others like it running</p>
-                <a href="https://mysociety.org/donate?utm_source=whatdotheyknow.com&utm_content=footer+donate+now&utm_medium=link&utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">Donate now</a>
+                <a href="<%= AlaveteliConfiguration.donation_url %>?utm_source=whatdotheyknow.com&utm_content=footer+donate+now&utm_medium=link&utm_campaign=mysoc_footer" class="mysoc-footer__donate__button">Donate now</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This hard coded URL is no longer correct. It should use www otherwise we
get a certificate error.

It _should_ redirect cleanly, but in any case, we should use the config
value here.

Fixes #433 