### PR TITLE
Fix broken outbound links

### DIFF
--- a/lib/views/followups/_followup.html.erb
+++ b/lib/views/followups/_followup.html.erb
@@ -50,7 +50,7 @@
         <%= _('If you are dissatisfied by the response you got from the ' \
               'public authority, you have the right to complain ' \
               '(<a href="{{url}}">details</a>).',
-              url: "http://foiwiki.com/foiwiki/index.php/Internal_reviews".html_safe) %>
+              url: "https://www.whatdotheyknow.com/help/unhappy#refer-to-ico".html_safe) %>
       </p>
     <% end %>
 

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -151,8 +151,8 @@
   <p>
     The ICO requests that serious breaches of data protection are reported to
     them; their guidance on what constitutes serious is at: <a
-    href="https://ico.org.uk/media/for-organisations/documents/1536/breach_reporting.pdf">
-    https://ico.org.uk/media/for-organisations/documents/1536/breach_reporting.pdf</a>.
+    href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/">
+    https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/</a>.
   </p>
   <p>
     <strong>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -100,8 +100,8 @@
         </li>
         <li>
           The Information Commissioner’s
-          <a href="http://www.ico.org.uk/for_organisations/freedom_of_information/guide/receiving_a_request">
-          Hints for Practitioners</a> say <i>“A
+          <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#1">
+          guidance for organisations</a> says <i>“A
           request must ... include an address for correspondence. This need not
           be the person’s residential or work address - it can be <strong>any
           address at which you can write to them</strong>, including a postal

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -396,8 +396,7 @@
     </li>
   </ul>
   <p>
-    Historically, some public authorities used mySociety’s <a
-    href="https://github.com/mysociety/foi-register">FOI Register</a>
+    Historically, some public authorities used mySociety’s FOI Register
     software (which has since been discontinued) in order to use
     WhatDoTheyKnow as a disclosure log for all their FOI activity. When
     people made requests to the authority their names were usually withheld

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -201,8 +201,8 @@
       </em>
     </li>
     <li>
-     The Information Commissioner’s <a href="http://www.ico.org.uk/for_organisations/freedom_of_information/guide/receiving_a_request">
-      Hints for Practitioners</a> say <em>“A request must ...
+     The Information Commissioner’s <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#1">
+      guidance for organisations</a> says <em>“A request must ...
       include an address for correspondence. This need not be the person’s
       residential or work address - it can be <strong>any address at which
       you can write to them</strong>, including a postal address or

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -90,7 +90,7 @@
   If you are still unhappy after the public authority has done their internal
   review, then you can refer your request to the Information Commissioner, who
   is empowered to uphold access to information laws. To make a referral,
-  start by reading <a href="https://ico.org.uk/concerns/getting/">the
+  start by reading <a href="https://ico.org.uk/make-a-complaint/official-information-concerns-report/">the
   Information Commissioner's advice for those with concerns about accessing
   information</a> which links to their form. If you requested information from a
   Scottish authority, then it is


### PR DESCRIPTION
A number of outbound links across the WhatDoTheyKnow help pages have become broken. This PR replaces all broken links identified this evening with suitable replacements. In one instance (FOI Register) I've removed the link as I cannot find a suitable replacement.

Fixes #628 
Fixes #635 