### PR TITLE
Add Castle Point BC invalid reply address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -156,6 +156,7 @@ Rails.configuration.to_prepare do
     SOCGroup_Correspondence@homeoffice.gov.uk
     FOI-E&E@Oxfordshire.gov.uk
     no-reply@bch.ecase.gsi.gov.uk
+    auto-reply@castlepoint.gov.uk
   )
 
   # Add survey methods to RequestMailer


### PR DESCRIPTION
## Relevant issue(s)
N/A - No issue raised for this one.

## What does this do?
This patch adds a new no-reply addresses for Castle Point Borough Council to model_patches.rb

## Why was this needed?
Correspondence being issued from public bodies from 'no-reply' email addresses which our users were unable to respond to. This particular address was located on the thread at https://www.whatdotheyknow.com/request/fraud_investigation_61 to Castle Point Borough Council.

## Implementation notes
N/A

## Screenshots
N/A

## Notes to reviewer
N/A

