### PR TITLE
Add two new Home Office addresses to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -16,6 +16,8 @@ Rails.configuration.to_prepare do
       NEW_FOISA@dundeecity.gov.uk
       noreply@slc.co.uk
       DoNotReply@dhsc.gov.uk
+      OSCTFOI@homeoffice.gov.uk
+      SOCGroup_Correspondence@homeoffice.gov.uk
     )
 
     User.class_eval do


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
This patch adds two new no-reply addresses to model_patches.rb.

## Why was this needed?
Two directorates at the Home Office are issuing responses (such as [691163](https://www.whatdotheyknow.com/request/reporting_of_reportable_poisons#incoming-1651063), and [689448](https://www.whatdotheyknow.com/request/home_office_financial_contributi#incoming-1642692)) from mailboxes that do not accept responses.

This patch complements our existing solution for problematic mailboxes at the Home Office and improves user experience by ensuring we aren't routing responses into an apparent ether.

## Implementation notes
As per previous patches, this is a direct addition to existing code - there are no specific implementation notes.

## Screenshots
N/A

## Notes to reviewer

N/A - happy days 😊