### PR TITLE
[#564] Don't survey suspended users

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -159,6 +159,14 @@ Rails.configuration.to_prepare do
         end
     end
 
+    User.class_eval do
+
+      def can_send_survey?
+        active? && !survey.already_done?
+      end
+
+    end
+
     ContactValidator.class_eval do
       attr_accessor :understand
 

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -145,7 +145,7 @@ Rails.configuration.to_prepare do
 
                     sent_to << info_request.user_id
 
-                    RequestMailer.survey_alert(info_request).deliver
+                    RequestMailer.survey_alert(info_request).deliver_now
                     store_sent.save!
                 end
             end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -135,7 +135,7 @@ Rails.configuration.to_prepare do
                     # Exclude users who have already completed the survey or
                     # have already been sent a survey email in this run
                     logger.debug "[alert_survey] Considering #{info_request.user.url_name}"
-                    next if info_request.user.survey.already_done? || sent_to.include?(info_request.user_id)
+                    next if !info_request.user.can_send_survey? || sent_to.include?(info_request.user_id)
 
                     store_sent = UserInfoRequestSentAlert.new
                     store_sent.info_request = info_request

--- a/spec/model_patches_spec.rb
+++ b/spec/model_patches_spec.rb
@@ -11,6 +11,53 @@ describe UserInfoRequestSentAlert, "when patched by the whatdotheyknow-theme" do
 
 end
 
+describe User, 'when patched by whatdotheyknow-theme' do
+
+  describe '#can_send_survey?' do
+    let(:user) { FactoryBot.create(:user) }
+    subject { user.can_send_survey? }
+
+    before do
+      allow(AlaveteliConfiguration).
+        to receive(:send_survey_mails).and_return(true)
+    end
+
+    context 'a survey has not been sent to an active user' do
+
+      before do
+        allow(user).to receive(:survey).
+          and_return(double('survey', :already_done? => false))
+      end
+
+      it { is_expected.to eq(true) }
+
+    end
+
+    context 'a survey has already been sent' do
+
+      before do
+        allow(user).to receive(:survey).
+          and_return(double('survey', :already_done? => true))
+      end
+
+      it { is_expected.to eq(false) }
+
+    end
+
+    context 'the user is not active' do
+
+      before do
+        allow(user).to receive(:active?).and_return(false)
+      end
+
+      it { is_expected.to eq(false) }
+
+    end
+
+  end
+
+end
+
 describe RequestMailer, 'when patched by whatdotheyknow-theme' do
 
   context 'when SEND_SURVEY_MAILS is set' do

--- a/spec/model_patches_spec.rb
+++ b/spec/model_patches_spec.rb
@@ -143,6 +143,20 @@ describe RequestMailer, 'when patched by whatdotheyknow-theme' do
       end
     end
 
+    context 'when a user is inactive' do
+
+      it 'does not send a survey alert' do
+        allow_any_instance_of(User).to receive(:survey).
+          and_return(double('survey', :already_done? => false))
+        allow_any_instance_of(User).to receive(:active?).
+          and_return(false)
+        get_surveyable_request
+        RequestMailer.alert_new_response_reminders
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
+      end
+
+    end
+
   end
 
   context 'when SEND_SURVEY_MAILS is not set' do


### PR DESCRIPTION
## Relevant issue(s)?

Closes #564

## What does this do?

* Adds a `User#can_send_survey?` method to test whether the user is eligible to receive a survey alert
  * Adds `!user.active?` as a reason to not send the survey alert
* Delegates the user-based part of `RequestMailer.alert_survey`'s decision whether to send a survey alert to the new `User#can_send_survey?` method
* Uses `#deliver_now` instead of the deprecated `#deliver` method when sending survey alerts

## Why was this needed?

We want to stop sending survey alerts to suspended users (by checking the `User#active?` method)