### PR TITLE
Improve adding custom inclusion validation options

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -200,5 +200,10 @@ Rails.configuration.to_prepare do
   #
   #    validates_inclusion_of :alert_type, :in => alert_types
   #
-  UserInfoRequestSentAlert._validate_callbacks.first.filter.options[:in] << 'survey_1'
+  callback = UserInfoRequestSentAlert._validate_callbacks.find do |callback|
+    filter = callback.filter
+    filter.is_a?(ActiveModel::Validations::InclusionValidator) &&
+      filter.attributes.include?(:alert_type)
+  end
+  callback.filter.options[:in] << 'survey_1'
 end


### PR DESCRIPTION
We were relying on Rails to not change the order of validation callbacks
but in Rails 6 this has now changed. Now we find the relevant callback
using class and attribute before updating its options.