### PR TITLE
Add version history to privacy policy (notice)

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -902,6 +902,13 @@
     <a href="https://www.mysociety.org/privacy/?utm_source=whatdotheyknow.com&utm_medium=link">More general information on
     how third party services work</a>
   </p>
+  <h2 id="changes-to-privacy-notice">
+    Changes to our privacy policy
+    <a href="#changes-to-privacy-notice">#</a>
+  </h2>
+  <p>
+  	We keep our privacy policy under review, and may make changes from time to time to ensure that it remains up-to-date and accurate. You can find a synopsis of changes we've made at our <a href="https://github.com/mysociety/whatdotheyknow-theme/commits/master/lib/views/help/privacy.html.erb" alt="Link to version history for WhatDoTheyKnow Privacy notice (hosted on Github)">Github repository</a>, but if you have any questions, please do <a href="/help/contact">contact us</a>.
+  </p> 
   <p><strong>Credits</strong></p>
   <p>
     Bits of wording taken from the <a href="http://gov.uk/help/cookies">


### PR DESCRIPTION
Fixes #700 by providing a link to version history on WDTK Github repository.

Wording loosely based on the ICO's own privacy notice.