### PR TITLE
[#4865] Add reCAPTCHA to the contact form

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -24,6 +24,18 @@ Rails.configuration.to_prepare do
     def volunteers; end
     def beginners; end
 
+    private
+
+    def set_recaptcha_required
+      @recaptcha_required =
+        AlaveteliConfiguration.contact_form_recaptcha &&
+        request_from_foreign_country?
+    end
+
+    def request_from_foreign_country?
+      country_from_ip != AlaveteliConfiguration.iso_country_code
+    end
+
   end
 
 end

--- a/lib/views/help/_contact_form.html.erb
+++ b/lib/views/help/_contact_form.html.erb
@@ -61,6 +61,10 @@
         </p>
     <% end %>
 
+    <% if @recaptcha_required %>
+      <%= recaptcha_tags %><br />
+    <% end %>
+
     <div class="form_button">
         <script><!--
             if (!!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/)) {


### PR DESCRIPTION
## Relevant issue(s)

Requires https://github.com/mysociety/alaveteli/pull/4909
Required by mysociety/alaveteli#4865 
Connects to mysociety/alaveteli#4865 

## What does this do?

Conditionally shows a reCAPTCHA on the contact form if the request appears to come from outside the UK

## Why was this needed?

WDTK has started getting a high level of spam through the contact form so we wanted to add reCAPTCHA as a deterrent but without forcing it on to every Alaveteli instance.

## Screenshots

<img width="702" alt="screen shot 2018-10-18 at 16 50 25" src="https://user-images.githubusercontent.com/27760/47167265-f68c2400-d2f5-11e8-8778-9bacf1882c53.png">
