### PR TITLE
Prevent spam terms being used in requests

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -26,4 +26,56 @@ Rails.configuration.to_prepare do
 
   end
 
+
+  RequestController.class_eval do
+    before_action :check_spam_terms, only: [:new]
+
+    def check_spam_terms
+      return true unless params[:outgoing_message]
+      return true unless params[:outgoing_message][:body]
+
+      if spammer?(params[:outgoing_message][:body])
+        # if they're signed in, ban them and redirect them to their profile
+        # so that they can see they've been banned
+        # otherwise, just prevent the form submission
+        if @user
+          msg = "Blocked user for use of spam terms, " \
+                "email: #{@user.email}, " \
+                "name: '#{@user.name}'"
+          Rails.logger.warn(msg)
+
+          @user.update!(ban_text: 'Account closed', closed_at: Time.zone.now)
+          clear_session_credentials
+          redirect_to show_user_path(@user.url_name)
+        else
+          msg = "Prevented unauthenticated user submitting spam term."
+          Rails.logger.warn(msg)
+
+          redirect_to root_path
+          true
+        end
+      else
+        true
+      end
+    end
+
+    def spammer?(text)
+      return false unless spam_terms.any?
+      # https://stackoverflow.com/a/43278823/387558
+      # String#match? is Ruby 2.4.0 only so need to tweak
+      # Need to make a case-insensitive regexp for each term then join them all
+      # together
+      text =~ Regexp.union(spam_terms.map { |t| Regexp.new(/#{t}/i) })
+    end
+
+    def spam_terms
+      config = Rails.root + 'tmp/spam_terms.txt'
+      if File.exist?(config)
+        File.read(config).split("\n")
+      else
+        []
+      end
+    end
+  end
+
 end

--- a/spec/integration/spam_terms_integration_spec.rb
+++ b/spec/integration/spam_terms_integration_spec.rb
@@ -1,0 +1,39 @@
+# -*- encoding : utf-8 -*-
+
+# If defined, ALAVETELI_TEST_THEME will be loaded in
+# config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'whatdotheyknow-theme'
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..','..','spec','spec_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..','..','spec','integration','alaveteli_dsl'))
+
+describe 'creating a request with spam terms' do
+  let(:user) { FactoryBot.create(:user) }
+  let(:public_body) { FactoryBot.create(:public_body, name: 'example') }
+  let(:user_session) { login(user) }
+  let(:spammy_message) { 'potato is a lower case spam term' }
+
+  before do
+    File.write(Rails.root + 'tmp/spam_terms.txt', "Potato\n")
+  end
+
+  it 'redirects to home page if the user is not signed in' do
+    visit new_request_to_body_path(url_name: public_body.url_name)
+    fill_in 'Summary', with: 'Message with spam terms'
+    fill_in 'Your request', with: spammy_message
+    find_button('Preview your public request').click
+
+    expect(page).to have_current_path(root_path)
+  end
+
+  it 'bans a signed in user and redirects to their profile page' do
+    using_session(user_session) do
+      visit new_request_to_body_path(url_name: public_body.url_name)
+      fill_in 'Summary', with: 'Message with spam terms'
+      fill_in 'Your request', with: spammy_message
+      find_button('Preview your public request').click
+
+      expect(user.reload).to be_banned
+      expect(page).to have_current_path(show_user_path(user.url_name))
+    end
+  end
+end


### PR DESCRIPTION
Hack for WDTK-specific cases.

If an anonymous user tries to submit spam terms in a request, just
redirect to the home page.

If a signed in user tries to submit spam terms in a request, ban them,
sign them out and then inform them they’ve been banned by sending them
to their profile page where they’ll be shown the ban message.

We can generate tmp/spam_terms.txt manually for now.