### PR TITLE
[#7] More prominent volunteer links

### DIFF
--- a/lib/views/general/_nav_items.html.erb
+++ b/lib/views/general/_nav_items.html.erb
@@ -1,0 +1,19 @@
+<li class="<%= 'selected' if controller?('request') && action?('new', 'select_authority') %>">
+  <%= link_to _("Make a request"), select_authority_path, :id => 'make-request-link' %>
+</li>
+
+<li class="<%= 'selected' if controller?('request') && !action?('new', 'select_authority') %>">
+  <%= link_to _("Browse requests"), request_list_successful_path %>
+</li>
+
+<li class="<%= 'selected' if controller?('public_body') %>">
+  <%= link_to _("View authorities"), list_public_bodies_default_path %>
+</li>
+
+<% unless AlaveteliConfiguration::blog_feed.empty? %>
+  <li class="<%= 'selected' if controller?('general') && action?('blog') %>"><%= link_to _("Read blog"), blog_path %></li>
+<% end %>
+
+<li class="<%= 'selected' if controller?('help') %>">
+  <%= link_to _("Help"), help_about_path %>
+</li>

--- a/lib/views/general/_nav_items.html.erb
+++ b/lib/views/general/_nav_items.html.erb
@@ -14,6 +14,10 @@
   <li class="<%= 'selected' if controller?('general') && action?('blog') %>"><%= link_to _("Read blog"), blog_path %></li>
 <% end %>
 
-<li class="<%= 'selected' if controller?('help') %>">
+<li class="<%= 'selected' if controller?('help') && !action?('volunteers') %>">
   <%= link_to _("Help"), help_about_path %>
+</li>
+
+<li class="<%= 'selected' if controller?('help') && action?('volunteers') %>">
+  <%= link_to _("Volunteer"), help_volunteers_path %>
 </li>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -21,6 +21,7 @@
                 <ul>
                     <li role="presentation"><%= link_to 'Help', help_path %></li>
                     <li role="presentation"><%= link_to 'Contact us', help_contact_path %></li>
+                    <li role="presentation"><%= link_to 'Become a volunteer', help_volunteers_path %></li>
                     <li role="presentation"><%= link_to 'Privacy and cookies', help_privacy_path %></li>
                     <li role="presentation"><%= link_to 'API', help_api_path %></li>
                     <% if feature_enabled?(:pro_pricing) %>


### PR DESCRIPTION
Adds a "Volunteer" link to the navbar

<img width="1036" alt="screen shot 2018-10-31 at 17 14 15" src="https://user-images.githubusercontent.com/27760/47805942-74a5ed00-dd30-11e8-84e2-2fbae214b4e2.png">

...and a "Become a volunteer" link to the footer...

<img width="1036" alt="screen shot 2018-10-31 at 17 15 30" src="https://user-images.githubusercontent.com/27760/47806011-9c955080-dd30-11e8-9f14-44ebe6099b02.png">

The existing "Run by Volunteers" link currently goes to `help/credits#helpus` which is a short section in the credits which links to `/help/volunteers`

Connects to #7