### PR TITLE
Add Public Body name to requires admin email

### DIFF
--- a/lib/views/request_mailer/requires_admin.text.erb
+++ b/lib/views/request_mailer/requires_admin.text.erb
@@ -1,0 +1,16 @@
+<%= raw @message %>
+
+---------------------------------------------------------------------
+<%= _('{{user_name}} has reported an {{law_used}} response as needing ' \
+       'administrator attention. Take a look, and reply to this email to ' \
+       'let them know what you are going to do about it.',
+    :user_name => raw(@reported_by.name),
+    :law_used => raw(@info_request.law_used_human(:short))) %>
+
+<%= _("Request '{{request_title}}':",
+    :request_title => raw(@info_request.title)) %>
+<%= @url %>
+
+<%= _('Administration URL:') %>
+<%= @admin_url %>
+---------------------------------------------------------------------

--- a/lib/views/request_mailer/requires_admin.text.erb
+++ b/lib/views/request_mailer/requires_admin.text.erb
@@ -7,8 +7,9 @@
     :user_name => raw(@reported_by.name),
     :law_used => raw(@info_request.law_used_human(:short))) %>
 
-<%= _("Request '{{request_title}}':",
-    :request_title => raw(@info_request.title)) %>
+<%= _("Request '{{request_title}}' to '{{public_body_name}}':",
+  :request_title => raw(@info_request.title),
+  :public_body_name => raw(@info_request.public_body.name)) %>
 <%= @url %>
 
 <%= _('Administration URL:') %>


### PR DESCRIPTION
This will make support easier, especially for batch requests where almost identical emails can be received.