### PR TITLE
[#4939] Only show user-to-user contact captcha if request is from outside the UK

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -13,6 +13,18 @@ Rails.configuration.to_prepare do
       @user.survey.allow_new_survey
       return redirect_to survey_url
     end
+
+    private
+
+    def set_recaptcha_required
+      @recaptcha_required =
+        AlaveteliConfiguration.user_contact_form_recaptcha &&
+        request_from_foreign_country?
+    end
+
+    def request_from_foreign_country?
+       country_from_ip != AlaveteliConfiguration.iso_country_code
+     end
   end
 
   HelpController.class_eval do

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -13,6 +13,9 @@ Rails.configuration.to_prepare do
       @user.survey.allow_new_survey
       return redirect_to survey_url
     end
+  end
+
+  Users::MessagesController.class_eval do
 
     private
 
@@ -23,8 +26,9 @@ Rails.configuration.to_prepare do
     end
 
     def request_from_foreign_country?
-       country_from_ip != AlaveteliConfiguration.iso_country_code
-     end
+      country_from_ip != AlaveteliConfiguration.iso_country_code
+    end
+
   end
 
   HelpController.class_eval do


### PR DESCRIPTION
## Relevant issue(s)

Requires mysociety/alaveteli#4939
Connects to mysociety/alaveteli#4939

## What does this do?

Overrides the reCAPTCHA controller code in core to restrict it to request from outside the UK