### PR TITLE
Add new invalid addresses to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -13,6 +13,9 @@ Rails.configuration.to_prepare do
       H&FInTouch@lbhf.gov.uk
       tfl@servicetick.com
       cap-donotreply@worcestershire.gov.uk
+      NEW_FOISA@dundeecity.gov.uk
+      noreply@slc.co.uk
+      DoNotReply@dhsc.gov.uk
     )
 
     User.class_eval do


### PR DESCRIPTION
## Relevant issue(s)

N/A - Issue not raised. Support mailbox correspondence.

## What does this do?

Adds invalid addresses for Dundee City Council, Student Loans Company, and the Department of Health and Social Care to ReplyToAddressValidator.invalid_reply_addresses

## Why was this needed?

This will hopefully help our users by preventing them replying to emails that do not accept replies.

## Implementation notes

N/A

## Screenshots

N/A

## Notes to reviewer

N/A