### PR TITLE
Add redirect to wdtk-routes.rb for England

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -1,6 +1,7 @@
 # Here you can override or add to the pages in the core website
 
 Rails.application.routes.draw do
+  get '/england' => redirect('/body?tag=england', status: 302)
   get '/london' => redirect('/body?tag=london', status: 302)
   get '/scotland' => redirect('/body?tag=scotland', status: 302)
   get '/cymru' => redirect('/cy/body?tag=wales', status: 302)


### PR DESCRIPTION
## Relevant issue(s)
#747 

## What does this do?
This patch adds a redirect for /england to wdtk-routes.rb

## Why was this needed?
To ensure feature parity between other national pages for WDTK users in the UK - we hadn't added an explicit entry for /england in previous work that had been implemented. We tag over 700 bodies with the specific tag of "england", therefore this functionality might be helpful for our users.

## Implementation notes
There is no specific implementation notes.

## Screenshots
N/A

## Notes to reviewer
This code is based on #417 and recent updates.