### PR TITLE
Reconcile with core & sidebar style

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1564,6 +1564,12 @@ dd {
   }
 }
 
+.sidebar__section.pro-upsell {
+  background-color: #faf785;
+  border-bottom: none;
+  padding: 0.85em;
+}
+
 .act_link:last-child {
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1556,13 +1556,45 @@ dd {
 }
 
 .sidebar__section {
-    border-bottom: 1px solid darken($color_light_grey, 7%);
-    margin-bottom: 1.5em;
-    padding-bottom: 1.5em;
-    h2 {
-      margin-top: 0 !important;
-    }
+  border-bottom: 1px solid darken($color_light_grey, 7%);
+  margin-bottom: 1.5em !important;
+  padding-bottom: 1.5em;
+  h2 {
+    margin-top: 0 !important;
+  }
 }
+
+.act_link:last-child {
+  margin-bottom: 0;
+}
+
+.sidebar__similar-requests {
+  .request_short_listing__authority {
+    margin-bottom: 0;
+  }
+}
+
+.copyright-notice {
+  border-top: none;
+  margin-bottom: 0;
+  padding-top: 0;
+  margin-top: 0;
+  font-size: 0.875em;
+  line-height: 1.5em;
+  small {
+    font-size: 1em;
+  }
+  a {
+    color: #777;
+    text-decoration: none;
+    &:hover,
+    &:active,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+}
+
 
 /* Sidebar request navigation */
 .request-navigation {

--- a/lib/views/request/_sidebar.html.erb
+++ b/lib/views/request/_sidebar.html.erb
@@ -1,4 +1,6 @@
 <div id="right_column" class="sidebar right_column" role="complementary">
+  <%= render partial: 'sidebar_pro_upsell' %>
+
   <% if (feature_enabled?(:alaveteli_pro) &&
          can?(:create_embargo, @info_request)) %>
     <%= render partial: "alaveteli_pro/info_requests/embargo_form",
@@ -6,40 +8,43 @@
   <% end %>
 
   <% if @info_request.attention_requested %>
-    <div class="request__special-status">
-    <% if @info_request.prominence(:decorate => true).is_hidden? %>
-      <h2><%= _('Request hidden') %></h2>
-      <p>
-        <%= _("This request has prominence 'hidden'. You can only see it " \
-              "because you are logged in as a super user.") %>
-      </p>
-    <% elsif @info_request.prominence(:decorate => true).is_requester_only? %>
-      <h2><%= _('Request hidden') %></h2>
-      <%# The eccentric formatting of the following string is in order that it be identical
-          to the corresponding string in request/show.html.erb %>
-      <p><%= _('This request is hidden, so that only you the requester ' \
-                  'can see it. Please <a href="{{url}}">contact us</a> ' \
-                  'if you are not sure why.',
-               :url => help_requesting_path.html_safe) %></p>
-    <% elsif @info_request.described_state != "attention_requested" %>
-      <h2><%= _('Offensive? Unsuitable?') %></h2>
-      <p><%= _('This request has been marked for review by the site ' \
-               'administrators, who have not hidden it at this time. ' \
-               'If you believe it should be hidden, please ' \
-               '<a href="{{url}}">contact us</a>.',
-              :url => help_requesting_path.html_safe) %></p>
-    <% end %>
+    <div class="sidebar__section request__special-status">
+      <% if @info_request.prominence(:decorate => true).is_hidden? %>
+        <h2><%= _('Request hidden') %></h2>
+        <p>
+          <%= _("This request has prominence 'hidden'. You can only see it " \
+                "because you are logged in as a super user.") %>
+        </p>
+      <% elsif @info_request.prominence(:decorate => true).is_requester_only? %>
+        <h2><%= _('Request hidden') %></h2>
+        <%# The eccentric formatting of the following string is in order that it
+            be identical to the corresponding string in request/show.html.erb %>
+        <p><%= _('This request is hidden, so that only you the requester ' \
+                    'can see it. Please <a href="{{url}}">contact us</a> ' \
+                    'if you are not sure why.',
+                 :url => help_requesting_path.html_safe) %></p>
+      <% elsif @info_request.described_state != "attention_requested" %>
+        <h2><%= _('Offensive? Unsuitable?') %></h2>
+        <p><%= _('This request has been marked for review by the site ' \
+                 'administrators, who have not hidden it at this time. ' \
+                 'If you believe it should be hidden, please ' \
+                 '<a href="{{url}}">contact us</a>.',
+                :url => help_requesting_path.html_safe) %></p>
+      <% end %>
     </div>
   <% end %>
 
-  <%= render :partial => 'request/act' %>
-  <%= render :partial => 'request/next_actions' %>
+  <div class="sidebar__section next-actions">
+    <%= render :partial => 'request/act' %>
+    <%= render :partial => 'request/next_actions' %>
+  </div>
+
   <%= render :partial => 'request/batch',
              :locals => { :info_request => @info_request } %>
 
   <% similar_requests, similar_more = @info_request.similar_requests %>
   <% unless similar_requests.empty? %>
-    <div class="sidebar__similar-requests">
+    <div class="sidebar__section sidebar__similar-requests">
       <h2><%= _('Requests like this')%></h2>
 
       <% utm_params = { :utm_source => site_name.downcase,
@@ -55,15 +60,20 @@
 
       <% if similar_more %>
         <p class="sidebar_similar_requests__more-link">
-          <%= link_to similar_request_path(@info_request.url_title, utm_params) do %>
-            <%= _("More similar requests") %>
-          <% end %>
+          <% path = similar_request_path(@info_request.url_title, utm_params) %>
+          <%= link_to _("More similar requests"), path %>
         </p>
       <% end %>
     </div>
   <% end %>
 
-  <!-- this link with this wording is here for legal reasons, discuss with
-    board and our lawyer before changing or removing it -->
-  <p class="copyright-notice"><small><%= link_to _('Are you the owner of any commercial copyright on this page?'), help_officers_path(:anchor => "copyright") %></small></p>
+  <div class="sidebar__section">
+    <!-- this link with this wording is here for legal reasons, discuss with
+         board and our lawyer before changing or removing it -->
+    <p class="copyright-notice">
+      <small><%= link_to _('Are you the owner of any commercial copyright ' \
+                           'on this page?'),
+                         help_officers_path(anchor: 'copyright') %></small>
+    </p>
+  </div>
 </div>


### PR DESCRIPTION
Reconciles the request page sidebar with core and improves styling

## Reconciled before styling (1c2acff)

![sidebar-reconciled](https://user-images.githubusercontent.com/282788/62790794-bb94f000-bac3-11e9-9d08-2bd59d2f8469.jpg)

## After styling (9f20069)

![sidebar-styled](https://user-images.githubusercontent.com/282788/62790803-c0f23a80-bac3-11e9-9f82-e985c71ea6f0.jpg)
