### PR TITLE
[#698] Add new tags to _more_info.html.erb to allow users to search DfE

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -38,6 +38,20 @@
   <% end %>
 <% end %>
 
+<% if public_body.has_tag?('urn') %>
+  <% public_body.get_tag_values('urn').each do |tag_value| %>
+      <%= link_to _('Establishment information'),
+                    "http://get-information-schools.service.gov.uk/Establishments/Establishment/Details/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
+<% if public_body.has_tag?('matuid') %>
+  <% public_body.get_tag_values('matuid').each do |tag_value| %>
+      <%= link_to _('Establishment group information'),
+                    "https://get-information-schools.service.gov.uk/Groups/Group/Details/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <%= link_to _('View FOI email address'), view_public_body_email_path(public_body.url_name) %><br>
 
 <%= link_to _("Ask us to update FOI email"), new_change_request_body_path(:body => public_body.url_name) %><br>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -52,6 +52,13 @@
   <% end %>
 <% end %>
 
+<% if public_body.has_tag?('spuid') %>
+  <% public_body.get_tag_values('spuid').each do |tag_value| %>
+      <%= link_to _('Establishment group information (sponsor)'),
+                    "https://get-information-schools.service.gov.uk/Groups/Group/Details/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <%= link_to _('View FOI email address'), view_public_body_email_path(public_body.url_name) %><br>
 
 <%= link_to _("Ask us to update FOI email"), new_change_request_body_path(:body => public_body.url_name) %><br>


### PR DESCRIPTION
# What does this do?
This PR adds three new tags ('urn', 'spuid', and 'matuid') to _more_info.html.erb, which allow referencing of the DfE's  "Get Information about Schools" website.

### Notes to reviewer

These additions should add a new entry to the respective public body pages under "More about this authority" where the tag 'urn', 'spuid', or 'matuid' appears in the body tags;

Example bodies:
[Canterbury College](https://www.whatdotheyknow.com/body/canterbury_college)
**Tags**: `dpr:Z7597166 fei urn:130730`
The 'dpr' tag should resolve to: https://ico.org.uk/ESDWebPages/Entry/Z7597166
The 'urn' tag should resolve to: http://get-information-schools.service.gov.uk/Establishments/Establishment/Details/130730

[Holyport College](https://www.whatdotheyknow.com/body/holyport_college)
**Tags**: `ch:07930340 dpr:ZA046885 free_school school urn:139971`
The 'ch' tag should resolve to: https://beta.companieshouse.gov.uk/company/07930340
The 'dpr' tag should resolve to: https://ico.org.uk/ESDWebPages/Entry/ZA046885
The 'urn' tag should resolve to: http://get-information-schools.service.gov.uk/Establishments/Establishment/Details/139971

[Ormiston Academies Trust](https://www.whatdotheyknow.com/body/ormiston_academies_trust)
**Tags**: `academy_trust ch:06982127 dpr:ZA006743 matuid:4106 spuid:4105`

The 'ch' tag should resolve to: https://beta.companieshouse.gov.uk/company/06982127
The 'dpr' tag should resolve to: https://ico.org.uk/ESDWebPages/Entry/ZA006743
The 'matuid' tag should resolve to: https://get-information-schools.service.gov.uk/Groups/Group/Details/4106
The 'spuid' tag should resolve to: https://get-information-schools.service.gov.uk/Groups/Group/Details/4105

_why two similar entries?_ The DfE lists sponsors in their own right and although some bodies are both an 'academy trust' and a 'sponsor' the data between the two does not always cross over. We could, if necessary, truncate this to one tag and duplicate - albeit, this may look a little unwieldy when users view a body page.

Fixes #698 