### PR TITLE
Define filters with before_action instead of before_filter

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -1,7 +1,7 @@
 require 'routingfilter'
 
 class ActionController::Base
-    before_filter :set_whatdotheyknow_view_paths
+    before_action :set_whatdotheyknow_view_paths
 
     def set_whatdotheyknow_view_paths
         self.prepend_view_path File.join(File.dirname(__FILE__), "views")


### PR DESCRIPTION
## Relevant issue(s)

Required by mysociety/alaveteli#3970

## What does this do?

Uses `before_action` instead of `before_filter`

## Why was this needed?

`before_filter` was deprecated in Rails 4.2 and will be removed altogether in 5.1

https://edgeguides.rubyonrails.org/4_2_release_notes.html#action-pack-notable-changes
https://github.com/rails/rails/blob/5-1-stable/actionpack/CHANGELOG.md#rails-510-april-27-2017