### PR TITLE
Update the link to the pro signup page

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -541,7 +541,7 @@
         campaigners which includes the ability to delay publication of your
         requests and responses. If you are a journalist, campaigner, activist,
         or someone else with a need to make requests for information which are,
-        at least initially, private then <a href="<%= new_pro_account_request_path %>">
+        at least initially, private then <a href="<%= account_request_index_path %>">
         find out more and get in touch</a>.
       </p>
     </dd>
@@ -607,7 +607,7 @@
       <p>
         If you are a journalist, activist, campaigner or someone else who would
         find it useful to have  a tool enabling you to make requests to multiple
-        bodies at the same time please <a href="<%= new_pro_account_request_path
+        bodies at the same time please <a href="<%= account_request_index_path
         %>"> find out more and get in touch</a>.
       </p>
     </dd>


### PR DESCRIPTION
Takes people to /pro

The `help#requesting` page is currently erroring