### PR TITLE
Separate next steps

### DIFF
--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -31,7 +31,10 @@
   <ul>
     <li>
       Ask for an <a href="#internal_review">internal review</a> at the public
-      authority. If that doesn't help, you can refer the request to the
+      authority.
+    </li>
+    <li>
+      If that doesn't help, you can refer the request to the
       <a href="#refer-to-ico">Information Commissioner</a>.
     </li>
     <li>


### PR DESCRIPTION
Make it clear that an internal review and a referral to the ICO or
separate steps.