### PR TITLE
Add Sevenoaks responder as invalid reply address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -9,6 +9,7 @@ Rails.configuration.to_prepare do
     ReplyToAddressValidator.invalid_reply_addresses = %w(
       FOIResponses@homeoffice.gsi.gov.uk
       FOIResponses@homeoffice.gov.uk
+      autoresponder@sevenoaks.gov.uk
     )
 
     User.class_eval do


### PR DESCRIPTION
Adds `autoresponder@sevenoaks.gov.uk` as an invalid reply 
address meaning users will not be able to send follow-ups or internal 
review requests to it.

This caused confusion for a user who contacted us because they had received a delivery failure message after replying to the above.

Linked to #670