### PR TITLE
Check there is a public body before trying to match the name

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -40,7 +40,7 @@ Rails.configuration.to_prepare do
         def email_subject_request(opts = {})
             html = opts.fetch(:html, true)
             subject_title = html ? self.title : self.title.html_safe
-            if (!is_batch_request_template?) && (public_body.url_name == 'general_register_office')
+            if (!is_batch_request_template?) && (public_body && public_body.url_name == 'general_register_office')
                 # without GQ in the subject, you just get an auto response
                 _('{{law_used_full}} request GQ - {{title}}', :law_used_full => law_used_human(:full),
                                                               :title => subject_title)


### PR DESCRIPTION
Otherwise the fails with an error when we attempt to use it when
guessing possible matching requests (by subject) in the holding pen.

Fixes mysociety/alaveteli#5010