### PR TITLE
A/B test position of donate-cta on request page

### DIFF
--- a/app/assets/javascripts/tests.js
+++ b/app/assets/javascripts/tests.js
@@ -1,0 +1,33 @@
+(function($) {
+  $(function () {
+    window.cxVariation = cxApi.chooseVariation();
+    if(window.cxVariation === 1){
+      var $donate = $('.sidebar__donate-cta');
+      var $link = $('.sidebar__donate-cta__button', $donate);
+      var experimentHref = URI($link.attr('href')).removeSearch('utm_content').
+        addSearch('utm_content', 'experiment_no_' + window.cxVariation).
+        toString();
+      $link.attr('href', experimentHref)
+
+      $('.asktheeu-promo').replaceWith($donate)
+    }
+
+    $('.sidebar__donate-cta__button').on('click', function(e){
+      if( typeof ga !== 'undefined' && ga.loaded ){
+        e.preventDefault();
+        var $link = $(this);
+        ga('send', {
+          hitType: 'event',
+          eventCategory: 'sidebar__donate-cta',
+          eventAction: 'click',
+          eventLabel: document.title,
+          hitCallback: function() {
+            window.location.href = $link;
+          }
+        });
+      }
+    });
+  });
+})(window.jQuery);
+
+

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1647,12 +1647,14 @@ dd {
  * (having to use some aggressive selectors here to override existing sidebar styles)
  */
 
+.sidebar__donate-cta,
 #right_column .sidebar__donate-cta {
   padding: 1em 1.5em 1.5em;
   background-color: lighten($color_red, 25%);
   margin-top: 1em;
 }
 
+h2.sidebar__donate-cta__header,
 #right_column h2.sidebar__donate-cta__header {
   text-transform: none;
   line-height: 1.3em;
@@ -1661,16 +1663,30 @@ dd {
   font-size: 1.125em;
 }
 
+.sidebar__donate-cta__para,
 #right_column .sidebar__donate-cta__para {
   line-height: 1.4em;
 }
 
+// `#left_column` here avoids weird background flash on :hover
+#left_column a.sidebar__donate-cta__button,
 #right_column a.sidebar__donate-cta__button {
   background-color: $color_red;
   &:hover,
   &:active,
   &:focus {
     background-color: darken($color_red, 10%);
+  }
+}
+
+// Part of our A/B experiment - needs to look a bit more polished
+// when no longer in #right_column.
+#left_column .sidebar__donate-cta {
+  border-radius: 0.3em;
+  margin-top: 2em;
+
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    padding: 2em;
   }
 }
 

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -39,6 +39,8 @@ end
 
 Rails.application.config.assets.precompile.unshift(LOOSE_THEME_ASSETS)
 
+Rails.application.config.assets.precompile << ["tests.js"]
+
 # In order to have the theme lib/ folder ahead of the main app one,
 # inspired in Ruby Guides explanation: http://guides.rubyonrails.org/plugins.html
 %w{ . }.each do |dir|

--- a/lib/helpers/donation_helper.rb
+++ b/lib/helpers/donation_helper.rb
@@ -5,15 +5,16 @@ module DonationHelper
   end
 
   def donate_now_link(content, options = {})
+    utm_params = options.delete(:utm_params) || { utm_content: CGI::escape(content) }
     link_to _('Donate Now'),
-      donation_url(:utm_content => CGI::escape(content)),
+      donation_url(utm_params),
       options
   end
 
   private
 
   def donation_url(options = {})
-    AlaveteliConfiguration::donation_url + "?" << options.merge(
+    AlaveteliConfiguration::donation_url + "?" << options.reverse_merge(
       :utm_source => 'whatdotheyknow.com',
       :utm_campaign => 'donation_drive_2016',
       :utm_medium => 'link'

--- a/lib/views/request/_sidebar.html.erb
+++ b/lib/views/request/_sidebar.html.erb
@@ -3,7 +3,12 @@
   <div class="sidebar__donate-cta">
     <h2 class="sidebar__donate-cta__header"><%= _('We work to defend the right to FOI for everyone') %></h2>
     <p class="sidebar__donate-cta__para"><%= _('Help us protect your right to hold public authorities to account. Donate and support our work.') %></p>
-    <%= donate_now_link 'request sidebar donate now', :class => 'button sidebar__donate-cta__button' %>
+    <% utm_params_donate = { :utm_source => site_name.downcase,
+                        :utm_medium => 'link',
+                        :utm_content => 'experiment_no_0',
+                        :utm_campaign => 'foi_request_page' } %>
+    <%= donate_now_link 'request sidebar donate now', :class => 'button sidebar__donate-cta__button', :utm_params => utm_params_donate %>
+
   </div>
   <% end %>
 

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -116,4 +116,7 @@
 
 <%= content_for :javascript do %>
   <%= javascript_include_tag 'request-attachments.js' %>
+  <script src="//www.google-analytics.com/cx/api.js?experiment=3ru5Qru2QIGkyOc6xWLpxg"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.1/URI.min.js" integrity="sha256-D3tK9Rf/fVqBf6YDM8Q9NCNf/6+F2NOKnYSXHcl0keU=" crossorigin="anonymous"></script>
+  <%= javascript_include_tag 'tests.js' %>
 <% end %>

--- a/spec/donation_helper_spec.rb
+++ b/spec/donation_helper_spec.rb
@@ -63,6 +63,19 @@ describe DonationHelper, type: :helper do
       )
     end
 
+    it 'outputs anchor tag with custom utm params' do
+      params = { utm_campaign: 'new_campaign', utm_content: 'content',
+                 utm_medium: 'paper', utm_source: 'example.com' }
+
+      expect(donate_now_link('foo bar', utm_params: params)).to have_xpath(
+        '//a[@href="http://example.com/foo?' \
+          'utm_campaign=new_campaign&' \
+          'utm_content=content&' \
+          'utm_medium=paper&' \
+          'utm_source=example.com"]'
+      )
+    end
+
     it 'can set class attribute' do
       link = donate_now_link('content', class: 'foo')
       anchor = Nokogiri::HTML(link).xpath('//a')[0]


### PR DESCRIPTION
Moves the red donation banner from the sidebar to the end of the page, using JavaScript, if the current user is in Context Experiment group 1.

Also tracks clicks on the donation banner button, no matter where it’s located, so we can use that as the goal in our Content Experiment.

I’ve [set up the experiment](https://analytics.google.com/analytics/web/#/report/siteopt-experiments/a24614779w48006686p48388638/) but not started it yet. Guess we could start it now, it wouldn’t have any effect, but I figured we should get this PR merged and deployed first, just for tidiness ;-)

See mysociety/whatdotheyknow-theme#542 and (more specifically) mysociety/alaveteli-experiments#115.

![screen shot 2018-12-20 at 15 27 09](https://user-images.githubusercontent.com/739624/50293545-c2ef8680-046b-11e9-86eb-9cd57383c366.png)
