### PR TITLE
Add H&F In Touch email as an invalid reply address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -10,6 +10,7 @@ Rails.configuration.to_prepare do
       FOIResponses@homeoffice.gsi.gov.uk
       FOIResponses@homeoffice.gov.uk
       autoresponder@sevenoaks.gov.uk
+      H&FInTouch@lbhf.gov.uk
     )
 
     User.class_eval do


### PR DESCRIPTION
Adds `H&FInTouch@lbhf.gov.uk` to the list of invalid reply addresses. This should prevent replies etc being sent to it which bounce (see mysociety/alaveteli#3465)

We've had a few of these for this email address, hopefully this will be a workaround to prevent problems for users.