### PR TITLE
Configure refusal references

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -46,6 +46,13 @@ Rails.configuration.to_prepare do
     end
   end
 
+  Legislation.refusals = {
+    foi: ['s 11', 's 12', 's 14', 's 21', 's 22', 's 22A', 's 23', 's 24',
+          's 26', 's 27', 's 28', 's 29', 's 30', 's 31', 's 32', 's 33',
+          's 34', 's 35', 's 36', 's 37', 's 38', 's 39', 's 40', 's 41',
+          's 42', 's 43', 's 44']
+  }
+
   PublicBody.class_eval do
     # Return the domain part of an email address, canonicalised and with common
     # extra UK Government server name parts removed.


### PR DESCRIPTION
Requires https://github.com/mysociety/alaveteli/pull/6015.

Adds refusals/exemptions from the Freedom of Information Act 2000 [1].

Fixes https://github.com/mysociety/alaveteli/issues/6002.

[1] https://foiwiki.com/foiwiki/index.php/Freedom_of_Information_Act_2000