### PR TITLE
ensure WDTK gets focus styles for keyboard users

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1855,6 +1855,11 @@ $color_asktheeu_dark_green: #C4DDB9;
  .houdini-label {
    color: $color_pro_blue;
    text-decoration: underline;
+   &:hover,
+   &:active,
+   &:focus {
+     color: $color_black;
+   }
  }
 
  .houdini-target {


### PR DESCRIPTION
A small change that is needed as a result of https://github.com/mysociety/alaveteli/pull/4812

Without this WDTK's colour changes override core's focus styles