### PR TITLE
Add redirects to wdtk-routes.rb for Northern Ireland, Scotland, and Wales

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   get '/scotland' => redirect('/body?tag=scotland', status: 302)
   get '/cymru' => redirect('/body?tag=wales', status: 302)
   get '/wales' => redirect('/body?tag=wales', status: 302)
+  get '/ni' => redirect('/body?tag=ni', status: 302)
+  get '/northernireland' => redirect('/body?tag=ni', status: 302)
 
   # Add a route for the survey
   scope '/profile/survey' do

--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   get '/london' => redirect('/body?tag=london', status: 302)
   get '/scotland' => redirect('/body?tag=scotland', status: 302)
-  get '/cymru' => redirect('/body?tag=wales', status: 302)
+  get '/cymru' => redirect('/cy/body?tag=wales', status: 302)
   get '/wales' => redirect('/body?tag=wales', status: 302)
   get '/ni' => redirect('/body?tag=ni', status: 302)
   get '/northernireland' => redirect('/body?tag=ni', status: 302)

--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -2,6 +2,9 @@
 
 Rails.application.routes.draw do
   get '/london' => redirect('/body?tag=london', status: 302)
+  get '/scotland' => redirect('/body?tag=scotland', status: 302)
+  get '/cymru' => redirect('/body?tag=wales', status: 302)
+  get '/wales' => redirect('/body?tag=wales', status: 302)
 
   # Add a route for the survey
   scope '/profile/survey' do

--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/cymru' => redirect('/cy/body?tag=wales', status: 302)
   get '/wales' => redirect('/body?tag=wales', status: 302)
   get '/ni' => redirect('/body?tag=ni', status: 302)
-  get '/northernireland' => redirect('/body?tag=ni', status: 302)
+  get '/northern-ireland' => redirect('/body?tag=ni', status: 302)
 
   # Add a route for the survey
   scope '/profile/survey' do


### PR DESCRIPTION
## Relevant issue(s)
#715, #716, #717 

## What does this do?

Based on existing code, this adds a redirect for whatdotheyknow.com/cymru, whatdotheyknow.com/scotland, and whatdotheyknow.com/wales to the appropriate tagged locations (e.g. /body?tag=wales, /body?tag=scotland).

## Why was this needed?
This is needed to ensure feature parity between key locales and to allow our users to easily find public bodies in Northern Ireland, Scotland, and Wales.

This builds on and complements the work done in #416 for /london, and gives us a good starting base to improve on our grouping of bodies.

## Implementation notes
There is nothing specific to note here, this is based on existing code.

## Screenshots
n/a

## Notes to reviewer

This is based on existing code from #417 which was used for the /london redirect.