### PR TITLE
[#455] Update referring to ICO guidance

### DIFF
--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -10,31 +10,52 @@
     <h1>Unhappy about the response you got?</h1>
   <% end %>
 
-  <p>If you <strong>didn’t get a reply within 20 working days</strong> you can:</p>
+  <p>
+    If you <strong>didn’t get a reply within 20 working days</strong> you can:
+  </p>
 
   <ul>
-    <li>Refer your request to the <a href="#refer-to-ico">Information Commissioner</a>.</li>
+    <li>
+      Refer your request to the
+      <a href="#refer-to-ico">Information Commissioner</a>.
+    </li>
   </ul>
 
-  <p>If you <strong>did not get all of the information</strong> that you requested, 
-  or your request was <strong>refused without a reason</strong> valid under the law you can:</p>
+  <p>
+    If you <strong>did not get all of the information</strong> that you
+    requested, or your request was <strong>refused without a reason</strong>
+    valid under the law you can:
+  </p>
 
   <ul>
-    <li>Ask for an <a href="#internal_review">internal review</a> at the public authority. If that doesn't help, you can refer the request to the <a href="#refer-to-ico">Information Commissioner</a>.</li>
-    <li><a href="<%= select_authority_path %>">Make a new request</a> asking for more specific information or to a more appropriate authority</li>
-    <li>or, <a href="#other_means">use other means</a> of asking your question</li>
+    <li>
+      Ask for an <a href="#internal_review">internal review</a> at the public
+      authority. If that doesn't help, you can refer the request to the
+      <a href="#refer-to-ico">Information Commissioner</a>.
+    </li>
+    <li>
+      <a href="<%= select_authority_path %>">Make a new request</a> asking for
+      more specific information or to a more appropriate authority
+    </li>
+    <li>
+      or, <a href="#other_means">use other means</a> of asking your question
+    </li>
   </ul>
 </div>
 
 <h2 id="internal_review">1. Asking for an internal review <a class="hover_a" href="#internal_review">#</a> </h2>
 <p>
   <% if !@info_request.nil? %>
-  Choose <%= link_to "request an internal review", new_request_followup_url(:request_id => @info_request.id) + "?internal_review=1#followup" %> and then write a message asking the authority to review your request.
+    <% path = new_request_followup_url(request_id: @info_request.id) +
+              "?internal_review=1#followup" %>
+
+    Choose <%= link_to "request an internal review", path %> and then write a
+    message asking the authority to review your request.
   <% else %>
-  At the bottom of the relevant request page on WhatDoTheyKnow choose
-  "request an internal review". Then write a message asking for an internal
-  review of your request. You may want to include a link to the
-  request page, to make it clear which request you are talking about.
+    At the bottom of the relevant request page on WhatDoTheyKnow choose
+    "request an internal review". Then write a message asking for an internal
+    review of your request. You may want to include a link to the
+    request page, to make it clear which request you are talking about.
   <% end %>
 </p>
 <p>Internal reviews should be quick. If one takes longer than 20 working days

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -13,14 +13,14 @@
   <p>If you <strong>didn’t get a reply within 20 working days</strong> you can:</p>
 
   <ul>
-    <li>Complain directly to the <a href="#complaining">Information Commissioner</a>.</li>
+    <li>Refer your request to the <a href="#refer-to-ico">Information Commissioner</a>.</li>
   </ul>
 
   <p>If you <strong>did not get all of the information</strong> that you requested, 
   or your request was <strong>refused without a reason</strong> valid under the law you can:</p>
 
   <ul>
-    <li>Ask for an <a href="#internal_review">internal review</a> at the public authority. If that doesn't help, complain to the <a href="#complaining">Information Commissioner</a>.</li>
+    <li>Ask for an <a href="#internal_review">internal review</a> at the public authority. If that doesn't help, you can refer the request to the <a href="#refer-to-ico">Information Commissioner</a>.</li>
     <li><a href="<%= select_authority_path %>">Make a new request</a> asking for more specific information or to a more appropriate authority</li>
     <li>or, <a href="#other_means">use other means</a> of asking your question</li>
   </ul>
@@ -46,34 +46,62 @@
   original decision.
 </p>
 
-<h2 id="complaining">2. Complaining to the Information Commissioner <a class="hover_a" href="#complaining">#</a> </h2>
-<p>If you are still unhappy after the public authority has done their internal review,
-  then you can complain to the Information Commissioner. To do this, read
-  <a href="https://ico.org.uk/concerns/getting/">the Information Commissioner's advice for those with concerns about accessing information</a>. If you requested information from a Scottish
-  authority, then  <a href="http://www.itspublicknowledge.info/YourRights/YourRights.asp">appeal
-  to the Scottish Information Commissioner</a>.
+<a name="complaining"></a>
+<h2 id="refer-to-ico">2. Referring a request to the Information Commissioner <a class="hover_a" href="#refer-to-ico">#</a></h2>
+<p>
+  If you are still unhappy after the public authority has done their internal
+  review, then you can refer your request to the Information Commissioner, who
+  is empowered to uphold access to information laws. To make a referral,
+  start by reading <a href="https://ico.org.uk/concerns/getting/">the
+  Information Commissioner's advice for those with concerns about accessing
+  information</a> which links to their form. If you requested information from a
+  Scottish authority, then it is
+  <a href="http://www.itspublicknowledge.info/YourRights/YourRights.asp">the
+  Scottish Information Commissioner</a> who you will need to contact.
 </p>
-<p>To make it easier to send the relevant information to the
-  Information Commissioner, either
-  <% if !@info_request.nil? %>
-  include a link to your request
-  <strong><%= request_url(@info_request) %></strong>
-  <% else %>
-  include a link to your request on WhatDoTheyKnow
-  <% end %>
-  in your complaint or print out the whole page of your request and all attachments.
+
+<p>
+  While the Information Commissioner asks for their form to be completed and
+  evidence supporting a referral to be attached in practice we are aware they
+  routinely consider referrals made via a simple email setting out the issues,
+  containing a link to the request on WhatDoTheyKnow.com to provide evidence of
+  the full history of the correspondence related to the request. If you do wish
+  to download copies of correspondence, and attachments, to send to the
+  Information Commissioner the <code>.zip</code> download feature, accessed via
+  "Actions" may assist.
 </p>
-<p>WhatDoTheyKnow has no special facilities for handling a request at this stage - it
-  passes into the Information Commissioner's system. You can leave annotations on your
-request keeping people informed of progress.</p>
-<p>A warning. Although the Information Commissioner has worked hard to reduce their backlog of casework,
-  it can still take several months to get resolution from them in most circumstances.
-  One area where they have sped up things considerably is that they are able to prompt non-responsive
-authorities to reply within a few weeks of receiving a complaint.</p>
-<p>If you reach this point, you should accept that you won't get the information quickly by this means. Maybe
-  you want to help the fight to improve Freedom of Information, or maybe
-  getting the information slowly is still worthwhile. You can also try and
-get the information by <strong>other means...</strong></p>
+
+<p>
+  WhatDoTheyKnow does not currently have any special facilities for handling a
+  referral to the Information Commissioner. We encourage users to leave
+  annotations on requests keeping people informed of progress.
+  <a href="https://icosearch.ico.org.uk/s/search.html?collection=ico-meta&profile=decisions&query">
+  Decisions by the Information Commissioner are published online</a> and you can
+  link to a decision via an annotation on the request.
+</p>
+
+<p>
+  A warning. Although the Information Commissioner has worked hard to reduce
+  their backlog of casework, it can still take several months to get resolution
+  from them in many cases. One area where they have sped up things considerably
+  is that they are able to prompt non-responsive authorities to reply within a
+  few weeks of receiving a complaint.
+</p>
+
+<p>
+  If you are unhappy with the response from the Information Commissioner's
+  office you can ask them to reconsider it under their
+  <a href="https://ico.org.uk/concerns/complaints-and-compliments-about-us/complain-about-us/">
+  complaints process</a>.
+</p>
+
+<p>
+  If you reach the point of referring a case to the Information Commissioner,
+  you should accept that you won't get the information quickly by this means.
+  Maybe you want to help the fight to improve our Freedom of Information regime,
+  or maybe getting the information slowly is still worthwhile. You can also try
+  and get the information by other means…
+</p>
 
 <h2 id="other_means">3. Using other means to answer your question <a class="hover_a" href="#other_means">#</a> </h2>
 <p>You can try pursuing your problem or your research in other ways.

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -1,25 +1,31 @@
-<div id="left_column" class="left_column">
 <% @title = "Unhappy about a Freedom of Information request?" %>
+
+<div id="left_column" class="left_column">
 <div class="unhappy-info">
   <% if !@info_request.nil? %>
-  <h1>Unhappy about the response you got
-  to your request &mdash; <%=request_link(@info_request) %>?
-  </h1>
+    <h1>Unhappy about the response you got
+    to your request &mdash; <%=request_link(@info_request) %>?
+    </h1>
   <% else %>
-  <h1>Unhappy about the response you got?</h1>
+    <h1>Unhappy about the response you got?</h1>
   <% end %>
+
   <p>If you <strong>didn’t get a reply within 20 working days</strong> you can:</p>
+
   <ul>
     <li>Complain directly to the <a href="#complaining">Information Commissioner</a>.</li>
   </ul>
+
   <p>If you <strong>did not get all of the information</strong> that you requested, 
   or your request was <strong>refused without a reason</strong> valid under the law you can:</p>
+
   <ul>
     <li>Ask for an <a href="#internal_review">internal review</a> at the public authority. If that doesn't help, complain to the <a href="#complaining">Information Commissioner</a>.</li>
     <li><a href="<%= select_authority_path %>">Make a new request</a> asking for more specific information or to a more appropriate authority</li>
     <li>or, <a href="#other_means">use other means</a> of asking your question</li>
   </ul>
 </div>
+
 <h2 id="internal_review">1. Asking for an internal review <a class="hover_a" href="#internal_review">#</a> </h2>
 <p>
   <% if !@info_request.nil? %>
@@ -39,6 +45,7 @@
   you originally requested, or you will be told that the review upholds the
   original decision.
 </p>
+
 <h2 id="complaining">2. Complaining to the Information Commissioner <a class="hover_a" href="#complaining">#</a> </h2>
 <p>If you are still unhappy after the public authority has done their internal review,
   then you can complain to the Information Commissioner. To do this, read
@@ -67,6 +74,7 @@ authorities to reply within a few weeks of receiving a complaint.</p>
   you want to help the fight to improve Freedom of Information, or maybe
   getting the information slowly is still worthwhile. You can also try and
 get the information by <strong>other means...</strong></p>
+
 <h2 id="other_means">3. Using other means to answer your question <a class="hover_a" href="#other_means">#</a> </h2>
 <p>You can try pursuing your problem or your research in other ways.
 </p>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -3,8 +3,9 @@
 <div id="left_column" class="left_column">
 <div class="unhappy-info">
   <% if !@info_request.nil? %>
-    <h1>Unhappy about the response you got
-    to your request &mdash; <%=request_link(@info_request) %>?
+    <h1>
+      Unhappy about the response you got to your request &mdash;
+      <%= request_link(@info_request) %>?
     </h1>
   <% else %>
     <h1>Unhappy about the response you got?</h1>


### PR DESCRIPTION
* Now "referring" to the ICO
* Kept the `#complaining` anchor for backwards compatibility
* Text supplied in #455

Fixes #455.