### PR TITLE
Show parent batch, from request sidebar

### DIFF
--- a/lib/views/request/_sidebar.html.erb
+++ b/lib/views/request/_sidebar.html.erb
@@ -42,6 +42,8 @@
 
   <%= render :partial => 'request/act' %>
   <%= render :partial => 'request/next_actions' %>
+  <%= render :partial => 'request/batch',
+             :locals => { :info_request => @info_request } %>
 
   <% similar_requests, similar_more = @info_request.similar_requests %>
   <% unless similar_requests.empty? %>


### PR DESCRIPTION
Updates whatdotheyknow-theme’s overridden `_sidebar` template to include the `_batch` partial that’s currently being added in core: https://github.com/mysociety/alaveteli/pull/4914

![image](https://user-images.githubusercontent.com/739624/47301716-70365180-d617-11e8-9560-8b2e99c159fa.png)