### PR TITLE
[pro#587] Override the pro pricing controller to use markup in pro_site_name

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -106,4 +106,13 @@ Rails.configuration.to_prepare do
     end
   end
 
+  AlaveteliPro::PlansController.class_eval do
+    def index
+      default_plan_name = add_stripe_namespace('pro')
+      stripe_plan = Stripe::Plan.retrieve(default_plan_name)
+      @plan = AlaveteliPro::WithTax.new(stripe_plan)
+      @pro_site_name = "WhatDoTheyKnow<sup>Pro</sup>"
+    end
+  end
+
 end


### PR DESCRIPTION
Requires mysociety/alaveteli/pull/5294
Related to mysociety/alaveteli-professional#587

Reinstates  the **WhatDoTheyKnow<sup>Pro</sup>** formatting on the pricing page otherwise the translatable template will render it as "**WhatDoTheyKnow Pro**"