### PR TITLE
Add request_mailer footer with volunteer link

### DIFF
--- a/lib/views/general/_default_footer.text.erb
+++ b/lib/views/general/_default_footer.text.erb
@@ -1,0 +1,1 @@
+<%# This file may be overwritten by a local theme to add footer text to emails %>

--- a/lib/views/general/_default_footer.text.erb
+++ b/lib/views/general/_default_footer.text.erb
@@ -1,1 +1,3 @@
-<%# This file may be overwritten by a local theme to add footer text to emails %>
+----------------------------------------------------------
+
+Help WDTK - <%= help_volunteers_url %>

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1,0 +1,30 @@
+# -*- encoding : utf-8 -*-
+ALAVETELI_TEST_THEME = 'whatdotheyknow-theme'
+require 'spec_helper'
+
+describe RequestMailer do
+
+  describe "when mail to a user through RequestMailer" do
+
+    let(:info_request) { FactoryBot.create(:info_request) }
+    let(:mail) { RequestMailer.old_unclassified_updated(info_request) }
+
+    before do
+      allow(info_request).to receive(:display_status).and_return("refused.")
+      allow(AlaveteliConfiguration).to receive(:site_name).and_return("Test")
+    end
+
+    it "appends the custom footer after the site team sign-off" do
+      expected = <<-EOF.strip_heredoc
+        -- the Test team
+
+        ----------------------------------------------------------
+
+        Help WDTK - http://test.host/en/help/volunteers
+        EOF
+      expect(mail.body).to include(expected)
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Relevant issue(s)

Connects to #519
Requires mysociety/alaveteli#4936

## What does this do?

Overrides the blank template in core to append a footer with a link to the Volunteer page

Example output:
```
To: Bob Smith <bob@localhost>
Subject: Someone has updated the status of your request


To help us keep the site tidy, someone else has updated the status of the
Freedom of Information request The cost of boring that you made to Ministry of Silly Walks, to "handled by post." If you disagree with their categorisation, please update the status again yourself to what you believe to be more accurate.

Follow this link to see the request:

http://alaveteli.10.10.10.30.xip.io/request/the_cost_of_boring_two

-- the Alaveteli team

----------------------------------------------------------

Help WDTK - https://www.whatdotheyknow.com/help/volunteers
```