### PR TITLE
Add links to Companies House and ICO

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -22,6 +22,18 @@
                     "http://beta.charitycommission.gov.uk/charity-details/?regid=#{ tag_value }&subid=0" %><br>
     <% end %>
   <% end %>
+
+<% if public_body.has_tag?('ch') %>
+  <% public_body.get_tag_values('ch').each do |tag_value| %>
+      <%= link_to _('Company registration'),
+                    "https://beta.companieshouse.gov.uk/company/#{ tag_value }" %><br>
+  <% end %>
+
+<% if public_body.has_tag?('dpr') %>
+  <% public_body.get_tag_values('dpr').each do |tag_value| %>
+      <%= link_to _('Data Protection registration'),
+                    "https://ico.org.uk/ESDWebPages/Entry/#{ tag_value }" %><br>
+  <% end %>
 <% end %>
 
 <%= link_to _('View FOI email address'), view_public_body_email_path(public_body.url_name) %><br>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -16,7 +16,7 @@
   <% public_body.get_tag_values('charity').each do |tag_value| %>
     <% if tag_value.match(/^SC/) %>
       <%= link_to _('Charity registration'),
-                    "https://www.oscr.org.uk/search/charity-details?number=#{ tag_value }" %><br>
+                    "https://www.oscr.org.uk/about-charities/search-the-register/charity-details?number=#{ tag_value }" %><br>
     <% else %>
       <%= link_to _('Charity registration'),
                     "http://beta.charitycommission.gov.uk/charity-details/?regid=#{ tag_value }&subid=0" %><br>


### PR DESCRIPTION
This PR expands on #491 to include links to Companies House and the ICO's data protection register. It's conceivable that for some bodies we may only use the DPR, however, for others, we may end up using both.

Some examples to test with:
- [DfT OLR Holdings Limited](https://www.whatdotheyknow.com/body/dohl); has 'ch' tag
- [Glasgow City Council](https://www.whatdotheyknow.com/body/gcc); has 'dpr' tag
- [Network Rail Limited](https://www.whatdotheyknow.com/body/network_rail); has 'ch' and 'dpr' tags

This is the first time I've wrangled with the Alaveteli codebase, so, _please be gentle_ 😊

Closes #581 