### PR TITLE
Fix footer link "Run by volunteers"

### DIFF
--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -5,7 +5,7 @@
             <h2 class="mysoc-footer__site-name"><%= site_name %></h2>
             <div class="mysoc-footer__site-description">
                 <p>A site to help anyone submit a Freedom of Information request. WhatDoTheyKnow also publishes and archives requests and responses, building a massive archive of information.</p>
-                <p><%= link_to 'Run by Volunteers', help_credits_path(:anchor => 'helpus') %> and powered by <%= link_to 'Alaveteli',  help_alaveteli_path %>.</p>
+                <p><%= link_to 'Run by Volunteers', help_credits_path(:anchor => 'volunteers') %> and powered by <%= link_to 'Alaveteli',  help_alaveteli_path %>.</p>
                 <p>Dedicated to <%= link_to 'Chris Lightfoot', "http://mk.ucant.org/archives/000129.html" %>.</p>
             </div>
         </div>


### PR DESCRIPTION
Linking to "Want to help?" section was confusing, it is much clearer to link to the "Volunteers" section, and credits them properly.

I think it used to say "Run by volunteers... and you!" and the "and you!" linked to "Want to help?". I'm guessing it got stuck with that value while being updated.