### PR TITLE
Use template instead of action with help_general_path

### DIFF
--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -115,7 +115,7 @@
     </dt>
     <dd>
       <p>
-        Find out about <a href="<%= help_general_path(:action => 'volunteers') %>"
+        Find out about <a href="<%= help_general_path(:template => 'volunteers') %>"
         >how to get involved</a>.
       </p>
     <dd>

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -120,14 +120,14 @@
       gwybodaeth yn yr adran help hon.</li>
       <li>Os ydych chi'n dal heb unrhyw lwc, yna gallwch ofyn am adolygiad mewnol,
         ac yna gwyno i'r Comisiynydd Gwybodaeth am yr awdurdod. Darllenwch
-        '<a href="<%= help_general_path(:action => 'unhappy') %>">ein tudalen Anhapus ynghylch yr ymateb a gawsoch?</a>'.
+        '<a href="<%= help_general_path(:template => 'unhappy') %>">ein tudalen Anhapus ynghylch yr ymateb a gawsoch?</a>'.
       </li>
     </ul>
     </dd>
     <dt id="not_satifised">Beth os nad wyf yn fodlon ā'r ymateb? <a href="#not_satifised">#</a> </dt>
     <dd>
     <p>Os na chawsoch y wybodaeth y gofynnoch amdani, neu os na dderbynioch chi
-      hi mewn pryd, yna darllenwch ein tudalen '<a href="<%= help_general_path(:action => 'unhappy') %>">Anhapus ynghylch yr ymateb a gawsoch?</a>'.
+      hi mewn pryd, yna darllenwch ein tudalen '<a href="<%= help_general_path(:template => 'unhappy') %>">Anhapus ynghylch yr ymateb a gawsoch?</a>'.
     </p>
     </dd>
     <dt id="reuse">Mae'n dweud na chaf i ddim ail-ddefnyddio'r wybodaeth a gefais! <a href="#reuse">#</a> </dt>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -440,7 +440,7 @@
         ask for an internal review, and then complain to the Information
         Commissioner about the authority. If you get no response at all then you
         can ask the ICO for help without waiting for an internal review. Read
-        our page &lsquo;<a href="<%= help_general_path(:action => 'unhappy')
+        our page &lsquo;<a href="<%= help_general_path(:template => 'unhappy')
         %>">Unhappy about the response you got?</a>&rsquo;.
       </li>
     </ul>
@@ -452,7 +452,7 @@
     <dd>
       If you didn&rsquo;t get the information you asked for, or you
       didn&rsquo;t get it in time, then read our page &lsquo;<a
-      href="<%= help_general_path(:action => 'unhappy') %>">Unhappy about the
+      href="<%= help_general_path(:template => 'unhappy') %>">Unhappy about the
       response you got?</a>&rsquo;.
     </dd>
     <dt id="reuse">


### PR DESCRIPTION
Needed to use the new dynamic routing workaround for the Rails 5 changes

Fixes the `No route matches {:action=>"unhappy", :controller=>"help"} missing required keys: [:template]` style errors that affect `help/requesting` and `help/credits`