### PR TITLE
Minor grammar correction on 'about' help page

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -108,7 +108,7 @@
       </p>
     </dd>
     <dt id="how_many">
-      How many people use the WhatDoTheyKnow?
+      How many people use WhatDoTheyKnow?
       <a href="#how_many">#</a>
     </dt>
     <dd>


### PR DESCRIPTION
We were saying "How many people use the WhatDoTheyKnow?" and this commit gets rid of "the"