### PR TITLE
Add address for WCC to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -156,6 +156,7 @@ Rails.configuration.to_prepare do
     SOCGroup_Correspondence@homeoffice.gov.uk
     FOI-E&E@Oxfordshire.gov.uk
     no-reply@bch.ecase.gsi.gov.uk
+    NoReply.FOI@worcester.gov.uk
   )
 
   # Add survey methods to RequestMailer


### PR DESCRIPTION
## Relevant issue(s)
Fixes #733 

## What does this do?
This patch adds a new no-reply addresses for Worcester City Council to model_patches.rb

## Why was this needed?
Correspondence being issued from public bodies from 'no-reply' email addresses which our users were unable to respond to.

## Implementation notes
N/A

## Screenshots
N/A

## Notes to reviewer
This can be merged at the same time as #731 - I've kept it as a separate PR given the time that has passed between the two.