### PR TITLE
[#5161] Fix utm_source

### DIFF
--- a/lib/views/request/_sidebar.html.erb
+++ b/lib/views/request/_sidebar.html.erb
@@ -3,7 +3,7 @@
   <div class="sidebar__donate-cta">
     <h2 class="sidebar__donate-cta__header"><%= _('We work to defend the right to FOI for everyone') %></h2>
     <p class="sidebar__donate-cta__para"><%= _('Help us protect your right to hold public authorities to account. Donate and support our work.') %></p>
-    <% utm_params_donate = { :utm_source => site_name.downcase,
+    <% utm_params_donate = { :utm_source => 'whatdotheyknow.com',
                         :utm_medium => 'link',
                         :utm_content => 'experiment_no_0',
                         :utm_campaign => 'foi_request_page' } %>


### PR DESCRIPTION
## Related issue(s)

Fixes mysociety/alaveteli#5161

## What does this do?

Expands the `utm_source` param from "`whatdotheyknow`" to "`whatdotheyknow.com`" for the outbound links to the donations page in the sidebar.

## Why was this needed?

The donations page shows WDTK-specific content and (I think) flags the donation as a contribution towards running WDTK, but only if we pass in the correct string. Also it's fractured the metrics a little bit as the footer link already does this "correctly" so ... that's a pain.

(Our own inbound links should continue to be `whatdotheyknow`/`site_name.downcase` (the resulting text is identical) and as this is a WDTK-specific change, there's no benefit - probably the opposite, in fact - to altering this in core.)

## Background

 (ok, mostly for my benefit as I can never keep these in my head properly)

`utm_source` is a required param for Google Analytics and is to do with tracking a "Campaign". It appears to set out to answer "where did our referred traffic come from?". (Not us examples include "google", "bing", "yahoo", "baidu" and "twitter.com" - I think Twitter might differentiate between traffic from the web and the app but ... I've never been entirely sure.)