### PR TITLE
[#3543] Hide requests which appear to be SARs

### DIFF
--- a/lib/views/admin_request/_hidden_user_explanation_reasons.html.erb
+++ b/lib/views/admin_request/_hidden_user_explanation_reasons.html.erb
@@ -6,6 +6,10 @@
                             state: 'not_foi',
                             message: 'personal_information' %>
 
+<%= hidden_user_explanation label: 'Subject access request',
+                            state: 'not_foi',
+                            message: 'subject_access_request' %>
+
 <% if @info_request.public_body_id == 7 %>
     <%= hidden_user_explanation label: 'Immigration correspondence',
                                 state: 'not_foi',

--- a/lib/views/admin_request/hidden_user_explanation/_subject_access_request.text.erb
+++ b/lib/views/admin_request/hidden_user_explanation/_subject_access_request.text.erb
@@ -1,0 +1,9 @@
+<%= _('We consider it is not a valid FOI request as it was correspondence ' \
+      'about your personal circumstances, and we have therefore hidden it ' \
+      'from other users.') %>
+
+<%= _('If you would like to know what information a public authority holds ' \
+       'about you, you should make a “Subject Access Request” in private. ' \
+       'The Information Commissioner’s website provides advice on accessing ' \
+       'your own personal information: ' \
+       'https://ico.org.uk/your-data-matters/your-right-of-access') %>


### PR DESCRIPTION
## Related issues

Closes mysociety/alaveteli#3543

Adapts the suggested text from mysociety/alaveteli#881 relating SAR requests (leaves the "Personal information"/"Personal correspondence" option as-is).

<a name="email_text"></a>
### Example email text

(artificially line wrapped to be readable on this page)

```
Subject: Your request on Alaveteli hidden


Dear Annie All Roles,

Your request 'Batch test' at http://10.10.10.30:3000/request/batch_test has been 
reviewed by moderators.

We consider it is not a valid FOI request as it was correspondence about your personal circumstances, and we have therefore hidden it from other users.

If you would like to know what information a public authority holds about you, you should make a “Subject Access Request” in private. The Information Commissioner’s website provides advice on accessing your own personal information: https://ico.org.uk/your-data-matters/your-right-of-access

You will still be able to view it while logged in to the site. Please reply to this
email if you would like to discuss this decision further.

Yours,

The Alaveteli team.
```

### New UI element

<img width="588" alt="screen shot 2018-11-14 at 16 18 43" src="https://user-images.githubusercontent.com/27760/48496015-07628380-e829-11e8-868a-ac4f8ad3079b.png">