### PR TITLE
Ensure the skip to content link text is displayed in white

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -60,6 +60,10 @@ body{
   font-family: $font-family;
 }
 
+.skip-to-link {
+  color: white !important;
+}
+
 a,
 a:visited {
   color: $link-color;


### PR DESCRIPTION
## Why was this needed?

Otherwise the pro livery unintentionally makes the link text invisible against the background

## Screenshots

Before:

<img width="399" alt="screen shot 2018-08-17 at 14 51 04" src="https://user-images.githubusercontent.com/27760/44270245-d45f2280-a22e-11e8-812e-16330408f96f.png">

After:

<img width="373" alt="screen shot 2018-08-17 at 14 52 20" src="https://user-images.githubusercontent.com/27760/44271087-1b4e1780-a231-11e8-88f3-1ccd59649c5d.png">

Closes #496 
