### PR TITLE
Pass event parameter to donate button click handler

### DIFF
--- a/app/assets/javascripts/tests.js
+++ b/app/assets/javascripts/tests.js
@@ -28,7 +28,7 @@ if ( typeof gtag !== 'undefined' ) {
 
 $(function(){
   // Record an event whenever the donation button is clicked.
-  $('.donate-cta__button').on('click', function(){
+  $('.donate-cta__button').on('click', function(e){
     if( typeof ga !== 'undefined' && ga.loaded ){
       e.preventDefault();
       var href = $(this).attr('href');


### PR DESCRIPTION
Fixup for 636b881b6e66a4d0177a48f4a819f4ac8275bd5d. The missing `e` parameter meant that our callback function didn’t intercept the browser’s default page navigation, and the Analytics event wasn’t recorded before the browser left the page.