### PR TITLE
Add Dundee and Aberdeen City to model_patchees.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -156,6 +156,8 @@ Rails.configuration.to_prepare do
     SOCGroup_Correspondence@homeoffice.gov.uk
     FOI-E&E@Oxfordshire.gov.uk
     no-reply@bch.ecase.gsi.gov.uk
+    new_foisa@dundeecity.gov.uk
+    noreply@aberdeencity.gov.uk
   )
 
   # Add survey methods to RequestMailer


### PR DESCRIPTION
## Relevant issue(s)
Fixes #730 

## What does this do?
This patch adds new no-reply addresses for both Aberdeen City and Dundee City Council to model_patches.rb

## Why was this needed?
Correspondence being issued from public bodies from 'no-reply' email addresses which our users were unable to respond to.

## Implementation notes
N/A

## Screenshots
N/A

## Notes to reviewer
Another minor change to our long-standing code, there are no specific notes. 🎉 