### PR TITLE
[Core#4891] Quick fix

### DIFF
--- a/lib/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/lib/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -1,0 +1,68 @@
+<% if info_request_batch.embargo_duration.present? %>
+<div class="sidebar__section update-embargo">
+  <h2 class="embargo-sidebar-heading">
+    <%= _("Privacy") %>
+  </h2>
+
+  <% example_embargo = info_request_batch.info_requests.first.embargo %>
+  <%= render partial: "alaveteli_pro/info_request_batches/embargo_info",
+             locals: { embargo: example_embargo, tense: :present } %>
+
+  <label class="houdini-label" for="input1"><%= _("Change privacy") %></label>
+  <input class="houdini-input" type="checkbox" id="input1">
+  <div class="houdini-target extend-embargo-sidebar">
+    <%= form_tag(
+          create_batch_alaveteli_pro_embargo_extensions_path,
+          class: 'js-embargo-form' ) do |f| %>
+      <%= hidden_field_tag :info_request_batch_id, info_request_batch.id %>
+      <% if local_assigns[:info_request] %>
+        <%= hidden_field_tag :info_request_id, info_request.id %>
+      <% end %>
+
+      <% if can?(:update, info_request_batch) %>
+        <p>
+        <% if example_embargo.expiring_soon? %>
+          <label class="form_label" for="extension_duration">
+            <%= _('Keep private for a further:') %>
+          </label>
+          <%= select_tag :extension_duration,
+                         options_for_select(
+                           embargo_extension_options(example_embargo)),
+                         class: 'js-embargo-duration' %>
+          <%= submit_tag _("Update"),
+                         class: "embargo__submit js-embargo-submit",
+                         data: {
+                         confirm: _("This will update the privacy for all " \
+                                    "of the requests in this batch. " \
+                                    "Are you sure?")
+                         } %>
+        <% else %>
+          <%= _("You will be able to extend this privacy period from " \
+                "{{embargo_extend_from}}.",
+                embargo_extend_from: embargo_extend_from(example_embargo)) %>
+        <% end %>
+        </p>
+      <% end %>
+    <% end %>
+
+    <% if info_request_batch.all_requests_created? %>
+      <%= button_to _("Publish requests"),
+                    destroy_batch_alaveteli_pro_embargoes_path(
+                      info_request_batch_id: info_request_batch.id),
+                    method: :post,
+                    data: {
+                      confirm: _("This will publish all of the requests in " \
+                                 "this batch. Are you sure?")
+                    } %>
+    <% else %>
+      <%= button_to _("Publish requests"),
+                    destroy_batch_alaveteli_pro_embargoes_path(
+                      info_request_batch_id: info_request_batch.id),
+                    method: :post,
+                    disabled: true,
+                    title: _('Disabled while sending remaining requests.')
+                    %>
+    <% end %>
+  </div>
+</div>
+<% end %>

--- a/lib/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
+++ b/lib/views/alaveteli_pro/info_request_batches/_embargo_form.html.erb
@@ -45,7 +45,7 @@
       <% end %>
     <% end %>
 
-    <% if info_request_batch.all_requests_created? %>
+    <%# if info_request_batch.all_requests_created? %>
       <%= button_to _("Publish requests"),
                     destroy_batch_alaveteli_pro_embargoes_path(
                       info_request_batch_id: info_request_batch.id),
@@ -54,15 +54,15 @@
                       confirm: _("This will publish all of the requests in " \
                                  "this batch. Are you sure?")
                     } %>
-    <% else %>
-      <%= button_to _("Publish requests"),
+    <%# else %>
+      <%# button_to _("Publish requests"),
                     destroy_batch_alaveteli_pro_embargoes_path(
                       info_request_batch_id: info_request_batch.id),
                     method: :post,
                     disabled: true,
                     title: _('Disabled while sending remaining requests.')
                     %>
-    <% end %>
+    <%# end %>
   </div>
 </div>
 <% end %>


### PR DESCRIPTION
 Don't call InfoRequestBatch#all_requests_created?

This iterates through each `InfoRequest` associated with the
`InfoRequestBatch` and then `map`s each `PublicBody`, which is really
slow for big batches.

The real fix is to check `InfoRequestBatch#sent_at`…

    --- a/app/models/info_request_batch.rb
    +++ b/app/models/info_request_batch.rb
    @@ -241,7 +241,7 @@ class InfoRequestBatch < ActiveRecord::Base
       #
       # Returns a Boolean
       def all_requests_created?
    -    requestable_public_bodies.empty?
    +    sent_at.present?
       end

…but there's some due diligence to do before we apply that.

Hack until we resolve mysociety/alaveteli#4891