### PR TITLE
[#657] Rework privacy page for no GA cookies

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -846,42 +846,38 @@
     such as what pages you visit, how long you are on the site, how you got
     here, what you click on, and information about your web browser. IP
     addresses are masked (only a portion is stored) and personal information
-    is only reported in aggregate. We do not allow Google to use or share
-    our analytics data for any purpose besides providing us with analytics
-    information, and we recommend that any user of Google Analytics does the
-    same.
+    is only reported in aggregate. We do not allow Google to store browser
+    cookies on your machine or device. We also do not allow Google to use or
+    share our analytics data for any purpose besides providing us with
+    analytics information, and we recommend that any user of Google Analytics
+    does the same.
   </p>
   <p>
     If you’re unhappy with data about your visit to be used in this way, you
     can install the <a
     href="http://tools.google.com/dlpage/gaoptout">official browser plugin
     for blocking Google Analytics</a>.
-  <p>
-    The cookies set by Google Analytics are as follows:
   </p>
-  <table>
-    <tr><th scope="col">Name</th>
-      <th scope="col">Typical Content</th>
-      <th scope="col">Expires</th>
-    </tr>
-    <tr>
-      <td>__utma</td><td>Unique anonymous visitor ID</td>
-      <td>2 years</td>
-    </tr>
-    <tr>
-      <td>__utmb</td><td>Unique anonymous session ID</td>
-      <td>30 minutes</td>
-    </tr>
-    <tr>
-      <td>__utmz</td>
-      <td>Information on how the site was reached (e.g. direct or via a
-      link/search/advertisement)</td><td>6 months</td>
-    </tr>
-    <tr>
-      <td>__utmx</td><td>Which variation of a page you are seeing if we are
-      testing different versions to see which is best</td><td>2 years</td>
-    </tr>
-  </table>
+  <p>
+    Please note that this website initialises Google Analytics with the
+    following settings:
+  </p>
+  <dl>
+    <dt>
+      anonymizeIp
+    </dt>
+    <dd>
+      This masks the last part of your IP address before any analytics data is
+      stored.
+    </dd>
+    <dt>
+      storage: none
+    </dt>
+    <dd>
+      This instructs Google to not create and store browser cookies on your
+      machine or device.
+    </dd>
+  </dl>
   <h4>Google’s Official Statement about Analytics Data</h4>
   <p>
     “This website uses Google Analytics, a web analytics service provided by


### PR DESCRIPTION
Depends on to https://github.com/mysociety/alaveteli/pull/5591
Fixes #657 
 
Had a go at rewriting the relevant section of the privacy page. Open to any fixups or suggestions.