### PR TITLE
[pro#356] Style details summaries like links

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -79,6 +79,12 @@ a:visited {
       color: $color_black;
     }
   }
+
+  details {
+    summary {
+      color: $color_pro_blue;
+    }
+  }
 }
 
 


### PR DESCRIPTION
Seems like a sensible default given they're clickable.

Initially required to make them look nice when displaying public body
notes in the batch builder.

**Without this change:**

![screen shot 2018-02-09 at 18 09 13](https://user-images.githubusercontent.com/282788/36042611-5b26465e-0dc4-11e8-9f5d-09b4872af5ac.png)

**With this change:**

![screen shot 2018-02-09 at 18 07 56](https://user-images.githubusercontent.com/282788/36042570-30cf8e06-0dc4-11e8-9af8-2a870750a585.png)

See https://github.com/mysociety/alaveteli-professional/issues/356.

Counterpart to https://github.com/mysociety/alaveteli/pull/4518 – can be merged independently though.