### PR TITLE
Disabled button style

### DIFF
--- a/app/assets/stylesheets/responsive/_mixins.scss
+++ b/app/assets/stylesheets/responsive/_mixins.scss
@@ -78,7 +78,6 @@
   &:active,
   &:focus {
     background-color: inherit;
-    color: inherit;
   }
 }
 

--- a/app/assets/stylesheets/responsive/_mixins.scss
+++ b/app/assets/stylesheets/responsive/_mixins.scss
@@ -22,6 +22,10 @@
       text-decoration: none;
       transition: background-color 300ms ease-out;
   }
+
+  &:disabled {
+    @include button-disabled;
+  }
 }
 
 @mixin button {
@@ -88,6 +92,10 @@
   &:visited:active,
   &:visited:focus {
     box-shadow: 0 1px 0 0 rgba(0,0,0,0.22);
+  }
+
+  &:disabled {
+    @include button-disabled;
   }
 }
 


### PR DESCRIPTION
Add disabled button style used on the new Stripe forms when there are errors preventing it from being submitted.

![image](https://user-images.githubusercontent.com/5426/65225055-ec4d4980-dab3-11e9-8f7c-cc544f00f360.png)

I'm pretty sure the mixin additions are fine but unsure about the impact of removing the `color: inherit`

If left in place the hover style looks like:

![image](https://user-images.githubusercontent.com/5426/65225130-17379d80-dab4-11e9-87da-5c64ac05a34d.png)


