### PR TITLE
Fix Google Optimize loading on request pages

### DIFF
--- a/app/assets/javascripts/tests.js
+++ b/app/assets/javascripts/tests.js
@@ -1,6 +1,3 @@
-// https://support.google.com/optimize/answer/9059383
-function gtag() { dataLayer.push(arguments); };
-
 function donateButtonTextVariant(variant) {
   if (variant === '0') {
       $(document).ready(function(){
@@ -17,10 +14,17 @@ function donateButtonTextVariant(variant) {
   }
 };
 
-gtag('event', 'optimize.callback', {
-  name: 'XinKUWDjTuK7Yxyo3ZBS4g',
-  callback: donateButtonTextVariant
-});
+if ( typeof dataLayer === 'object' && typeof gtag === 'undefined' ) {
+  // https://support.google.com/optimize/answer/9059383
+  function gtag() { dataLayer.push(arguments); };
+}
+
+if ( typeof gtag !== 'undefined' ) {
+  gtag('event', 'optimize.callback', {
+    name: 'XinKUWDjTuK7Yxyo3ZBS4g',
+    callback: donateButtonTextVariant
+  });
+}
 
 $(function(){
   // Record an event whenever the donation button is clicked.

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -6,6 +6,11 @@
 
 <% if flash[:request_sent] %><%= render :partial => 'request_sent' %><% end %>
 
+<% content_for :ga_pageview do %>
+  window.dataLayer = window.dataLayer || [];
+  ga('require', 'GTM-53XVLCX');
+<% end %>
+
 <%= render :partial => 'ga_events' %>
 
 <%= render :partial => 'hidden_request_messages' %>
@@ -109,11 +114,6 @@
 </div>
 
 <%- if @sidebar %><%= render :partial => @sidebar_template %><% end %>
-
-<%= content_for :ga_pageview do %>
-  ga('require', 'GTM-53XVLCX');
-  ga('send', 'pageview');
-<% end %>
 
 <%= content_for :javascript do %>
   <%= javascript_include_tag 'request-attachments.js' %>


### PR DESCRIPTION
Fix for two mistakes in 636b881 (original PR #591):

1. Makes sure that `dataLayer` is defined at pageload.
2. Avoids calling `ga('send', 'pageview')` twice.

Also, the `content_for :ga_pageview` block is now defined *before* the `render partial => 'ga_events'` block so our `ga` `create/require/send` calls are in the [same order that the docs recommend](https://support.google.com/optimize/answer/6262084). I don‘t think it makes a difference whether the pageview is sent before or after the Optimize ID is included, but at least this way it matches the docs.

@garethrees Once you merge and deploy this, I _think_ the Optimize experiment should work.

Related:

* https://github.com/mysociety/whatdotheyknow-theme/pull/591
* https://github.com/mysociety/research/issues/194