### PR TITLE
Add ScotlandLateCalculator

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -54,7 +54,9 @@ Rails.configuration.to_prepare do
 
         def late_calculator
           @late_calculator ||=
-            if public_body.has_tag?('school')
+            if public_body.has_tag?('scotland')
+              ScotlandLateCalculator.new
+            elsif public_body.has_tag?('school')
               SchoolLateCalculator.new
             else
               orig_late_calculator

--- a/lib/scotland_late_calculator.rb
+++ b/lib/scotland_late_calculator.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+class ScotlandLateCalculator
+  def self.description
+    %q(Scotland has extended deadlines during COVID-19)
+  end
+
+  def reply_late_after_days
+    60
+  end
+
+  def reply_very_late_after_days
+    100
+  end
+end

--- a/spec/model_patches_spec.rb
+++ b/spec/model_patches_spec.rb
@@ -220,6 +220,13 @@ describe InfoRequest do
         to be_instance_of(SchoolLateCalculator)
     end
 
+    it 'returns a ScotlandLateCalculator if the associated body is in Scotland' do
+      subject.public_body =
+        FactoryBot.build(:public_body, tag_string: 'scotland')
+      expect(subject.late_calculator).
+        to be_instance_of(ScotlandLateCalculator)
+    end
+
   end
 
 end


### PR DESCRIPTION
Scotland has extended deadlines during COVID-19. This applies a custom
LateCalculator to authorities tagged `scotland` to reflect the new
timelines.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/672.

**New late calculation** for authority tagged `scotland`:

<img width="1082" alt="Screenshot 2020-04-02 at 11 49 08" src="https://user-images.githubusercontent.com/282788/78241734-cb40c900-74d8-11ea-8557-8a08f7b30041.png">

Remove the late calc – still get the same due date for requests made during covid-19.

<img width="1073" alt="Screenshot 2020-04-02 at 11 51 26" src="https://user-images.githubusercontent.com/282788/78241784-e14e8980-74d8-11ea-86ac-865e95b1fbfe.png">

Not sure what situations this might get recalculated in, but I imagine we'll be _mostly_ correct. Given its a temporary measure, I think we can live with a few deviations.
