### PR TITLE
Left/right indents for incoming/outgoing correspondence

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -769,6 +769,11 @@ div.correspondence {
   border: none;
   border-top: 8px solid $incoming-correspondence-color;
   background-color: $incoming-correspondence-background;
+
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    margin-left: 5em;
+  }
+
   a.link_to_this {
     background-color: $incoming-correspondence-color;
   }
@@ -778,6 +783,11 @@ div.correspondence {
   border: none;
   border-top: 8px solid $outgoing-correspondence-color;
   background-color: $outgoing-correspondence-background;
+
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    margin-right: 5em;
+  }
+
   a.link_to_this {
     background-color: $outgoing-correspondence-color;
   }
@@ -820,6 +830,13 @@ input#reedit_button {
 .comment_in_request {
   a.link_to_this {
     background-color: $comment-color;
+  }
+}
+
+// `div` annoyingly required because overloaded selector in core
+div.comment_in_request {
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    margin-left: 5em;
   }
 }
 


### PR DESCRIPTION
Probably the minimum viable solution to mysociety/alaveteli#4504.

Should hopefully make it easier to track who’s who, when quickly scrolling down long correspondence threads.

![screenshot_2018-07-26 why do you have such a fancy dog - a freedom of information request to geraldine quango](https://user-images.githubusercontent.com/739624/43269110-13dc55e6-90ea-11e8-90e0-a6d32b781740.png)
