### PR TITLE
[#523] Add anchor for backwards compatibility

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -315,6 +315,7 @@
     <a href="#Names">#</a>
   </h2>
 
+  <a name="public_request"></a>
   <h3 id="public_names">
     Why do users’ names and requests appear publicly on the site?
     <a href="#public_names">#</a>


### PR DESCRIPTION
> the anchor name has changed at some point in the past year from
> `#public_request` to `#public_names`

Other themes are expecting to use `public_request`, so this should be
treated as a WDTK-theme specific problem, hence the compatibility fix,
rather than changing the anchor references in Alaveteli core.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/523