### PR TITLE
Update links to charity/company databases in _more_info.html.erb

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -19,7 +19,7 @@
                     "https://www.oscr.org.uk/about-charities/search-the-register/charity-details?number=#{ tag_value }" %><br>
     <% else %>
       <%= link_to _('Charity registration'),
-                    "http://beta.charitycommission.gov.uk/charity-details/?regid=#{ tag_value }&subid=0" %><br>
+                    "https://register-of-charities.charitycommission.gov.uk/charity-search/-/results/page/1/delta/20/keywords/#{ tag_value }" %><br>
     <% end %>
   <% end %>
 <% end %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -27,7 +27,7 @@
 <% if public_body.has_tag?('ch') %>
   <% public_body.get_tag_values('ch').each do |tag_value| %>
       <%= link_to _('Company registration'),
-                    "https://beta.companieshouse.gov.uk/company/#{ tag_value }" %><br>
+                    "https://find-and-update.company-information.service.gov.uk/company/#{ tag_value }" %><br>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #711 

## What does this do?
This patch updates the URLs that we use for Charity Commission and Companies House databases in the _more_info.html.erb sidebar.

The URL format for Companies House is a straight find-and-replace of the domain name, replacing `beta.companieshouse.gov.uk` with `find-and-update.company-information.service.gov.uk`.

The URL for the Charities Commission is a more significant change - replacing the domain name and parameters.

## Why was this needed?
Both databases have moved from beta to production, and as such, the domain name and URL format have changed. This is more problematic for the Charity Commission as links from the old production and beta systems do not degrade gracefully.

## Implementation notes
This is an update to existing code - there are no specific tests that need to be conducted; however, to ensure that the correct charity link is being rendered, it may be helpful to check a few bodies.

To test the charity commission database:

1. Select the public body page for an appropriate [charity](https://www.whatdotheyknow.com/body?tag=charity), for example [Dudley and West Midlands Zoological Society Limited](https://www.whatdotheyknow.com/body/dudley_zoo) (an English charity), [North Ayrshirie Leisure Limited](https://www.whatdotheyknow.com/body/ka_leisure) (Scotland).
2. Ensure that the 'Charity Registration' link is being rendered in the sidebar
3. Check that the correct link is being registered. For charities with a registration number starting 'SC' this should be a link to OSCR; otherwise, it should be a link to the Charity Commission.

## Screenshots
N/A

## Notes to reviewer
N/A