### PR TITLE
Added reference to data sharing policy

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -288,9 +288,10 @@
     register of researchers who have access to the datasets. Data passed to
     third parties will never exceed what is publically available on the website.
   </p>
+
   <p>
-    When it is complete, our Research Data Release policy will be available  on
-    request.
+    Our Research Data Release policy can be viewed
+    <a href="https://docs.google.com/document/d/1ytnM2U3fjMgri49YizFDt_9A-2uQmcF4qnGgFDMJpk0/edit#">here</a>.
   </p>
 
   <h3 id="encrypted_transfer">


### PR DESCRIPTION
Removed reference to upcoming policy, added link to policy.

Policy: https://docs.google.com/document/d/1ytnM2U3fjMgri49YizFDt_9A-2uQmcF4qnGgFDMJpk0/edit#

Addresses #685 