### PR TITLE
Second phase of request page donation button A/B testing

### DIFF
--- a/app/assets/javascripts/tests.js
+++ b/app/assets/javascripts/tests.js
@@ -1,10 +1,42 @@
-(function($) {
-  $(function () {
-    window.cxVariation = cxApi.chooseVariation();
-    if(window.cxVariation === 1){
-      // Do something.
+// https://support.google.com/optimize/answer/9059383
+function gtag() { dataLayer.push(arguments); };
+
+function donateButtonTextVariant(variant) {
+  if (variant === '0') {
+      $(document).ready(function(){
+        $('.donate-cta__button').text('Donate now');
+      });
+  } else if (variant === '1') {
+    $(document).ready(function(){
+      $('.donate-cta__button').text('Donate £5 now');
+    });
+  } else if (variant === '2') {
+    $(document).ready(function(){
+      $('.donate-cta__button').text('Donate £10 now');
+    });
+  }
+};
+
+gtag('event', 'optimize.callback', {
+  name: 'XinKUWDjTuK7Yxyo3ZBS4g',
+  callback: donateButtonTextVariant
+});
+
+$(function(){
+  // Record an event whenever the donation button is clicked.
+  $('.donate-cta__button').on('click', function(){
+    if( typeof ga !== 'undefined' && ga.loaded ){
+      e.preventDefault();
+      var href = $(this).attr('href');
+      ga('send', {
+        hitType: 'event',
+        eventCategory: 'Request page donate button',
+        eventAction: 'click',
+        eventLabel: document.title,
+        hitCallback: function() {
+          window.location.href = href;
+        }
+      });
     }
   });
-})(window.jQuery);
-
-
+});

--- a/app/assets/javascripts/tests.js
+++ b/app/assets/javascripts/tests.js
@@ -2,31 +2,8 @@
   $(function () {
     window.cxVariation = cxApi.chooseVariation();
     if(window.cxVariation === 1){
-      var $donate = $('.sidebar__donate-cta');
-      var $link = $('.sidebar__donate-cta__button', $donate);
-      var experimentHref = URI($link.attr('href')).removeSearch('utm_content').
-        addSearch('utm_content', 'experiment_no_' + window.cxVariation).
-        toString();
-      $link.attr('href', experimentHref)
-
-      $('.asktheeu-promo').replaceWith($donate)
+      // Do something.
     }
-
-    $('.sidebar__donate-cta__button').on('click', function(e){
-      if( typeof ga !== 'undefined' && ga.loaded ){
-        e.preventDefault();
-        var $link = $(this);
-        ga('send', {
-          hitType: 'event',
-          eventCategory: 'sidebar__donate-cta',
-          eventAction: 'click',
-          eventLabel: document.title,
-          hitCallback: function() {
-            window.location.href = $link.attr('href');
-          }
-        });
-      }
-    });
   });
 })(window.jQuery);
 

--- a/app/assets/stylesheets/responsive/_print_style.scss
+++ b/app/assets/stylesheets/responsive/_print_style.scss
@@ -173,8 +173,7 @@ p.subtitle {
     border: 0;
 }
 
-.correspondence__footer,
-.asktheeu-promo--requestpage {
+.correspondence__footer {
     display: none;
 }
 

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1503,6 +1503,9 @@ dd {
     margin-bottom: 0.875em;
     font-weight: 600;
   }
+  & > h2:first-child {
+    margin-top: 0;
+  }
   .link_button_green {
     width: 100%;
   }
@@ -1601,50 +1604,30 @@ dd {
   font-size: 1em;
 }
 
-/* Donate cta in request sidebar
- * (having to use some aggressive selectors here to override existing sidebar styles)
- */
+/* Donate cta banner, below correspondence on request page */
 
-.sidebar__donate-cta,
-#right_column .sidebar__donate-cta {
+.donate-cta {
   padding: 1em 1.5em 1.5em;
   background-color: lighten($color_red, 25%);
-  margin-top: 1em;
+  margin-top: 2em;
+  border-radius: 0.3em;
+
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    padding: 2em;
+  }
 }
 
-h2.sidebar__donate-cta__header,
-#right_column h2.sidebar__donate-cta__header {
-  text-transform: none;
-  line-height: 1.3em;
-  font-weight: 600;
+.donate-cta__header {
   margin-top: 0;
   font-size: 1.125em;
 }
 
-.sidebar__donate-cta__para,
-#right_column .sidebar__donate-cta__para {
-  line-height: 1.4em;
-}
-
-// `#left_column` here avoids weird background flash on :hover
-#left_column a.sidebar__donate-cta__button,
-#right_column a.sidebar__donate-cta__button {
+a.donate-cta__button {
   background-color: $color_red;
   &:hover,
   &:active,
   &:focus {
     background-color: darken($color_red, 10%);
-  }
-}
-
-// Part of our A/B experiment - needs to look a bit more polished
-// when no longer in #right_column.
-#left_column .sidebar__donate-cta {
-  border-radius: 0.3em;
-  margin-top: 2em;
-
-  @include respond-min($main_menu-mobile_menu_cutoff) {
-    padding: 2em;
   }
 }
 

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1836,8 +1836,7 @@ $color_asktheeu_dark_green: #C4DDB9;
   }
 }
 
-.asktheeu-promo--homepage,
-.asktheeu-promo--requestpage {
+.asktheeu-promo--homepage {
   margin-top: 2em;
   margin-bottom: 0;
 }

--- a/lib/views/request/_sidebar.html.erb
+++ b/lib/views/request/_sidebar.html.erb
@@ -1,25 +1,12 @@
 <div id="right_column" class="sidebar right_column" role="complementary">
-  <% if show_donation_button? && !flash[:request_sent] %>
-  <div class="sidebar__donate-cta">
-    <h2 class="sidebar__donate-cta__header"><%= _('We work to defend the right to FOI for everyone') %></h2>
-    <p class="sidebar__donate-cta__para"><%= _('Help us protect your right to hold public authorities to account. Donate and support our work.') %></p>
-    <% utm_params_donate = { :utm_source => 'whatdotheyknow.com',
-                        :utm_medium => 'link',
-                        :utm_content => 'experiment_no_0',
-                        :utm_campaign => 'foi_request_page' } %>
-    <%= donate_now_link 'request sidebar donate now', :class => 'button sidebar__donate-cta__button', :utm_params => utm_params_donate %>
-
-  </div>
-  <% end %>
-
   <% if (feature_enabled?(:alaveteli_pro) &&
          can?(:create_embargo, @info_request)) %>
     <%= render partial: "alaveteli_pro/info_requests/embargo_form",
                locals: { info_request: @info_request } %>
   <% end %>
 
-  <div class="request__special-status">
   <% if @info_request.attention_requested %>
+    <div class="request__special-status">
     <% if @info_request.prominence(:decorate => true).is_hidden? %>
       <h2><%= _('Request hidden') %></h2>
       <p>
@@ -42,8 +29,8 @@
                '<a href="{{url}}">contact us</a>.',
               :url => help_requesting_path.html_safe) %></p>
     <% end %>
+    </div>
   <% end %>
-  </div>
 
   <%= render :partial => 'request/act' %>
   <%= render :partial => 'request/next_actions' %>

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -110,10 +110,12 @@
 
 <%- if @sidebar %><%= render :partial => @sidebar_template %><% end %>
 
+<%= content_for :ga_pageview do %>
+  ga('require', 'GTM-53XVLCX');
+  ga('send', 'pageview');
+<% end %>
+
 <%= content_for :javascript do %>
   <%= javascript_include_tag 'request-attachments.js' %>
-  <!-- Uncomment when we have an experiment to run.
-  <script src="//www.google-analytics.com/cx/api.js?experiment=Gt1sN3W0SRidPYU_pm-uuQ"></script>
   <%= javascript_include_tag 'tests.js' %>
-  -->
 <% end %>

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -93,13 +93,27 @@
     </div>
   <% end %>
 
+  <% if show_donation_button? && !flash[:request_sent] %>
+    <div class="donate-cta">
+      <h2 class="donate-cta__header"><%= _('We work to defend the right to FOI for everyone') %></h2>
+      <p class="donate-cta__para"><%= _('Help us protect your right to hold public authorities to account. Donate and support our work.') %></p>
+      <% utm_params_donate = { :utm_source => 'whatdotheyknow.com',
+                          :utm_medium => 'link',
+                          :utm_content => 'experiment_no_0',
+                          :utm_campaign => 'foi_request_page' } %>
+      <%= donate_now_link 'request page donate now', :class => 'button donate-cta__button', :utm_params => utm_params_donate %>
+
+    </div>
+  <% end %>
+
 </div>
 
 <%- if @sidebar %><%= render :partial => @sidebar_template %><% end %>
 
 <%= content_for :javascript do %>
   <%= javascript_include_tag 'request-attachments.js' %>
+  <!-- Uncomment when we have an experiment to run.
   <script src="//www.google-analytics.com/cx/api.js?experiment=Gt1sN3W0SRidPYU_pm-uuQ"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.19.1/URI.min.js" integrity="sha256-D3tK9Rf/fVqBf6YDM8Q9NCNf/6+F2NOKnYSXHcl0keU=" crossorigin="anonymous"></script>
   <%= javascript_include_tag 'tests.js' %>
+  -->
 <% end %>

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -93,23 +93,6 @@
     </div>
   <% end %>
 
-  <% unless @user && @user.is_pro? %>
-    <div class="asktheeu-promo asktheeu-promo--requestpage">
-      <h2 class="asktheeu-promo__header">Looking for an EU Authority?</h2>
-      <p>You can request <em>documents</em> directly from EU Institutions at our sister site
-        <a href="http://asktheeu.org/?utm_source=whatdotheyknow&utm_medium=banner&utm_content=request_page&utm_campaign=alaveteli-experiments-54">
-          AskTheEU.org
-        </a>.
-        <a href="http://www.asktheeu.org/en/help/requesting/?utm_source=whatdotheyknow&utm_medium=banner&utm_content=request_page&utm_campaign=alaveteli-experiments-54">
-          Find out more
-        </a>.
-      </p>
-      <a href="http://asktheeu.org/?utm_source=whatdotheyknow&utm_medium=banner&utm_content=request_page&utm_campaign=alaveteli-experiments-54" class="asktheeu-promo__image">
-        <img src="<%= image_path('ask-the-eu-logo.png') %>" alt="AskTheEU.org" />
-      </a>
-    </div>
-  <% end %>
-
 </div>
 
 <%- if @sidebar %><%= render :partial => @sidebar_template %><% end %>


### PR DESCRIPTION
* Move the request page donation banner out of the sidebar, to its new home at the bottom of the correspondence list (replacing the AskTheEU banner that was there previously).
* Set up Google Optimize on the request pages, and have it pick one of three wording variations for the donation button.
* Trigger a Google Analytics event when the donation button is clicked.

Meanwhile, a [Google Optimize](https://optimize.google.com/optimize/home) experiment has been set up (as per https://github.com/mysociety/research/issues/194) with three variants (0, 1, and 2) and looking out for an "objective" of a Google Analytics event with a `category` of `Request page donate button`.

We’ll need to remember to "Start" the Optimize experiment, once we go ahead with all this.

Part of https://github.com/mysociety/alaveteli-experiments/issues/117.