### PR TITLE
Fix minor typos in how.html.erb

### DIFF
--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -67,7 +67,7 @@
   <p>
     These policies are not set in stone. New and unforeseen circumstances occur
     frequently, and while our body of policy and practice helps guide decisions,
-    any WDTK volunteer or mySociety staff member/trustee involved is free to
+    any WhatDoTheyKnow volunteer or mySociety staff member/trustee involved is free to
     suggest that the right thing to do in a specific case is to make an
     exception and/or establish a new policy.
   </p>
@@ -342,7 +342,7 @@
       User accounts
   </h2>
   <p>
-    If you sign up for an account on WhatDotheyKnow, a profile listing any
+    If you sign up for an account on WhatDoTheyKnow, a profile listing any
     requests and annotations you have made will be publicly accessible.
   </p>
   <p>

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -293,7 +293,7 @@
   <ul>
     <li>
       The admin team act to re-send requests/messages when we spot failed
-      delivery within a reasonable period of a user submitting the
+      delivery within a reasonable period of a user submitting the request.
     </li>
     <li>
       A public body or the requestor may ask us to resend a specific message and


### PR DESCRIPTION
## Relevant issue(s)
None logged.

## What does this do?
Fixes some minor typos in how.html.erb and removes an undefined acronym.

## Why was this needed?
To correct some typos, and remove a potentially unclear acronym for ease of clarity.

## Implementation notes
A very minor update to existing code - there is no functional changes so this is a straight merge.

## Screenshots
N/A

## Notes to reviewer
N/A - happy days 🥳