### PR TITLE
Make wording a bit more clear

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -685,8 +685,8 @@
     <li>
       If you are a decision-maker of any seniority, or if you are responding to an
       FOI request, we will not normally remove your details from documents and
-      emails sent by a public body. Accountability of decision-making is at the
-      heart of good government.
+      emails sent by a public body or from FOI requests. Accountability of
+      decision-making is at the heart of good government.
     </li>
     <li>
       If you hold a junior, non-decision making post we will consider requests


### PR DESCRIPTION
Indicate that we won't by default remove decision-makers' names
from requests either.