### PR TITLE
Minor edits to the WhatDoTheyKnow help pages

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -108,7 +108,7 @@
       </p>
     </dd>
     <dt id="how_many">
-      How many people use the WhatDoTheyKnow?
+      How many people use WhatDoTheyKnow?
       <a href="#how_many">#</a>
     </dt>
     <dd>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -531,7 +531,7 @@
   </p>
   <p>
     In any, rare, case where a retention period over four weeks is deemed
-    necessary and it is considered the release of the material is would pose a
+    necessary and it is considered the release of the material would pose a
     significant risk of harm, mySociety staff are responsible for moving the
     material to non-web accessible storage on mySociety’s servers and deleting
     it when the retention period is complete.

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -243,8 +243,8 @@
   <p>
     If that doesn’t work, and you want to provide your postal address
     privately in order to receive the documents, mark your request as
-    “They are going to reply by post”, and it will give you an email
-    address to use for that purpose.
+    “They are going to reply by postal mail”, and it will give you an
+    email address to use for that purpose.
   </p>
   <h3 id="our_logging">
     Our own logging

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -411,7 +411,7 @@
     </p>
     <ul>
       <li>
-        First, check it went through.  If you see <a
+        <strong>First, check it went through.</strong>  If you see <a
         href="https://www.mysociety.org/2016/07/29/the-small-symbol-that-tells-you-all-is-well/?utm_source=whatdotheyknow.com&utm_medium=link">
         a little green tick</a> on your request page, you can
         be sure that your request went through smoothly from our end and has
@@ -423,9 +423,9 @@
         WhatDoTheyKnow requests are sent by  email.
       </li>
       <li>
-        If it went through, follow up. Use the “Write a reply” option under
-        “Actions” on your request, to request an acknowledgement of your request
-        if one isn’t forthcoming.
+        <strong>If it went through, follow up.</strong> Use the “Write a reply”
+        option under “Actions” on your request, to request an acknowledgement
+        of your request if one isn’t forthcoming.
       </li>
       <li>
         <strong>If they have not received it,</strong> the problem is most


### PR DESCRIPTION
Whilst browsing the help pages I saw a couple of tweaks that could be made.

- A grammatical correction to the about page
- Add some bold text to the requesting page
- Change 'post' to 'postal mail' on the privacy page

Plus, it gave me a good opportunity to play with the basics of GitHub etc! Hope I've done it right, apologies in advance if not 😃 