### PR TITLE
Add home office email to public_body_questions.rb

### DIFF
--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -14,11 +14,17 @@ Rails.configuration.to_prepare do
         you get a response. This has the benefit of highlighting difficulties
         communicating with the Home Office to MPs.
       </p>
+      <p>
+      You could also try contacting the Home Office by email at: <a
+      href="mailto:public.enquiries@homeoffice.gov.uk">public.enquiries@
+      homeoffice.gov.uk</a>.
+      </p>
 
       <p>
-        Misusing our service, which makes all correspondence public, won't help
-        you pursue your individual case as the Home Office will not enter into
-        correspondence about individual cases via our service.
+        Misusing our service, <strong>which makes all correspondence
+        public</strong>,won't help you pursue your individual case as the Home
+        Office will not enter into correspondence about individual cases via our
+        service.
       </p>
     HTML
   )


### PR DESCRIPTION
## Relevant issue(s)
#722 

## What does this do?
This patch adds the  Home Office public enquiries email to 'home_office_deny_response' within public_body_questions.rb

## Why was this needed?
When we present users with the refusal prompt contained in 'home_office_deny_response' we don't provide them with an explicit 'out', e.g. we don't tell them how to contact the public body themselves. This is perhaps leading to users bypassing this option and choosing to continue using WDTK for requests concerning their own circumstances (BRP / Visa / Entitlements etc).

## Implementation notes
Nothing specific - this adds to existing code.

## Screenshots
N/A

## Notes to reviewer

This is an interim hack - it does two things, it adds `<strong>` tags to the phrase "which makes all correspondence public" and adds a paragraph containing the Home Office public enquiries email.

I did ponder providing a link to the relevant section on the [HO website](https://www.gov.uk/government/organisations/home-office#org-contacts), but opted for this as a simpler signpost.