### PR TITLE
[#735] Expand House Rule on others' personal information

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -67,7 +67,9 @@
       here</a>.
     </li>
     <li>
-      Do not post other people’s sensitive personal data to the site.
+      Do not use our service to request other people's personal information and 
+      do not include such information in requests, annotations or follow-ups, 
+      unless it is fair to do so.
     </li>
     <li>
       Do not seek to evade the actions of site administrators by, for example,


### PR DESCRIPTION
## Relevant issue(s)

Fixes #735 

## What does this do?
This PR expands on the bullet point surrounding others' personal information on the WhatDoTheyKnow.com House Rules.
 
## Why was this needed?
Currently the House Rules state:

- Do not post other people’s sensitive personal data to the site.
- Do not use WhatDoTheyKnow to request your personal information from authorities. [...]

Neither of these closely correspond to the situation where a requester makes an inappropriate request asking for another person's personal information, which will almost certainly be rejected.

The situation isn't clear cut as sometimes it is fair and reasonable to request, and receive, others' personal data eg. expenses/allowances for senior public officials.

## Implementation notes
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/47503358/100786496-292c0480-340a-11eb-92aa-cce30d65ae3b.png)


## Notes to reviewer
N/A


