### PR TITLE
[#751] Fix apostrophe tags in help pages

### DIFF
--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -51,7 +51,7 @@
     </ul>
     <% unless is_contact_page? %>
     <h2 id="contact">Contact us</h2>
-    <p>If your question isn't answered here, or you just wanted to let us know
+    <p>If your question isn’t answered here, or you just wanted to let us know
       something about the site, <a href="<%= help_contact_path %>">contact&nbsp;us</a>.
     </p>
     <% end %>

--- a/lib/views/help/about.cy.html.erb
+++ b/lib/views/help/about.cy.html.erb
@@ -7,31 +7,31 @@
     Beth yw diben WhatDoTheyKnow? <a href="#purpose">#</a>
     </dt>
     <dd>
-    Mae i'ch helpu i ddarganfod gwybodaeth fewnol am yr hyn y mae llywodraeth y DU yn ei wneud.
+    Mae i’ch helpu i ddarganfod gwybodaeth fewnol am yr hyn y mae llywodraeth y DU yn ei wneud.
     </dd>
     <dt id="premise">
-    Sut mae'r wefan yn gweithio? <a href="#premise">#</a>
+    Sut mae’r wefan yn gweithio? <a href="#premise">#</a>
     </dt>
     <dd>
-    Rydych chi'n dewis yr awdurdod cyhoeddus yr hoffech wybodaeth oddi wrtho, yna'n ysgrifennu nodyn byr yn disgrifio yr hyn yr ydych am ei wybod. Yna byddwn yn anfon eich cais at yr awdurdod cyhoeddus. Caiff unrhyw ymateb ganddynt ei gyhoeddi yn awtomatig ar y wefan i chi ac unrhyw un arall i ddod o hyd iddo a'i ddarllen.
+    Rydych chi’n dewis yr awdurdod cyhoeddus yr hoffech wybodaeth oddi wrtho, yna’n ysgrifennu nodyn byr yn disgrifio yr hyn yr ydych am ei wybod. Yna byddwn yn anfon eich cais at yr awdurdod cyhoeddus. Caiff unrhyw ymateb ganddynt ei gyhoeddi yn awtomatig ar y wefan i chi ac unrhyw un arall i ddod o hyd iddo a’i ddarllen.
     </dd>
     <dt id="whybother_me">
-    Pam fyddwn i'n trafferthu i wneud hyn? <a href="#whybother_me">#</a>
+    Pam fyddwn i’n trafferthu i wneud hyn? <a href="#whybother_me">#</a>
     </dt>
     <dd>
-    Rydych chi'n talu trethi, a'r llywodraeth wedyn yn gwneud pethau gyda'r arian. Pob math o bethau sy'n effeithio ar eich bywyd, o ofal iechyd drwodd iat amddiffyn. Mae'n gwneud rhai pethau'n wael, rhai yn dda. Po fwyaf rydym yn dysgu am sut mae llywodraeth yn gweithio, po orau y gallwn wneud awgrymiadau i wella'r pethau a wneir yn wael,  ac i ddathlu'r pethau mae'n yn ei wneud yn dda.
+    Rydych chi’n talu trethi, a’r llywodraeth wedyn yn gwneud pethau gyda’r arian. Pob math o bethau sy’n effeithio ar eich bywyd, o ofal iechyd drwodd iat amddiffyn. Mae’n gwneud rhai pethau’n wael, rhai yn dda. Po fwyaf rydym yn dysgu am sut mae llywodraeth yn gweithio, po orau y gallwn wneud awgrymiadau i wella’r pethau a wneir yn wael,  ac i ddathlu’r pethau mae’n yn ei wneud yn dda.
     </dd>
     <dt id="whybother_them">
-    Pam fyddai'r awdurdod cyhoeddus yn trafferthu i ymateb? <a href="#whybother_them">#</a>
+    Pam fyddai’r awdurdod cyhoeddus yn trafferthu i ymateb? <a href="#whybother_them">#</a>
     </dt>
     <dd>
-    O dan gyfraith Rhyddid Gwybodaeth (FOI), mae'n rhaid iddynt ymateb. Bydd yr ymateb naill ai'n cynnwys y wybodaeth yr ydych ei heisiau, neu'n rhoi rheswm cyfreithiol dilys pam mae'n rhaid iddo gael ei gadw'n gyfrinachol.
+    O dan gyfraith Rhyddid Gwybodaeth (FOI), mae’n rhaid iddynt ymateb. Bydd yr ymateb naill ai’n cynnwys y wybodaeth yr ydych ei heisiau, neu’n rhoi rheswm cyfreithiol dilys pam mae’n rhaid iddo gael ei gadw’n gyfrinachol.
     </dd>
     <dt id="who">
-    Pwy sy'n gwneud WhatDoTheyKnow? <a href="#who">#</a>
+    Pwy sy’n gwneud WhatDoTheyKnow? <a href="#who">#</a>
     </dt>
     <dd>
-    Cafodd WhatDoTheyKnow ei greu gan <a href="http://www.mysociety.org/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a> ac mae'n cael ei gynnal ganddi. Ar y dechrau cafodd <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/?utm_source=whatdotheyknow.com&utm_medium=link">ei ariannu gan Ymddiriedolaeth Elusennol JRSST</a>. Mae mySociety yn brosiect yr elusen gofrestredig <a href="https://www.mysociety.org/about/structure-and-governance/?utm_source=whatdotheyknow.com&utm_medium=link">Democratiaeth Dinasyddion Ar-lein y DG</a>. Os ydych yn hoffi'r hyn rydym yn ei wneud, yna gallwch <a href="<%= donation_url %>">roi rhodd</a>.
+    Cafodd WhatDoTheyKnow ei greu gan <a href="http://www.mysociety.org/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a> ac mae’n cael ei gynnal ganddi. Ar y dechrau cafodd <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/?utm_source=whatdotheyknow.com&utm_medium=link">ei ariannu gan Ymddiriedolaeth Elusennol JRSST</a>. Mae mySociety yn brosiect yr elusen gofrestredig <a href="https://www.mysociety.org/about/structure-and-governance/?utm_source=whatdotheyknow.com&utm_medium=link">Democratiaeth Dinasyddion Ar-lein y DG</a>. Os ydych yn hoffi’r hyn rydym yn ei wneud, yna gallwch <a href="<%= donation_url %>">roi rhodd</a>.
     </dd>
     <dt id="updates">
     Sut y gallaf gadw i fyny gyda newyddion am WhatDoTheyKnow?<a href="#updates">#</a>

--- a/lib/views/help/contact.cy.html.erb
+++ b/lib/views/help/contact.cy.html.erb
@@ -12,7 +12,7 @@
 <li> Yn gofyn am wybodaeth breifat amdanoch chi eich hun? Darllenwch ein tudalen gymorth am <a href="<%= help_requesting_path(:anchor => 'data_protection') %>">ddiogelu data</a> . </li>
 </ul>
 
-<h1>Codi mater gyda'r Llywodraeth</h1>
+<h1>Codi mater gyda’r Llywodraeth</h1>
 
 <ul>
 <li><a href="http://www.writetothem.com">Ysgrifennwch at eich AS, cynghorydd lleol neu gynrychiolydd arall</a></li> .
@@ -26,9 +26,9 @@
     <% if !flash[:notice] %>
 <ul>
 <li> Darllenwch y <a href="<%= help_about_path %>">dudalen gymorth</a> yn gyntaf, gan y gallai ateb eich cwestiwn yn gyflymach. </li>
-<li>Byddem wrth ein bodd cael clywed sut brofiad gawsoch wrth ddefnyddio'r wefan hon. Naill ai llenwch y ffurflen hon,
+<li>Byddem wrth ein bodd cael clywed sut brofiad gawsoch wrth ddefnyddio’r wefan hon. Naill ai llenwch y ffurflen hon,
 neu anfonwch e-bost at <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a></li>
-<li>Rydym yn <strong>elusen</strong> ac nid yn rhan o'r Llywodraeth.</li> </ul>
+<li>Rydym yn <strong>elusen</strong> ac nid yn rhan o’r Llywodraeth.</li> </ul>
 </ul>
     <% end %>
 </div>
@@ -54,12 +54,12 @@ neu anfonwch e-bost at <a href="mailto:<%=@contact_email%>"><%=@contact_email%><
     </p>
 
     <p>
-        <label class="form_label" for="contact_message">Neges i'r wefan:</label>
+        <label class="form_label" for="contact_message">Neges i’r wefan:</label>
         <%= f.text_area :message, :rows => 10, :cols => 60 %>
     </p>
 
     <p style="display:none;">
-        <%= f.label :comment, "Peidiwch â llenwi'r yn y maes hwn" %>
+        <%= f.label :comment, "Peidiwch â llenwi’r yn y maes hwn" %>
         <%= f.text_field :comment %>
     </p>
 
@@ -79,13 +79,13 @@ neu anfonwch e-bost at <a href="mailto:<%=@contact_email%>"><%=@contact_email%><
     <% end %>
 
     <p class="form_note">
-    Dim ond gyda <strong>phroblemau technegol</strong> y gallwn eich helpu, neu gyda chwestiynau am Ryddid Gwybodaeth. Gweler ben y dudalen hon os hoffech gysylltu â'r Llywodraeth. </p>
+    Dim ond gyda <strong>phroblemau technegol</strong> y gallwn eich helpu, neu gyda chwestiynau am Ryddid Gwybodaeth. Gweler ben y dudalen hon os hoffech gysylltu â’r Llywodraeth. </p>
 
 
     <div class="form_button">
         <%= hidden_field_tag(:submitted_contact_form, 1) %>
-        <%= submit_tag "Anfonwch neges i'r elusen", :data => { :disable_with => "Anfon..." } %>
-        &lt;- Ni sy'n cynnal y wefan hon, nid y Llywodraeth!
+        <%= submit_tag "Anfonwch neges i’r elusen", :data => { :disable_with => "Anfon..." } %>
+        &lt;- Ni sy’n cynnal y wefan hon, nid y Llywodraeth!
     </div>
 
 <% end %>

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -111,7 +111,7 @@
       </p>
       <p>
         Many of <a href="https://www.mysociety.org/about/team/?utm_source=whatdotheyknow.com&utm_medium=link">
-        mySociety's staff</a>, past and present, have contributed to the site's
+        mySociety’s staff</a>, past and present, have contributed to the site’s
         success.
       </p>
       <p>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -67,7 +67,7 @@
       here</a>.
     </li>
     <li>
-      Do not use our service to request other people's personal information and 
+      Do not use our service to request other people’s personal information and 
       do not include such information in requests, annotations or follow-ups, 
       unless it is fair to do so.
     </li>

--- a/lib/views/help/officers.cy.html.erb
+++ b/lib/views/help/officers.cy.html.erb
@@ -1,20 +1,20 @@
-﻿<% @title = "Cwestiynau Swyddog Rhyddid Gwybodaeth" %>
+﻿﻿<% @title = "Cwestiynau Swyddog Rhyddid Gwybodaeth" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
   <h1 id="officers"><%= @title %> <a href="#officers">#</a></h1>
   <dl>
     <dt id="top">
-    Rwyf newydd gyrraedd yma o waelod cais RhG, beth sy'n digwydd? <a href="#top">#</a>
+    Rwyf newydd gyrraedd yma o waelod cais RhG, beth sy’n digwydd? <a href="#top">#</a>
     </dt>
     <dd>
     <p>
-      Mae WhatDoTheyKnow yn wasanaeth sy'n cael ei rhedeg gan elusen. Mae'n helpu aelodau cyffredin o'r cyhoedd wneud ceisiadau Rhyddid Gwybodaeth, ac yn ei wneud yn hawdd iddynt olrhain a rhannu'r ymatebion.
+      Mae WhatDoTheyKnow yn wasanaeth sy’n cael ei rhedeg gan elusen. Mae’n helpu aelodau cyffredin o’r cyhoedd wneud ceisiadau Rhyddid Gwybodaeth, ac yn ei wneud yn hawdd iddynt olrhain a rhannu’r ymatebion.
     </p>
     <p>
-      Fe wnaed y cais Rhyddid Gwybodaeth a gawsoch gan rywun sy'n defnyddio WhatDoTheyKnow. Gallwch ateb y cais fel y byddech yn ateb unrhyw gais arall gan unigolyn. Yr unig wahaniaeth yw y bydd eich ymateb yn cael ei gyhoeddi yn awtomatig ar y Rhyngrwyd.
+      Fe wnaed y cais Rhyddid Gwybodaeth a gawsoch gan rywun sy’n defnyddio WhatDoTheyKnow. Gallwch ateb y cais fel y byddech yn ateb unrhyw gais arall gan unigolyn. Yr unig wahaniaeth yw y bydd eich ymateb yn cael ei gyhoeddi yn awtomatig ar y Rhyngrwyd.
     </p>
     <p>
-      Os oes gennych pryderon am breifatrwydd neu rai eraill, darllenwch yr atebion isod. Efallai yr hoffech ddarllen y <a href="http://www.whatdotheyknow.com/help/about">cyflwyniad i WhatDoTheyKnow</a> i ddarganfod mwy am yr hyn y mae'r wefan yn ei gwneud o safbwynt defnyddiwr. Gallwch hefyd chwilio'r wefan i ddod o hyd i'r awdurdod yr ydych yn gweithio iddo, a gweld statws unrhyw geisiadau a wnaed drwy ddefnyddio'r wefan.
+      Os oes gennych pryderon am breifatrwydd neu rai eraill, darllenwch yr atebion isod. Efallai yr hoffech ddarllen y <a href="http://www.whatdotheyknow.com/help/about">cyflwyniad i WhatDoTheyKnow</a> i ddarganfod mwy am yr hyn y mae’r wefan yn ei gwneud o safbwynt defnyddiwr. Gallwch hefyd chwilio’r wefan i ddod o hyd i’r awdurdod yr ydych yn gweithio iddo, a gweld statws unrhyw geisiadau a wnaed drwy ddefnyddio’r wefan.
     </p>
     <p>
       Yn olaf, rydym yn croesawu sylwadau a syniadau gan swyddogion Rhyddid Gwybodaeth, <a href="<%= help_contact_path %>">cysylltwch â ni</a> os gwelwch yn dda.
@@ -23,35 +23,35 @@
   </dl>
   <dl>
     <dt id="responses">
-    Pam ydych chi'n cyhoeddi ymatebion i geisiadau Rhyddid Gwybodaeth? <a href="#responses">#</a>
+    Pam ydych chi’n cyhoeddi ymatebion i geisiadau Rhyddid Gwybodaeth? <a href="#responses">#</a>
     </dt>
     <dd>
-    Rydym yn meddwl bod llawer o fudd iddo. Yn bennaf, bydd yn annog y cyhoedd i gymryd diddordeb yng ngwaith y llywodraeth ac i gymryd rhan. Rydym hefyd yn gobeithio y bydd yn lleihau'r nifer o geisiadau ail-adroddus ar unrhyw bwnc y bydd corff cyhoeddus ei dderbyn. O ystyried bod ymatebion Rhyddid Gwybodaeth yn cynnwys gwybodaeth icyhoeddus, y gallai unrhyw un yn hawdd gwneud cais amdani eto gan yr awdurdod cyhoeddus, rydym yn credu nad oes unrhyw reswm dros beidio â'u cyhoeddi'n eang.
+    Rydym yn meddwl bod llawer o fudd iddo. Yn bennaf, bydd yn annog y cyhoedd i gymryd diddordeb yng ngwaith y llywodraeth ac i gymryd rhan. Rydym hefyd yn gobeithio y bydd yn lleihau’r nifer o geisiadau ail-adroddus ar unrhyw bwnc y bydd corff cyhoeddus ei dderbyn. O ystyried bod ymatebion Rhyddid Gwybodaeth yn cynnwys gwybodaeth icyhoeddus, y gallai unrhyw un yn hawdd gwneud cais amdani eto gan yr awdurdod cyhoeddus, rydym yn credu nad oes unrhyw reswm dros beidio â’u cyhoeddi’n eang.
     </dd>
     <dt id="realpeople">
-    Ydy'r bobl sy'n gwneud ceisiadau yn bobl go iawn? <a href="http://www.whatdotheyknow.com/help/officers#realpeople">#</a>
+    Ydy’r bobl sy’n gwneud ceisiadau yn bobl go iawn? <a href="http://www.whatdotheyknow.com/help/officers#realpeople">#</a>
     </dt>
     <dd>
-    Ydyn. At ddibenion cadw golwg ar yr ymatebion byddwn yn defnyddio cyfeiriadau e-bost a gynhyrchir gan gyfrifiadur ar gyfer pob cais. Fodd bynnag, cyn y gallant anfon cais, rhaid i bob defnyddiwr gofrestru ar y wefan gyda chyfeiriad e-bost unigryw y byddwn wedyn yn ei ddilysu. Gallwch chwilio y wefan hon a dod o hyd i dudalen rhestru'r holl geisiadau y mae pob person wedi ei wneud.
+    Ydyn. At ddibenion cadw golwg ar yr ymatebion byddwn yn defnyddio cyfeiriadau e-bost a gynhyrchir gan gyfrifiadur ar gyfer pob cais. Fodd bynnag, cyn y gallant anfon cais, rhaid i bob defnyddiwr gofrestru ar y wefan gyda chyfeiriad e-bost unigryw y byddwn wedyn yn ei ddilysu. Gallwch chwilio y wefan hon a dod o hyd i dudalen rhestru’r holl geisiadau y mae pob person wedi ei wneud.
     </dd>
     <dt id="email_only">
     Dydy cyfeiriad e-bost ddim yn gyfeiriad digonol i gais RhG! <a href="#email_only">#</a>
     </dt>
     <dd>
-    Ydy mae. Mae'r<a href="http://www.whatdotheyknow.com/request/1142/response/2894/attach/5/20080806100741260.pdf">llythyr hwn gan Swyddfa'r Comisiynydd Gwybodaeth i Gyngor Dosbarth Rother</a> yn rhoi arweiniad ar y mater, yn benodol yng nghyd-destun ceisiadau a wneir drwy WhatDoTheyKnow.
+    Ydy mae. Mae’r<a href="http://www.whatdotheyknow.com/request/1142/response/2894/attach/5/20080806100741260.pdf">llythyr hwn gan Swyddfa’r Comisiynydd Gwybodaeth i Gyngor Dosbarth Rother</a> yn rhoi arweiniad ar y mater, yn benodol yng nghyd-destun ceisiadau a wneir drwy WhatDoTheyKnow.
     </dd>
     <dt id="vexatious">
     Ydych chi ddim yn gwneud llawer o geisiadau blinderus? <a href="#vexatious">#</a>
     </dt>
   </dl>
   <p>
-    Dydy WhatDoTheyKnow ddim yn gwneud unrhyw geisiadau. Rydym yn anfon ceisiadau ar ran ein defnyddwyr, sydd yn bobl go iawn sy'n gwneud y ceisiadau.
+    Dydy WhatDoTheyKnow ddim yn gwneud unrhyw geisiadau. Rydym yn anfon ceisiadau ar ran ein defnyddwyr, sydd yn bobl go iawn sy’n gwneud y ceisiadau.
   </p>
   <p>
-    Edrych arno fel hyn - pe bai llawer o bobl yn gwneud ceisiadau gan ddefnyddio cyfeiriadau e-bost Hotmail gwahanol, fyddech chi ddim yn meddwl bod Microsoft oedd yn gwneud ceisiadau blinderus. Mae'n union yr un fath os bydd llawer o geisiadau yn cael eu gwneud drwy WhatDoTheyKnow. At hynny, gan fod yr holl geisiadau yn cael eu cyhoeddus mae'n llawer haws i chi weld a yw un o'n defnyddwyr yn gwneud ceisiadau blinderus.
+    Edrych arno fel hyn - pe bai llawer o bobl yn gwneud ceisiadau gan ddefnyddio cyfeiriadau e-bost Hotmail gwahanol, fyddech chi ddim yn meddwl bod Microsoft oedd yn gwneud ceisiadau blinderus. Mae’n union yr un fath os bydd llawer o geisiadau yn cael eu gwneud drwy WhatDoTheyKnow. At hynny, gan fod yr holl geisiadau yn cael eu cyhoeddus mae’n llawer haws i chi weld a yw un o’n defnyddwyr yn gwneud ceisiadau blinderus.
   </p>
   <p>
-    Os nad yw hynny'n ddigon i chi, mae'r <a href="http://www.whatdotheyknow.com/request/1142/response/2894/attach/5/20080806100741260.pdf">llythyr gan Swyddfa'r Comisiynydd Gwybodaeth i Gyngor Dosbarth Rother</a> yn rhoi rhywfaint o arweiniad ar y mater.
+    Os nad yw hynny’n ddigon i chi, mae’r <a href="http://www.whatdotheyknow.com/request/1142/response/2894/attach/5/20080806100741260.pdf">llythyr gan Swyddfa’r Comisiynydd Gwybodaeth i Gyngor Dosbarth Rother</a> yn rhoi rhywfaint o arweiniad ar y mater.
   </p>
   <dl>
     <dt id="spam_problems">
@@ -59,65 +59,65 @@
     </dt>
   </dl>
   <p>
-    Os yw cais yn ymddangos ar y wefan, yna rydym wedi ceisio ei anfon at yr awdurdod drwy e-bost. Bydd unrhyw negeseuon am fethiant i gyflwyno cais yn ymddangos yn awtomatig ar y wefan. Gallwch weld y cyfeiriad yr ydym yn ei ddefnyddio gyda'r ddolen "Gweld cyfeiriad e-bost RhG" sy'n ymddangos ar y dudalen ar gyfer yr awdurdod. <a href="<%= help_contact_path %>">Cysylltwch â ni</a> os oes cyfeiriad gwell y gallwn ei ddefnyddio.
+    Os yw cais yn ymddangos ar y wefan, yna rydym wedi ceisio ei anfon at yr awdurdod drwy e-bost. Bydd unrhyw negeseuon am fethiant i gyflwyno cais yn ymddangos yn awtomatig ar y wefan. Gallwch weld y cyfeiriad yr ydym yn ei ddefnyddio gyda’r ddolen "Gweld cyfeiriad e-bost RhG" sy’n ymddangos ar y dudalen ar gyfer yr awdurdod. <a href="<%= help_contact_path %>">Cysylltwch â ni</a> os oes cyfeiriad gwell y gallwn ei ddefnyddio.
   </p>
   <p>
-    Weithiau fydd ceisiadau ddim yn cael eu cyflwyno oherwydd eu bod yn cael eu symud yn dawel gan "hidlyddion sbam" adran TG yr awdurdod. Gall awdurdodau wneud yn siwr na fydd hyn yn digwydd drwy ofyn i'w hadrannau TG i roi e-byst gan <strong>@whatdotheyknow.com</strong> ar "restr wen". Os byddwch yn <a href="<%= help_contact_path %>">gofyn i ni</a>, byddwn yn ailanfon unrhyw gais, a/ neu'n rhoi manylion technegol ei gyflwyno fel y gall adran TG fynd ar drywydd yr hyn a ddigwyddodd i'r neges.
+    Weithiau fydd ceisiadau ddim yn cael eu cyflwyno oherwydd eu bod yn cael eu symud yn dawel gan "hidlyddion sbam" adran TG yr awdurdod. Gall awdurdodau wneud yn siwr na fydd hyn yn digwydd drwy ofyn i’w hadrannau TG i roi e-byst gan <strong>@whatdotheyknow.com</strong> ar "restr wen". Os byddwch yn <a href="<%= help_contact_path %>">gofyn i ni</a>, byddwn yn ailanfon unrhyw gais, a/ neu’n rhoi manylion technegol ei gyflwyno fel y gall adran TG fynd ar drywydd yr hyn a ddigwyddodd i’r neges.
   </p>
   <p>
-    Yn olaf, gallwch ymateb i unrhyw gais o'ch porwr gwe, heb fod angen unrhyw e-bost, gan ddefnyddio'r ddolen "ymateb i gais" ar waelod pob tudalen gais.
+    Yn olaf, gallwch ymateb i unrhyw gais o’ch porwr gwe, heb fod angen unrhyw e-bost, gan ddefnyddio’r ddolen "ymateb i gais" ar waelod pob tudalen gais.
   </p>
   <dl>
     <dt id="days">
-    Sut ydych chi'n cyfrifo'r dyddiad cau a ddangosir ar dudalennau gais?<a href="#days">#</a>
+    Sut ydych chi’n cyfrifo’r dyddiad cau a ddangosir ar dudalennau gais?<a href="#days">#</a>
     </dt>
   </dl>
   <p>
-    Mae'r Ddeddf Rhyddid Gwybodaeth yn dweud:
+    Mae’r Ddeddf Rhyddid Gwybodaeth yn dweud:
   </p>
   <blockquote>
     <p>
-      Rhaid i awdurdod cyhoeddus gydymffurfio ag adran 1 (1) <strong>yn brydlon</strong> ac yn sicr heb fod yn hwyrach na'r ugeinfed diwrnod gwaith ar ôl y dyddiad derbyn.
+      Rhaid i awdurdod cyhoeddus gydymffurfio ag adran 1 (1) <strong>yn brydlon</strong> ac yn sicr heb fod yn hwyrach na’r ugeinfed diwrnod gwaith ar ôl y dyddiad derbyn.
     </p>
   </blockquote>
   <p>
-    Mae manylion 'nerdy' o sut yn union y penwythnosau yn cael eu cyfrif, a a beth fydd yn digwydd os bydd y cais yn cyrraedd y tu allan i oriau swyddfa, yn fanylion yn unig. Yr hyn sy'n bwysig yma yw bod y gyfraith yn dweud bod rhaid i awdurdodau ymateb yn <strong>brydlon.</strong>
+    Mae manylion ’nerdy’ o sut yn union y penwythnosau yn cael eu cyfrif, a a beth fydd yn digwydd os bydd y cais yn cyrraedd y tu allan i oriau swyddfa, yn fanylion yn unig. Yr hyn sy’n bwysig yma yw bod y gyfraith yn dweud bod rhaid i awdurdodau ymateb yn <strong>brydlon.</strong>
   </p>
   <p>
-    Os oes gennych reswm da pam bod cais yn mynd i gymryd peth amser i'w brosesu, mae'r rhai sy'n gwneud cais yn gwerthfawogi derbyn e-bost cyflym gyda brawddeg neu ddwy yn dweud beth sy'n digwydd.
+    Os oes gennych reswm da pam bod cais yn mynd i gymryd peth amser i’w brosesu, mae’r rhai sy’n gwneud cais yn gwerthfawogi derbyn e-bost cyflym gyda brawddeg neu ddwy yn dweud beth sy’n digwydd.
   </p>
   <p>
-    Mae Swyddogion Rhyddid Gwybodaeth yn aml yn gorfod gwneud llawer o <strong>waith caled</strong> i ateb ceisiadau, ac mae hyn o olwg y cyhoedd. Rydym yn credu y byddai'n helpu pawb i gael mwy o'r cymhlethdod yn weladwy.
+    Mae Swyddogion Rhyddid Gwybodaeth yn aml yn gorfod gwneud llawer o <strong>waith caled</strong> i ateb ceisiadau, ac mae hyn o olwg y cyhoedd. Rydym yn credu y byddai’n helpu pawb i gael mwy o’r cymhlethdod yn weladwy.
   </p>
   <dl>
     <dt id="days2">
-    Ond mewn gwirionedd, sut ydych chi'n cyfrifo'r terfyn amser?<a href="#days2">#</a>
+    Ond mewn gwirionedd, sut ydych chi’n cyfrifo’r terfyn amser?<a href="#days2">#</a>
     </dt>
   </dl>
   <p>
-    Darllenwch yr ateb i'r cwestiwn blaenorol yn gyntaf. Yn gyfreithiol, mae'n rhaid i awdurdodau ymateb yn <strong>brydlon</strong> i geisiadau Rhyddid Gwybodaeth. Os byddant yn methu â gwneud hynny, mae'n well os ydynt yn dangos y gwaith caled y maent yn ei wneud trwy egluro yr hyn sy'n cymryd yr amser ychwanegol.
+    Darllenwch yr ateb i’r cwestiwn blaenorol yn gyntaf. Yn gyfreithiol, mae’n rhaid i awdurdodau ymateb yn <strong>brydlon</strong> i geisiadau Rhyddid Gwybodaeth. Os byddant yn methu â gwneud hynny, mae’n well os ydynt yn dangos y gwaith caled y maent yn ei wneud trwy egluro yr hyn sy’n cymryd yr amser ychwanegol.
   </p>
   <p>
     Wedi dweud hynny, mae WhatDoTheyKnow yn dangos y dyddiad cau cyfreithiol uchaf ar gyfer ymateb ar bob cais. Dyma sut rydym yn ei gyfrifo.
   </p>
   <ul>
-    <li>Os bydd y diwrnod yr ydym yn cyflwyno'r cais drwy e-bost yn ddiwrnod gwaith, rydym yn cyfrif y diwrnod hwnnw i fod yn "ddiwrnod sero", hyd yn oed os cafodd ei gyflwyno yn hwyr yn y nos. Mae diwrnodau yn gorffen am hanner nos. Yna byddwn yn cyfrif y diwrnod gwaith nesaf fel "un diwrnod", ac yn y blaen hyd at <strong>20 diwrnod gwaith.</strong>
+    <li>Os bydd y diwrnod yr ydym yn cyflwyno’r cais drwy e-bost yn ddiwrnod gwaith, rydym yn cyfrif y diwrnod hwnnw i fod yn "ddiwrnod sero", hyd yn oed os cafodd ei gyflwyno yn hwyr yn y nos. Mae diwrnodau yn gorffen am hanner nos. Yna byddwn yn cyfrif y diwrnod gwaith nesaf fel "un diwrnod", ac yn y blaen hyd at <strong>20 diwrnod gwaith.</strong>
     </li>
     <li>Os bydd y diwrnod y cafodd yr e-bost ei gyflwyno yn ddiwrnod na fydd pobl yn gweithio, rydym yn cyfrif y diwrnod gwaith nesaf fel "un diwrnod". Cyflwyno yw cyflwyno, hyd yn oed os bydd yn digwydd ar y penwythnos. Mae rhai awdurdodau <a href="http://www.whatdotheyknow.com/request/policy_regarding_body_scans#incoming-1100">yn anghytuno â hyn</a> , mae ein cyfreithiwr yn anghytuno â hwy.</li>
-    <li>Rydym yn annog pobl sy'n gwneud cais i nodi pan fyddant wedi <strong>egluro</strong> eu cais fel y bydd y cloc yn cael ei ailosod, ond weithiau maent yn cael hyn yn anghywir. Os ydych yn gweld problem gyda chais arbennig, gadewch i ni wybod a byddwn yn ei drwsio.
+    <li>Rydym yn annog pobl sy’n gwneud cais i nodi pan fyddant wedi <strong>egluro</strong> eu cais fel y bydd y cloc yn cael ei ailosod, ond weithiau maent yn cael hyn yn anghywir. Os ydych yn gweld problem gyda chais arbennig, gadewch i ni wybod a byddwn yn ei drwsio.
     </li>
   </ul>
   <p>
-    Dangosir y dyddiad a gyfrifir felly ar geisiadau gyda'r testun "Yn ôl y gyfraith, dylai'r Cyngor Dinas Lerpwl fel arfer wedi ymateb erbyn...". Dim ond un achos sy'n eithriadol: gweler y cwestiwn nesaf am y <a href="#public_interest_test">estyniadau amser prawf buddiant cyhoeddus</a> .
+    Dangosir y dyddiad a gyfrifir felly ar geisiadau gyda’r testun "Yn ôl y gyfraith, dylai’r Cyngor Dinas Lerpwl fel arfer wedi ymateb erbyn...". Dim ond un achos sy’n eithriadol: gweler y cwestiwn nesaf am y <a href="#public_interest_test">estyniadau amser prawf buddiant cyhoeddus</a> .
   </p>
   <p>
     Mae ysgolion hefyd yn achos arbennig, y mae WhatDoTheyKnow yn ei arddangos yn wahanol.
   </p>
   <ul>
-    <li>Ers mis Mehefin 2009, mae gan <strong>ysgolion</strong> "20 diwrnod gwaith gan anwybyddu unrhyw ddiwrnod gwaith nad yw'n ddiwrnod ysgol, neu 60 diwrnod gwaith, pa un bynnag yw'r cyntaf" ( <a href="http://www.legislation.gov.uk/uksi/2009/1369/contents/made">Rhyddid Gwybodaeth (Amser ar gyfer Cydymffurfio â Chais) 2009</a> ). Mae WhatDoTheyKnow yn nodi ar geisiadau i ysgolion fod y terfyn o 20 diwrnod yn berthnasol yn unig yn ystod y tymor, ac yn dangos bod y ceisiadau'n bendant yn hwyr ar ôl 60 diwrnod gwaith.</li>
+    <li>Ers mis Mehefin 2009, mae gan <strong>ysgolion</strong> "20 diwrnod gwaith gan anwybyddu unrhyw ddiwrnod gwaith nad yw’n ddiwrnod ysgol, neu 60 diwrnod gwaith, pa un bynnag yw’r cyntaf" ( <a href="http://www.legislation.gov.uk/uksi/2009/1369/contents/made">Rhyddid Gwybodaeth (Amser ar gyfer Cydymffurfio â Chais) 2009</a> ). Mae WhatDoTheyKnow yn nodi ar geisiadau i ysgolion fod y terfyn o 20 diwrnod yn berthnasol yn unig yn ystod y tymor, ac yn dangos bod y ceisiadau’n bendant yn hwyr ar ôl 60 diwrnod gwaith.</li>
   </ul>
   <p>
-    Os ydych wir eisiau gwybod y manylion technegol, darllenwch <a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">canllawiau manwl Swyddfa'r Comisiynydd Gwybodaeth</a> . Yn y cyfamser, cofiwch fod y gyfraith yn dweud bod rhaid i awdurdodau ymateb yn <strong>brydlon.</strong> Dyna sy wir yn bwysig.
+    Os ydych wir eisiau gwybod y manylion technegol, darllenwch <a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">canllawiau manwl Swyddfa’r Comisiynydd Gwybodaeth</a> . Yn y cyfamser, cofiwch fod y gyfraith yn dweud bod rhaid i awdurdodau ymateb yn <strong>brydlon.</strong> Dyna sy wir yn bwysig.
   </p>
   <dl>
     <dt id="public_interest_test">
@@ -125,48 +125,48 @@
     </dt>
   </dl>
   <p>
-    Mae'r Ddeddf Rhyddid Gwybodaeth yn gadael i awdurdodau wneud cais am estyniad amser amhenodol wrth ystyried <strong>prawf budd y cyhoedd.</strong> Dywed Canllawiau'r Comisiynydd Gwybodaeth na ddylai gael ei ddefnyddio ond mewn achosion "eithriadol o gymhleth" ( <a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">Canllawiau Arfer Da Rhyddid Gwybodaeth Rhif 4</a> ). Nid WhatDoTheyKnow yn trin yr achos hwn mewn ffordd arbennig, a dyna pam rydym yn defnyddio yr ymadrodd "Fel arfer, dylai ... wedi ymateb erbyn" pan eir heibio i'r terfyn 20 diwrnod gwaith.
+    Mae’r Ddeddf Rhyddid Gwybodaeth yn gadael i awdurdodau wneud cais am estyniad amser amhenodol wrth ystyried <strong>prawf budd y cyhoedd.</strong> Dywed Canllawiau’r Comisiynydd Gwybodaeth na ddylai gael ei ddefnyddio ond mewn achosion "eithriadol o gymhleth" ( <a href="https://ico.org.uk/media/for-organisations/documents/1165/time-for-compliance-foia-guidance.pdf">Canllawiau Arfer Da Rhyddid Gwybodaeth Rhif 4</a> ). Nid WhatDoTheyKnow yn trin yr achos hwn mewn ffordd arbennig, a dyna pam rydym yn defnyddio yr ymadrodd "Fel arfer, dylai ... wedi ymateb erbyn" pan eir heibio i’r terfyn 20 diwrnod gwaith.
   </p>
   <p>
-    Mae'r un canllawiau yn dweud, hyd yn oed mewn achosion eithriadol o gymhleth, na ddylai yr un cais Rhyddid Gwybodaeth gymryd mwy na <strong>40 diwrnod gwaith</strong> i ateb. Mae WhatDoTheyKnow yn arddangos ceisiadau sy mor hwyr â hynny gyda geiriad cryfach i ddangos eu bod yn bendant yn hwyr.
+    Mae’r un canllawiau yn dweud, hyd yn oed mewn achosion eithriadol o gymhleth, na ddylai yr un cais Rhyddid Gwybodaeth gymryd mwy na <strong>40 diwrnod gwaith</strong> i ateb. Mae WhatDoTheyKnow yn arddangos ceisiadau sy mor hwyr â hynny gyda geiriad cryfach i ddangos eu bod yn bendant yn hwyr.
   </p>
   <p>
-    Nid yw Deddf Rhyddid Gwybodaeth (Yr Alban) yn caniatáu estyniad "er budd y cyhoedd" o'r fath. Byddai WhatDoTheyKnow yn hoffi gweld y gyfraith yn cael ei newid naill ai i gael gwared ar y estyniad o Ddeddf y Deyrnas Gyfunol, neu i ailgyflwyno terfyn amser absoliwt o 40 diwrnod gwaith, hyd yn oed gyda'r estyniad ( <a href="http://www.publicwhip.org.uk/division.php?date=2000-10-17&amp;number=1&amp;house=lords">Pleidleisiodd</a> Tŷ'r Arglwyddi i gael gwared o'r ddarpariaeth ar gyfer y fath terfyn amser yn ystod taith gychwynnol y Ddeddf drwy'r Senedd y DU).
+    Nid yw Deddf Rhyddid Gwybodaeth (Yr Alban) yn caniatáu estyniad "er budd y cyhoedd" o’r fath. Byddai WhatDoTheyKnow yn hoffi gweld y gyfraith yn cael ei newid naill ai i gael gwared ar y estyniad o Ddeddf y Deyrnas Gyfunol, neu i ailgyflwyno terfyn amser absoliwt o 40 diwrnod gwaith, hyd yn oed gyda’r estyniad ( <a href="http://www.publicwhip.org.uk/division.php?date=2000-10-17&amp;number=1&amp;house=lords">Pleidleisiodd</a> Tŷ’r Arglwyddi i gael gwared o’r ddarpariaeth ar gyfer y fath terfyn amser yn ystod taith gychwynnol y Ddeddf drwy’r Senedd y DU).
   </p>
   <dl>
     <dt id="large_file">
     Sut y gallaf anfon ffeil fawr fydd ddim yn mynd drwy e-bost?<a href="#large_file">#</a>
     </dt>
     <dd>
-    Yn hytrach nag e-bost, gallwch ymateb i gais yn uniongyrchol o'ch porwr gwe, gan gynnwys lanlwytho ffeil. I wneud hyn, dewiswch "ymateb i gais" ar waelod tudalen y cais. <a href="<%= help_contact_path %>">Cysylltwch â ni</a> os yw'n rhy fawr ar gyfer hwnnw hyd yn oed (mwy na, dyweder, 50Mb).
+    Yn hytrach nag e-bost, gallwch ymateb i gais yn uniongyrchol o’ch porwr gwe, gan gynnwys lanlwytho ffeil. I wneud hyn, dewiswch "ymateb i gais" ar waelod tudalen y cais. <a href="<%= help_contact_path %>">Cysylltwch â ni</a> os yw’n rhy fawr ar gyfer hwnnw hyd yn oed (mwy na, dyweder, 50Mb).
     </dd>
     <dt id="names">
-    Pam ydych chi'n cyhoeddi enwau'r gweision sifil a thestun e-byst? <a href="#names">#</a>
+    Pam ydych chi’n cyhoeddi enwau’r gweision sifil a thestun e-byst? <a href="#names">#</a>
     </dt>
     <dd>
-    Rydym yn ystyried beth mae swyddogion neu weision yn ei wneud yn ystod eu cyflogaeth i fod yn wybodaeth gyhoeddus. Byddwn ond yn dileu cynnwys o dan amgylchiadau eithriadol: gweler ein <a href="<%= help_privacy_path(:anchor => 'takedown') %>">polisi cymryd i lawr</a> .
+    Rydym yn ystyried beth mae swyddogion neu weision yn ei wneud yn ystod eu cyflogaeth i fod yn wybodaeth gyhoeddus. Byddwn ond yn dileu cynnwys o dan amgylchiadau eithriadol: gweler ein <a href="<%= help_privacy_path(:anchor => ’takedown’) %>">polisi cymryd i lawr</a> .
     </dd>
     <dt id="mobiles">
     A ydych yn cyhoeddi cyfeiriadau e-bost neu rifau ffôn symudol? <a href="#mobiles">#</a>
     </dt>
   </dl>
   <p>
-    Er mwyn atal spam, rydym yn cael gwared yn awtomatig o'r rhan fwyaf o gyfeiriadau e-bost a rhai rhifau ffôn symudol o'r ymatebion i geisiadau. <a href="<%= help_contact_path %>">Cysylltwch â ni</a> os ydym wedi methu un. Am resymau technegol nid ydym bob amser yn eu tynnu o'r atodiadau, fel ffeiliau PDF penodol.
+    Er mwyn atal spam, rydym yn cael gwared yn awtomatig o’r rhan fwyaf o gyfeiriadau e-bost a rhai rhifau ffôn symudol o’r ymatebion i geisiadau. <a href="<%= help_contact_path %>">Cysylltwch â ni</a> os ydym wedi methu un. Am resymau technegol nid ydym bob amser yn eu tynnu o’r atodiadau, fel ffeiliau PDF penodol.
   </p>
   <p>
-    Os bydd angen i chi wybod beth oedd y cyfeiriad rydym wedi symud, <a href="<%= help_contact_path %>">cysylltwch â ni</a> os gwelwch yn dda. O bryd i'w gilydd, bydd cyfeiriad e-bost yn ffurfio rhan bwysig o ymateb a byddwn yn ei roi ar ffurf aneglur mewn anodiant.
+    Os bydd angen i chi wybod beth oedd y cyfeiriad rydym wedi symud, <a href="<%= help_contact_path %>">cysylltwch â ni</a> os gwelwch yn dda. O bryd i’w gilydd, bydd cyfeiriad e-bost yn ffurfio rhan bwysig o ymateb a byddwn yn ei roi ar ffurf aneglur mewn anodiant.
   </p>
   <dl>
     <dt id="copyright">
     <a name="commercial" id="commercial"></a> Beth yw eich polisi ar hawlfraint dogfennau?<a href="http://www.whatdotheyknow.com/help/officers#copyright">#</a>
     </dt>
     <dd>
-    Mae ein Deddf Rhyddid Gwybodaeth yn gyfraith "ddall i'r ceisydd", felly gall unrhyw un yn y byd wneud cais am yr un ddogfen a chael copi ohoni. Os ydych yn credu ein bod yn torri hawlfraint drwy roi dogfen ar y rhyngrwyd, gallwch <a href="<%= help_contact_path %>">gysylltu â ni</a> a gofyn i ni ei thynnu i lawr. Fodd bynnag, er mwyn arbed arian trethdalwyr drwy atal ceisiadau dyblyg, ac ar gyfer cysylltiadau cyhoeddus da, byddem yn eich cynghori i beidio â gwneud hynny.
+    Mae ein Deddf Rhyddid Gwybodaeth yn gyfraith "ddall i’r ceisydd", felly gall unrhyw un yn y byd wneud cais am yr un ddogfen a chael copi ohoni. Os ydych yn credu ein bod yn torri hawlfraint drwy roi dogfen ar y rhyngrwyd, gallwch <a href="<%= help_contact_path %>">gysylltu â ni</a> a gofyn i ni ei thynnu i lawr. Fodd bynnag, er mwyn arbed arian trethdalwyr drwy atal ceisiadau dyblyg, ac ar gyfer cysylltiadau cyhoeddus da, byddem yn eich cynghori i beidio â gwneud hynny.
     </dd>
   </dl>
   <p>
     <strong>Os nad ydych wedi eisoes,</strong> darllenwch <a href="<%= help_about_path %>">y cyflwyniad</a> -&gt;<br>
-    <strong>Fel arall,</strong> y <a href="<%= help_credits_path %>">credydau</a> neu'r <a href="<%= help_api_path %>">API rhaglenwyr</a> -&gt;
+    <strong>Fel arall,</strong> y <a href="<%= help_credits_path %>">credydau</a> neu’r <a href="<%= help_api_path %>">API rhaglenwyr</a> -&gt;
   </p>
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -283,7 +283,7 @@
     </dd>
 
     <dt id="classifications">
-      Why is "Awaiting classification" or "Delayed" appearing on requests we've
+      Why is "Awaiting classification" or "Delayed" appearing on requests we’ve
       responded to?
       <a href="#classifications">#</a>
     </dt>
@@ -295,7 +295,7 @@
       </p>
       <p>
         Requests which have not been classified for a couple of months can have
-        their classifications updated by any user. A request's classification
+        their classifications updated by any user. A request’s classification
         can be changed via "Actions" > "Update the status of this request".
       </p>
     </dd>

--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -3,26 +3,26 @@
 <div id="left_column_flip" class="left_column_flip">
   <h1 id="privacy"><%= @title %> <a href="#privacy">#</a> </h1>
   <dl>
-    <dt id="email_address">Pwy sy'n cael gweld fy nghyfeiriad e-bost? <a href="#email_address">#</a> </dt>
+    <dt id="email_address">Pwy sy’n cael gweld fy nghyfeiriad e-bost? <a href="#email_address">#</a> </dt>
     <dd>
-    <p>Ni fyddwn yn datgelu eich cyfeiriad e-bost i neb oni bai bod yn rhaid i ni yn ôl y gyfraith, neu i chi ofyn i ni wneud. Mae hyn yn cynnwys yr awdurdod cyhoeddus yr ydych chi'n anfon cais ato. Chân nhw weld dim ond cyfeiriad e-bost @whatdotheyknow.com sy'n benodol i'r cais hwnnw. </p>
+    <p>Ni fyddwn yn datgelu eich cyfeiriad e-bost i neb oni bai bod yn rhaid i ni yn ôl y gyfraith, neu i chi ofyn i ni wneud. Mae hyn yn cynnwys yr awdurdod cyhoeddus yr ydych chi’n anfon cais ato. Chân nhw weld dim ond cyfeiriad e-bost @whatdotheyknow.com sy’n benodol i’r cais hwnnw. </p>
     <p>Os byddwch yn anfon neges at ddefnyddiwr arall ar y wefan, yna bydd yn datgelu eich cyfeiriad e-bost iddynt. Byddwch yn cael gwybod bod hyn yn mynd i ddigwydd.</p> </dd>
-    <dt id="nasty_spam">Fyddwch chi'n anfon sbam cas, ynfyd at fy nghyfeiriad e-bost? <a href="nasty_spam">#</a> </dt>
-    <dd>Na fyddwn. Ar ôl i chi gofrestru â WhatDoTheyKnow ni fyddwn ond yn anfon negeseuon e-bost atoch chi sy'n ymwneud â chais a wnaethoch, rhybudd e-bost eich bod wedi cofrestru ar ei gyfer, neu am resymau eraill yr ydych yn awdurdodi yn benodol. Ni fyddwn byth yn rhoi neu'n gwerthu eich cyfeiriadau e-bost i neb arall, oni bai bod yn rhaid i yn ôl y gyfraith neu i chi ofyn i ni wneud. </dd>
+    <dt id="nasty_spam">Fyddwch chi’n anfon sbam cas, ynfyd at fy nghyfeiriad e-bost? <a href="nasty_spam">#</a> </dt>
+    <dd>Na fyddwn. Ar ôl i chi gofrestru â WhatDoTheyKnow ni fyddwn ond yn anfon negeseuon e-bost atoch chi sy’n ymwneud â chais a wnaethoch, rhybudd e-bost eich bod wedi cofrestru ar ei gyfer, neu am resymau eraill yr ydych yn awdurdodi yn benodol. Ni fyddwn byth yn rhoi neu’n gwerthu eich cyfeiriadau e-bost i neb arall, oni bai bod yn rhaid i yn ôl y gyfraith neu i chi ofyn i ni wneud. </dd>
     <dt id="public_request">Pam bydd fy enw ac fy nghais yn ymddangos yn gyhoeddus ar y wefan? <a href="#public_request">#</a> </dt>
     <dd>
-    <p>Rydym yn cyhoeddi eich cais ar y Rhyngrwyd fel y gall unrhyw un ei ddarllen a defnyddio'r wybodaeth yr ydych wedi dod o hyd iddi. Nid ydym fel arfer yn dileu ceisiadau ( <a href="#delete_requests">mwy o fanylion</a> ). </p>
-    <p> Mae eich enw ynghlwm yn eich cais, felly mae'n rhaid iddo gael ei gyhoeddi hefyd. Nid yw ond yn deg, gan ein bod ni'n mynd i gyhoeddi enw'r gwas sifil sy'n ysgrifennu yr ymateb i'ch cais. Mae defnyddio eich enw go iawn hefyd yn helpu pobl i ddod i gysylltiad â chi i'ch helpu gyda'ch gwaith ymchwil neu i ymgyrchu gyda chi. </p>
-    <p>Yn ôl y gyfraith, rhaid i chi ddefnyddio eich enw go iawn ar gyfer y cais iddo fod cais Rhyddid Gwybodaeth dilys. Gweler y cwestiwn nesaf ar gyfer dewisiadau eraill os nad ydych am i'ch enw llawn gael ei gyhoeddi. </p> </dd>
+    <p>Rydym yn cyhoeddi eich cais ar y Rhyngrwyd fel y gall unrhyw un ei ddarllen a defnyddio’r wybodaeth yr ydych wedi dod o hyd iddi. Nid ydym fel arfer yn dileu ceisiadau ( <a href="#delete_requests">mwy o fanylion</a> ). </p>
+    <p> Mae eich enw ynghlwm yn eich cais, felly mae’n rhaid iddo gael ei gyhoeddi hefyd. Nid yw ond yn deg, gan ein bod ni’n mynd i gyhoeddi enw’r gwas sifil sy’n ysgrifennu yr ymateb i’ch cais. Mae defnyddio eich enw go iawn hefyd yn helpu pobl i ddod i gysylltiad â chi i’ch helpu gyda’ch gwaith ymchwil neu i ymgyrchu gyda chi. </p>
+    <p>Yn ôl y gyfraith, rhaid i chi ddefnyddio eich enw go iawn ar gyfer y cais iddo fod cais Rhyddid Gwybodaeth dilys. Gweler y cwestiwn nesaf ar gyfer dewisiadau eraill os nad ydych am i’ch enw llawn gael ei gyhoeddi. </p> </dd>
     <dt id="real_name">A allaf wneud cais Rhyddid Gwybodaeth gan ddefnyddio ffugenw? <a href="#real_name">#</a> </dt>
     <dd>
     <p>Yn dechnegol, rhaid i chi ddefnyddio eich enw iawn ar gyfer eich cais iddo fod yn gais Rhyddid Gwybodaeth dilys yn ôl y gyfraith. Gweler y <a href="http://www.ico.org.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/name_of_applicant_fop083_v1.pdf">canllawiau hyn gan y Comisiynydd Gwybodaeth</a> (Ionawr 2009). </p>
-    <p>Fodd bynnag, mae'r un canllawiau hefyd yn dweud ei fod yn arfer da i'r awdurdod cyhoeddus ystyried cais a wnaed gan ddefnyddio ffugenw amlwg. Dylech gyfeirio at hyn os bydd awdurdod cyhoeddus yn gwrthod cais am eich bod yn defnyddio ffugenw.</p>
-    <p>Byddwch yn ofalus, serch hynny, hyd yn oed os yw'r awdurdod yn dilyn yr arfer da hwn, bydd y ffugenw yn ôl pob tebyg yn ei gwneud yn amhosibl i chi gwyno wrth y Comisiynydd Gwybodaeth yn ddiweddarach am y ffordd y cafodd eich cais ei drin. </p>
+    <p>Fodd bynnag, mae’r un canllawiau hefyd yn dweud ei fod yn arfer da i’r awdurdod cyhoeddus ystyried cais a wnaed gan ddefnyddio ffugenw amlwg. Dylech gyfeirio at hyn os bydd awdurdod cyhoeddus yn gwrthod cais am eich bod yn defnyddio ffugenw.</p>
+    <p>Byddwch yn ofalus, serch hynny, hyd yn oed os yw’r awdurdod yn dilyn yr arfer da hwn, bydd y ffugenw yn ôl pob tebyg yn ei gwneud yn amhosibl i chi gwyno wrth y Comisiynydd Gwybodaeth yn ddiweddarach am y ffordd y cafodd eich cais ei drin. </p>
     <p>Mae yna nifer o ddewisiadau da eraill yn hytrach na defnyddio ffugenw.</p> <ul>
-    <li>Defnyddiwch ffurf wahanol ar eich enw. Mae'r arweiniad yn dweud y gall "Mr Arthur Thomas Roberts" wneud cais dilys fel "Arthur Roberts", "AR Roberts", neu "Mr Roberts", ond <strong>nid</strong> fel "Arthur" neu "ATR". </li>
+    <li>Defnyddiwch ffurf wahanol ar eich enw. Mae’r arweiniad yn dweud y gall "Mr Arthur Thomas Roberts" wneud cais dilys fel "Arthur Roberts", "AR Roberts", neu "Mr Roberts", ond <strong>nid</strong> fel "Arthur" neu "ATR". </li>
     <li>Gall menywod ddefnyddio eu henw cyn priodi.</li>
-    <li>Yn y rhan fwyaf o achosion, gallwch ddefnyddio unrhyw enw yr ydych "adnabyddus trwyddo ac/neu sy'n cael ei ddefnyddio yn rheolaidd". </li>
+    <li>Yn y rhan fwyaf o achosion, gallwch ddefnyddio unrhyw enw yr ydych "adnabyddus trwyddo ac/neu sy’n cael ei ddefnyddio yn rheolaidd". </li>
     <li>Defnyddiwch enw corff neu sefydliad, enw cwmni, enw masnachu cwmni, neu enw masnachu unig fasnachwr. </li>
     <li>Gofynnwch i rywun arall i wneud y cais ar eich rhan. </li>
     <li>Gallwch, os ydych yn sownd mewn gwirionedd, ofyn i ni wneud y cais ar eich rhan. <a href="<%= help_contact_path %>">Cysylltwch â ni</a> â rheswm da pam na allwch chi wneud y cais eich hun ac na allwch ofyn i ffrind wneud ar eich rhan. Nid oes gennym yr adnoddau i wneud hyn i bawb. </li>
@@ -30,87 +30,87 @@
   <p>Peidiwch â cheisio dynwared rhywun arall.</p> </dd>
   <dt id="anonymous">Pam mae ceisiadau dienw ar y safle? <a href="#anonymous">#</a> </dt>
   <dd>
-  Mae rhai awdurdodau cyhoeddus yn defnyddio meddalwedd mySociety yn FOI Cofrestru er mwyn defnyddio WhatDoTheyKnow fel log datgelu ar gyfer eu holl weithgarwch Rhyddid Gwybodaeth.   Pan fydd pobl yn gwneud cais i'r awdurdod y bydd eu henwau fel arfer yn cael ei ddal yn ôl rhag eu cyhoeddi union fel y byddent mewn log datgelu awdurdod ar wefan yr awdurdod.
+  Mae rhai awdurdodau cyhoeddus yn defnyddio meddalwedd mySociety yn FOI Cofrestru er mwyn defnyddio WhatDoTheyKnow fel log datgelu ar gyfer eu holl weithgarwch Rhyddid Gwybodaeth.   Pan fydd pobl yn gwneud cais i’r awdurdod y bydd eu henwau fel arfer yn cael ei ddal yn ôl rhag eu cyhoeddi union fel y byddent mewn log datgelu awdurdod ar wefan yr awdurdod.
   </dd>
   <dt id="full_address">Maen nhw wedi gofyn am fy nghyfeiriad post! <a href="#full_address">#</a> </dt>
   <dd>
   <p>Os bydd awdurdod cyhoeddus yn gofyn i chi am eich cyfeiriad llawn, corfforol, atebwch iddynt gan ddweud fod Adran 8.1.b y Ddeddf Rhyddid Gwybodaeth yn gofyn am "cyfeiriad ar gyfer gohebiaeth", a bod y cyfeiriad e-bost rydych yn ei ddefnyddio yn ddigonol. </p>
-  <p> Mae gan y Weinyddiaeth Gyfiawnder <a href="http://www.justice.gov.uk/information-access-rights/foi-guidance-for-practitioners/procedural-guidance/foi-what-constitutes">ganllawiau ar hyn</a> - <em>"Yn ogystal â gohebiaeth copi caled ysgrifenedig, mae ceisiadau sy'n cael eu trosglwyddo yn electronig (er enghraifft, mewn e-byst) yn dderbyniol ...</em><em>Os bydd cais yn cael ei dderbyn trwy e-bost a chyfeiriad post ddim yn cael ei roi, dylai'r cyfeiriad e-bost gael ei drin fel y cyfeiriad dychwelyd. " </em> </p>
-  <p>A fel petai hynny'n ddim yn ddigon, mae <a href="http://www.ico.org.uk/for_organisations/freedom_of_information/guide/receiving_a_request">Awgrymiadau ar gyfer Ymarferwyr</a> y Comisiynydd Gwybodaeth yn dweud <em>"Mae'n rhaid i gais ... gynnwys cyfeiriad ar gyfer gohebiaeth. Does dim rhaid iddo fod yn gyfeiriad preswyl nac yn gyfeiriad gwaith yr unigolyn - gellir defnyddio <strong>unrhyw gyfeiriad y gellir ysgrifennu ato</strong>, gan gynnwys cyfeiriad post neu <strong>gyfeiriad e-bost</strong>;"</em> </p> </dd>
+  <p> Mae gan y Weinyddiaeth Gyfiawnder <a href="http://www.justice.gov.uk/information-access-rights/foi-guidance-for-practitioners/procedural-guidance/foi-what-constitutes">ganllawiau ar hyn</a> - <em>"Yn ogystal â gohebiaeth copi caled ysgrifenedig, mae ceisiadau sy’n cael eu trosglwyddo yn electronig (er enghraifft, mewn e-byst) yn dderbyniol ...</em><em>Os bydd cais yn cael ei dderbyn trwy e-bost a chyfeiriad post ddim yn cael ei roi, dylai’r cyfeiriad e-bost gael ei drin fel y cyfeiriad dychwelyd. " </em> </p>
+  <p>A fel petai hynny’n ddim yn ddigon, mae <a href="http://www.ico.org.uk/for_organisations/freedom_of_information/guide/receiving_a_request">Awgrymiadau ar gyfer Ymarferwyr</a> y Comisiynydd Gwybodaeth yn dweud <em>"Mae’n rhaid i gais ... gynnwys cyfeiriad ar gyfer gohebiaeth. Does dim rhaid iddo fod yn gyfeiriad preswyl nac yn gyfeiriad gwaith yr unigolyn - gellir defnyddio <strong>unrhyw gyfeiriad y gellir ysgrifennu ato</strong>, gan gynnwys cyfeiriad post neu <strong>gyfeiriad e-bost</strong>;"</em> </p> </dd>
   <dt id="postal_answer">Na, na, mae angen cyfeiriad post arnynt fel y gallant anfon ymateb bapur! <a href="#postal_answer">#</a> </dt>
   <dd>
-  <p>Os dim ond copi papur o'r wybodaeth yr ydych ei eisiau sy gan yr awdurdod, efallai y byddant yn gofyn i chi am gyfeiriad post. I ddechrau, ceisiwch eu perswadio i sganio y dogfennau i chi. Gallwch hyd yn oed <a href="http://www.whatdotheyknow.com/request/car_parking_charges_policy_and_a#outgoing-532">gynnig rhoi sganiwr iddynt</a> , a oedd yn yr achos penodol hwnnw wedi codi embaras ar yr awdurdod a gwneud iddynt  ddod o hyd i un oedd ganddynt eisoes.</p>
-  <p>Os nad yw hynny'n gweithio, a'ch bod am roi eich cyfeiriad post yn breifat er mwyn derbyn y dogfennau, nodwch ar eich cais fel "Maen nhw'n mynd i ymateb drwy'r post", a bydd yn rhoi cyfeiriad e-bost i ddefnyddio at y diben hwnnw.</p> </dd>
+  <p>Os dim ond copi papur o’r wybodaeth yr ydych ei eisiau sy gan yr awdurdod, efallai y byddant yn gofyn i chi am gyfeiriad post. I ddechrau, ceisiwch eu perswadio i sganio y dogfennau i chi. Gallwch hyd yn oed <a href="http://www.whatdotheyknow.com/request/car_parking_charges_policy_and_a#outgoing-532">gynnig rhoi sganiwr iddynt</a> , a oedd yn yr achos penodol hwnnw wedi codi embaras ar yr awdurdod a gwneud iddynt  ddod o hyd i un oedd ganddynt eisoes.</p>
+  <p>Os nad yw hynny’n gweithio, a’ch bod am roi eich cyfeiriad post yn breifat er mwyn derbyn y dogfennau, nodwch ar eich cais fel "Maen nhw’n mynd i ymateb drwy’r post", a bydd yn rhoi cyfeiriad e-bost i ddefnyddio at y diben hwnnw.</p> </dd>
   <dt id="cwcis"> Beth am gwcis a gwasanaethau trydydd parti? <a href="#cookies">#</a> </dt>
   <dd>
   <p> <strong> Ein defnydd o gwcis a gwasanaethau allanol: yr hyn y dylech ei wybod, a sut i ddewis peidio os ydych eisiau. </strong> </p>
-  <p> Crynodeb: Rydym yn gofalu llawer am breifatrwydd ein defnyddwyr. Rydym yn darparu manylion isod, ac rydym yn gwneud ein anoddaf i ofalu am y data preifat sydd gennym. Fel llawer o wefannau eraill, rydym weithiau'n defnyddio cwcis a Google Analytics i'n helpu i wneud ein gwefannau yn well. Mae'r offer hyn yn gyffredin iawn ac yn defnyddio gan nifer o safleoedd eraill, ond mae ganddynt oblygiadau preifatrwydd, ac fel elusen sy'n ymwneud â defnyddiau cadarnhaol yn gymdeithasol o'r rhyngrwyd, rydym yn credu ei bod yn bwysig i esbonio iddynt yn llawn. Os nad ydych am rannu eich gweithgareddau pori ar safleoedd mySociety â chwmnïau eraill, gallwch addasu eich defnydd neu osod ategion porwr optio allan.</p>
+  <p> Crynodeb: Rydym yn gofalu llawer am breifatrwydd ein defnyddwyr. Rydym yn darparu manylion isod, ac rydym yn gwneud ein anoddaf i ofalu am y data preifat sydd gennym. Fel llawer o wefannau eraill, rydym weithiau’n defnyddio cwcis a Google Analytics i’n helpu i wneud ein gwefannau yn well. Mae’r offer hyn yn gyffredin iawn ac yn defnyddio gan nifer o safleoedd eraill, ond mae ganddynt oblygiadau preifatrwydd, ac fel elusen sy’n ymwneud â defnyddiau cadarnhaol yn gymdeithasol o’r rhyngrwyd, rydym yn credu ei bod yn bwysig i esbonio iddynt yn llawn. Os nad ydych am rannu eich gweithgareddau pori ar safleoedd mySociety â chwmnïau eraill, gallwch addasu eich defnydd neu osod ategion porwr optio allan.</p>
   <p> <strong> Cwcis </strong> </p>
-  <p> I wneud ein gwasanaeth yn haws neu'n fwy defnyddiol, rydym weithiau yn rhoi ffeiliau data bach ar eich cyfrifiadur neu ffôn symudol, a elwir yn 'cookies'; mae llawer o wefannau yn gwneud hyn. Rydym yn defnyddio'r wybodaeth hon i, er enghraifft, cofiwch eich bod wedi logio i mewn fel nad oes angen i chi wneud hynny ar bob tudalen, neu i fesur sut mae pobl yn defnyddio'r wefan fel y gallwn ei wella a sicrhau ei fod yn gweithio'n iawn. Isod, rydym yn rhestru'r cwcis a gwasanaethau y gall y safle hwn yn eu defnyddio.</p>
+  <p> I wneud ein gwasanaeth yn haws neu’n fwy defnyddiol, rydym weithiau yn rhoi ffeiliau data bach ar eich cyfrifiadur neu ffôn symudol, a elwir yn ’cookies’; mae llawer o wefannau yn gwneud hyn. Rydym yn defnyddio’r wybodaeth hon i, er enghraifft, cofiwch eich bod wedi logio i mewn fel nad oes angen i chi wneud hynny ar bob tudalen, neu i fesur sut mae pobl yn defnyddio’r wefan fel y gallwn ei wella a sicrhau ei fod yn gweithio’n iawn. Isod, rydym yn rhestru’r cwcis a gwasanaethau y gall y safle hwn yn eu defnyddio.</p>
   <table>
     <tr> <th scope="col"> Enw </th> <th scope="col"> Cynnwys nodweddiadol </th> <th scope="col"> Yn dod i ben </th> </tr>
-    <tr> <td> _wdtk_cookie_session </td> <td> Mae dynodwr unigryw ar hap </td> <td> Pryd porwr gwe ar gau, neu 1 mis os 'Cofiwch fi' yn cael ei ddefnyddio </td> </tr>
+    <tr> <td> _wdtk_cookie_session </td> <td> Mae dynodwr unigryw ar hap </td> <td> Pryd porwr gwe ar gau, neu 1 mis os ’Cofiwch fi’ yn cael ei ddefnyddio </td> </tr>
     <tr> <td> seen_foi2 </td> <td> The rhif 1 os ydych wedi gweld rhybudd </td> <td> 7 diwrnod </td> </tr>
-    <tr> <td> last_request_id </td> <td> Mae nifer, gan nodi'r cais Rhyddid Gwybodaeth diwethaf i chi edrych ar ar y safle </td> <td> Pryd porwr gwe ar gau </td> </tr>
-    <tr> <td> last_body_id </td> <td> Mae nifer, gan nodi'r awdurdod cyhoeddus diwethaf i chi edrych ar ar y safle </td> <td> Pryd porwr gwe ar gau </td> </tr>
+    <tr> <td> last_request_id </td> <td> Mae nifer, gan nodi’r cais Rhyddid Gwybodaeth diwethaf i chi edrych ar ar y safle </td> <td> Pryd porwr gwe ar gau </td> </tr>
+    <tr> <td> last_body_id </td> <td> Mae nifer, gan nodi’r awdurdod cyhoeddus diwethaf i chi edrych ar ar y safle </td> <td> Pryd porwr gwe ar gau </td> </tr>
   </table>
-  <p> <strong> Mesur defnydd o'r wefan (Google Analytics) </strong> </p>
+  <p> <strong> Mesur defnydd o’r wefan (Google Analytics) </strong> </p>
   <p>
-    Rydym yn defnyddio Google Analytics i gasglu gwybodaeth am sut mae pobl yn defnyddio'r safle hwn. Rydym yn gwneud hyn i wneud yn siŵr ei fod yn diwallu anghenion ei defnyddwyr 'ac i ddeall sut y gallwn wneud yn well. Mae Google Analytics yn storio gwybodaeth megis beth tudalennau rydych yn ymweld â, pa mor hir ydych chi ar y safle, sut y cawsoch yma, yr hyn yr ydych yn clicio ar, a gwybodaeth am eich porwr gwe. Cyfeiriadau IP yn cael eu cuddio (dim ond cyfran yn cael ei storio) a gwybodaeth bersonol yn unig yn cael ei adrodd gyda'i gilydd. Nid ydym yn caniatáu i Google i ddefnyddio neu rannu ein analytics data ar gyfer unrhyw ddiben ar wahân i roi gwybodaeth i ni analytics, ac rydym yn argymell bod unrhyw ddefnyddiwr o Google Analytics gwneud yr un peth.
+    Rydym yn defnyddio Google Analytics i gasglu gwybodaeth am sut mae pobl yn defnyddio’r safle hwn. Rydym yn gwneud hyn i wneud yn siŵr ei fod yn diwallu anghenion ei defnyddwyr ’ac i ddeall sut y gallwn wneud yn well. Mae Google Analytics yn storio gwybodaeth megis beth tudalennau rydych yn ymweld â, pa mor hir ydych chi ar y safle, sut y cawsoch yma, yr hyn yr ydych yn clicio ar, a gwybodaeth am eich porwr gwe. Cyfeiriadau IP yn cael eu cuddio (dim ond cyfran yn cael ei storio) a gwybodaeth bersonol yn unig yn cael ei adrodd gyda’i gilydd. Nid ydym yn caniatáu i Google i ddefnyddio neu rannu ein analytics data ar gyfer unrhyw ddiben ar wahân i roi gwybodaeth i ni analytics, ac rydym yn argymell bod unrhyw ddefnyddiwr o Google Analytics gwneud yr un peth.
   </p>
-  <p> Os ydych chi'n anhapus gyda data am eich ymweliad gael ei ddefnyddio yn y ffordd hon, gallwch osod y <a href="http://tools.google.com/dlpage/gaoptout"> ategyn porwr swyddogol ar gyfer blocio Google Analytics </a>.
-  <p> Mae'r cwcis a osodir gan Google Analytics fel a ganlyn:
+  <p> Os ydych chi’n anhapus gyda data am eich ymweliad gael ei ddefnyddio yn y ffordd hon, gallwch osod y <a href="http://tools.google.com/dlpage/gaoptout"> ategyn porwr swyddogol ar gyfer blocio Google Analytics </a>.
+  <p> Mae’r cwcis a osodir gan Google Analytics fel a ganlyn:
     <table>
       <tr> <th scope="col"> Enw </th> <th scope="col"> Cynnwys nodweddiadol </th> <th scope="col"> Yn dod i ben </th> </tr>
       <tr> <td> __ utma </td> <td> ID ymwelwyr dienw Unigryw </td> <td> 2 flynedd </td> </tr>
       <tr> <td> __ utmb </td> <td> Sesiwn ID Unigryw anhysbys </td> <td> 30 munud </td> </tr>
-      <tr> <td> __ utmz </td> <td> Gwybodaeth am sut mae'r safle yn cyrraedd (ee yn uniongyrchol neu drwy ddolen / chwilio / hysbyseb) </td> <td> 6 mis </td> </tr>
+      <tr> <td> __ utmz </td> <td> Gwybodaeth am sut mae’r safle yn cyrraedd (ee yn uniongyrchol neu drwy ddolen / chwilio / hysbyseb) </td> <td> 6 mis </td> </tr>
       <tr> <td> __ utmx </td> <td> Pa amrywiad o dudalen yr ydych yn gweld os ydym yn profi gwahanol fersiynau i weld pa un sydd orau </td> <td> 2 flynedd </td> </tr>
     </table>
     <h4> Google Datganiad Swyddogol am Analytics Data </h4>
-    <p> "Mae'r wefan hon yn defnyddio Google Analytics, gwasanaeth dadansoddi'r we a ddarperir gan Google, Inc. (" Google "). Google Analytics yn defnyddio "cwcis", sef ffeiliau testun a roddir ar eich cyfrifiadur, i helpu'r wefan i ddadansoddi sut mae defnyddwyr yn defnyddio'r safle. Bydd yr wybodaeth a gynhyrchir gan y cwci am eich defnydd o'r wefan (gan gynnwys eich cyfeiriad IP) yn cael ei throsglwyddo i ac yn storio gan Google ar weinyddion yn yr Unol Daleithiau. Bydd Google yn defnyddio'r wybodaeth hon at ddibenion gwerthuso eich defnydd o'r wefan, llunio adroddiadau ar weithgaredd gwefan ar gyfer gweithredwyr gwefan a darparu gwasanaethau eraill yn ymwneud â gweithgaredd gwefan a defnydd o'r rhyngrwyd. Gall Google hefyd drosglwyddo'r wybodaeth hon i drydydd parti pan ofynnir iddo wneud hynny yn ôl y gyfraith, neu lle mae trydydd partïon o'r fath yn prosesu'r wybodaeth ar ran Google. Ni fydd Google yn cysylltu eich cyfeiriad IP ag unrhyw ddata arall a gedwir gan Google. Efallai y byddwch yn gwrthod defnyddio cwcis drwy ddewis y gosodiadau priodol ar eich porwr, fodd bynnag, sylwer, os byddwch yn gwneud hyn efallai na fyddwch yn gallu defnyddio'r swyddogaeth lawn y wefan hon. Drwy ddefnyddio'r wefan hon, rydych yn rhoi caniatâd i brosesu data amdanoch chi gan Google yn y modd ac i'r dibenion a nodir uchod. "</p>
+    <p> "Mae’r wefan hon yn defnyddio Google Analytics, gwasanaeth dadansoddi’r we a ddarperir gan Google, Inc. (" Google "). Google Analytics yn defnyddio "cwcis", sef ffeiliau testun a roddir ar eich cyfrifiadur, i helpu’r wefan i ddadansoddi sut mae defnyddwyr yn defnyddio’r safle. Bydd yr wybodaeth a gynhyrchir gan y cwci am eich defnydd o’r wefan (gan gynnwys eich cyfeiriad IP) yn cael ei throsglwyddo i ac yn storio gan Google ar weinyddion yn yr Unol Daleithiau. Bydd Google yn defnyddio’r wybodaeth hon at ddibenion gwerthuso eich defnydd o’r wefan, llunio adroddiadau ar weithgaredd gwefan ar gyfer gweithredwyr gwefan a darparu gwasanaethau eraill yn ymwneud â gweithgaredd gwefan a defnydd o’r rhyngrwyd. Gall Google hefyd drosglwyddo’r wybodaeth hon i drydydd parti pan ofynnir iddo wneud hynny yn ôl y gyfraith, neu lle mae trydydd partïon o’r fath yn prosesu’r wybodaeth ar ran Google. Ni fydd Google yn cysylltu eich cyfeiriad IP ag unrhyw ddata arall a gedwir gan Google. Efallai y byddwch yn gwrthod defnyddio cwcis drwy ddewis y gosodiadau priodol ar eich porwr, fodd bynnag, sylwer, os byddwch yn gwneud hyn efallai na fyddwch yn gallu defnyddio’r swyddogaeth lawn y wefan hon. Drwy ddefnyddio’r wefan hon, rydych yn rhoi caniatâd i brosesu data amdanoch chi gan Google yn y modd ac i’r dibenion a nodir uchod. "</p>
     <p> <a href="https://www.mysociety.org/privacy/?utm_source=whatdotheyknow.com&utm_medium=link"> gwybodaeth fwy cyffredinol ar sut trydydd parti gwasanaethau gwaith </a> </p>
     <p> <strong> Ein logio hun </strong> </p>
-    <p> Yn ychwanegol at y wybodaeth a roddwch i ni amdanoch eich hun er mwyn defnyddio'r safle (ee eich enw
+    <p> Yn ychwanegol at y wybodaeth a roddwch i ni amdanoch eich hun er mwyn defnyddio’r safle (ee eich enw
       a chyfeiriad e-bost), rydym yn casglu a chofnodi gwybodaeth ychwanegol er mwyn dadansoddi a atgyweiria broblemau
-      gyda'r safle. Mae ein logiau gweinydd gwe yn cadw hanes o geisiadau dudalen. Mae hyn yn cynnwys gwybodaeth am
+      gyda’r safle. Mae ein logiau gweinydd gwe yn cadw hanes o geisiadau dudalen. Mae hyn yn cynnwys gwybodaeth am
       ceisiadau, gan gynnwys y cyfeiriad IP cleient, data a gyflwynwyd (a allai gynnwys eich cyfeiriad e-bost pan fydd
       fyddwch yn mewngofnodi ar y safle), dyddiad cais ac amser, tudalen y gofynnwyd amdani, fersiwn porwr a
-      <a href="https://en.wikipedia.org/wiki/HTTP_referer"> </a> cyfeiriwr. Rydym fel mater o drefn yn cadw'r wybodaeth hon
+      <a href="https://en.wikipedia.org/wiki/HTTP_referer"> </a> cyfeiriwr. Rydym fel mater o drefn yn cadw’r wybodaeth hon
       am 28 diwrnod.
     </p>
     <p> <strong> Credydau </strong> </p>
-    <p> darnau o eiriad a gymerwyd o'r <a href="http://gov.uk/help/cookies"> gov.uk dudalen cwcis </a> (o dan y Drwydded Llywodraeth Agored).
+    <p> darnau o eiriad a gymerwyd o’r <a href="http://gov.uk/help/cookies"> gov.uk dudalen cwcis </a> (o dan y Drwydded Llywodraeth Agored).
     </dd>
     <dt id="delete_requests">Allwch chi ddileu fy ngheisiadau, neu newid fy enw? <a href="#delete_requests">#</a> </dt>
     <dd>
-    <p>Mae WhatDoTheyKnow yn archif barhaol, gyhoeddus o geisiadau Rhyddid Gwybodaeth. Er efallai na fyddwch bellach yn gweld defnydd i'r ateb gawsoch i gais, gallai fod o ddiddordeb i eraill. Am y rheswm hwn, ni fyddwn yn dileu ceisiadau. </p>
-    <p>O dan amgylchiadau eithriadol efallai y byddwn yn tynnu neu'n newid eich enw ar y wefan, <a href="#takedown">gweler y cwestiwn nesaf</a>. Yn yr un modd, efallai y byddwn hefyd yn dileu gwybodaeth bersonol arall. </p>
+    <p>Mae WhatDoTheyKnow yn archif barhaol, gyhoeddus o geisiadau Rhyddid Gwybodaeth. Er efallai na fyddwch bellach yn gweld defnydd i’r ateb gawsoch i gais, gallai fod o ddiddordeb i eraill. Am y rheswm hwn, ni fyddwn yn dileu ceisiadau. </p>
+    <p>O dan amgylchiadau eithriadol efallai y byddwn yn tynnu neu’n newid eich enw ar y wefan, <a href="#takedown">gweler y cwestiwn nesaf</a>. Yn yr un modd, efallai y byddwn hefyd yn dileu gwybodaeth bersonol arall. </p>
     <p>Os ydych yn poeni am hyn cyn i chi wneud eich cais, gweler yr adran ar <a href="#real_name">ffugenwau</a> .</p> </dd>
     <dt id="takedown">A fedrwch chi dynnu gwybodaeth bersonol amdanaf? <a href="#takedown">#</a> </dt>
     <dd>
-    <p>Os gwelwch unrhyw wybodaeth bersonol amdanoch chi ar y wefan yr hoffech i ni dtynnu neu guddio, yna rhowch <a href="<%= help_contact_path %>">wybod i ni</a> . Nodwch yn union pa wybodaeth yr ydych yn credu sy'n broblem a pham, a lle y mae'n ymddangos ar y wefan.</p>
-    <p>Os yw'n wybodaeth bersonol sensitif sydd wedi cael ei phostio ar ddamwain, yna byddwn fel arfer yn ei dileu. Fel arfer, ni fyddwn ond yn ystyried ceisiadau i gael gwared ar wybodaeth bersonol a ddaw oddi wrth yr unigolyn dan sylw, ond am wybodaeth sensitif byddem yn gwerthfawrogi pe bai unrhyw un yn tynnu ein sylw ati.</p>
+    <p>Os gwelwch unrhyw wybodaeth bersonol amdanoch chi ar y wefan yr hoffech i ni dtynnu neu guddio, yna rhowch <a href="<%= help_contact_path %>">wybod i ni</a> . Nodwch yn union pa wybodaeth yr ydych yn credu sy’n broblem a pham, a lle y mae’n ymddangos ar y wefan.</p>
+    <p>Os yw’n wybodaeth bersonol sensitif sydd wedi cael ei phostio ar ddamwain, yna byddwn fel arfer yn ei dileu. Fel arfer, ni fyddwn ond yn ystyried ceisiadau i gael gwared ar wybodaeth bersonol a ddaw oddi wrth yr unigolyn dan sylw, ond am wybodaeth sensitif byddem yn gwerthfawrogi pe bai unrhyw un yn tynnu ein sylw ati.</p>
     <p>Mae gennych hawl o dan <a
     href="http://www.legislation.gov.uk/ukpga/1998/29/section/10">adran 10 y Ddeddf Ddiogelu Data</a>
     i ofyn i ni ddileu eich gwybodaeth bersonol ar y sail ei bod yn achosi difrod neu ofid sylweddol a
-    diangen i chi. Byddwn ni'n ystyried unrhyw hysbysiad o'r fath, nad oes rhaid iddo'n sôn yn benodol
-    am y Ddeddf, ac yn ei gydbwyso yn erbyn unrhyw fudd a ddeuai i'r cyhoedd o gyhoeddi'r deunydd.
+    diangen i chi. Byddwn ni’n ystyried unrhyw hysbysiad o’r fath, nad oes rhaid iddo’n sôn yn benodol
+    am y Ddeddf, ac yn ei gydbwyso yn erbyn unrhyw fudd a ddeuai i’r cyhoedd o gyhoeddi’r deunydd.
     Ceir peth arweiniad ar yr hysbysiadau hyn <a
       href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/damage-or-distress/">
     ar wefan y ICO</a>.
     </dd>
     <dt id="public_servant_takedown">Rwy&rsquo;n was cyhoeddus - a fedrwch dynnu gwybodaeth bersonol amdanaf i? <a href="#public_servant_takedown">#</a></dt>
     <dd>
-    <p>Er bod gennym ragdybiaeth gyffredinol ei bod yn well fod yn fwy agored, byddwn yn ystyried ceisiadau i gael gwared ar enwau gweision cyhoeddus pan mae'n ymddangos yn annhebygol y bydd budd y cyhoedd yn cael ei niweidio drwy wneud hynny.</p>
+    <p>Er bod gennym ragdybiaeth gyffredinol ei bod yn well fod yn fwy agored, byddwn yn ystyried ceisiadau i gael gwared ar enwau gweision cyhoeddus pan mae’n ymddangos yn annhebygol y bydd budd y cyhoedd yn cael ei niweidio drwy wneud hynny.</p>
     <p>Mae hyn yn golygu:
       <ul>
-        <li>Os ydych yn rhywun sy'n gwneud penderfyniadau ac yn rhyw fath o radd uchel, neu os ydych yn ymateb i gais Rhyddid Gwybodaeth, ni fyddwn fel rheol yn tynnu eich manylion o ddogfennau ac e-byst a anfonwyd gan gorff cyhoeddus. Mae atebolrwydd y broses o wneud penderfyniad wrth wraidd llywodraethu da.</li>
-        <li>Os ydych yn dal swydd gradd isel, lle na gymerir penderfyniadau, byddwn yn ystyried ceisiadau i ddileu eich manylion. Mae cael gwared ar y manylion hyn yn anodd i'n gwirfoddolwyr ei wneud, felly rhowch wybod i ni pam mae hyn yn wirioneddol bwysig i chi. Os byddwn yn cytuno i gael gwared ar eich manylion byddwn yn cymryd camau rhesymol i wneud hynny, ond mewn rhai achosion efallai na fyddwn yn gallu am resymau technegol.</li>
+        <li>Os ydych yn rhywun sy’n gwneud penderfyniadau ac yn rhyw fath o radd uchel, neu os ydych yn ymateb i gais Rhyddid Gwybodaeth, ni fyddwn fel rheol yn tynnu eich manylion o ddogfennau ac e-byst a anfonwyd gan gorff cyhoeddus. Mae atebolrwydd y broses o wneud penderfyniad wrth wraidd llywodraethu da.</li>
+        <li>Os ydych yn dal swydd gradd isel, lle na gymerir penderfyniadau, byddwn yn ystyried ceisiadau i ddileu eich manylion. Mae cael gwared ar y manylion hyn yn anodd i’n gwirfoddolwyr ei wneud, felly rhowch wybod i ni pam mae hyn yn wirioneddol bwysig i chi. Os byddwn yn cytuno i gael gwared ar eich manylion byddwn yn cymryd camau rhesymol i wneud hynny, ond mewn rhai achosion efallai na fyddwn yn gallu am resymau technegol.</li>
       </ul>
     </p>
     </dd>
   </dl>
-  <p><strong>Dysgwch fwy</strong> o'r cymorth i <a href="<%= help_officers_path %>">swyddogion Rhyddid Gwybodaeth</a> -&gt;
+  <p><strong>Dysgwch fwy</strong> o’r cymorth i <a href="<%= help_officers_path %>">swyddogion Rhyddid Gwybodaeth</a> -&gt;
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -7,7 +7,7 @@
     WhatDoTheyKnow is run by the charity mySociety.
   </p>
   <p>
-    For full details of mySociety's structure, governance, and details of the
+    For full details of mySociety’s structure, governance, and details of the
     relevant registrations with the Information Commissioner and The Charity
     Commission see: <a href="https://www.whatdotheyknow.com/help/about#who">Who
     makes WhatDoTheyKnow?</a>.
@@ -572,10 +572,10 @@
     duplicate requesting.
   </p>
   <p>
-    We believe that our processing of our users' data is as they would expect
+    We believe that our processing of our users’ data is as they would expect
     when they use our service. If you use WhatDoTheyKnow to make a FOI request,
     you are consenting to your data being processed as described on this page.
-    We make clear how we handle users' data, and link to this page, at
+    We make clear how we handle users’ data, and link to this page, at
     appropriate places within our service, including during the process of
     signing up, and making a request.
   </p>
@@ -837,7 +837,7 @@
     </tr>
     <tr>
       <td>widget_vote</td><td>A random identifier for an ‛I also want to
-      know’ vote you've made for a request</td><td>When web browser is closed
+      know’ vote you’ve made for a request</td><td>When web browser is closed
       </td>
     </tr>
   </table>
@@ -921,7 +921,7 @@
   <p>
     We keep our privacy policy under review, and may make changes from time to
     time to ensure that it remains up-to-date and accurate. You can find a
-    synopsis of changes we've made at our
+    synopsis of changes we’ve made at our
     <a href="https://git.io/JU14r" alt="Link to version history for WhatDoTheyKnow Privacy notice (hosted on GitHub)">GitHub repository</a>,
     but if you have any questions, please do
     <%= link_to 'contact us', help_contact_path %>.

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -5,25 +5,25 @@
   <dl>
     <dt id="which_authority">Dydw i ddim yn siŵr i ba awdurdod i wneud cais, sut y gallaf gael gwybod? <a href="#which_authority">#</a> </dt>
     <dd>
-    <p>Gall fod yn anodd deall strwythur cymhleth y llywodraeth, a gweithio allan pwy sy'n gwybod
+    <p>Gall fod yn anodd deall strwythur cymhleth y llywodraeth, a gweithio allan pwy sy’n gwybod
     y wybodaeth yr ydych ei heisiau. Dyma rai awgrymiadau:</p>
     <ul>
-      <li>Pori neu chwilio WhatDoTheyKnow gan chwilio am geisiadau tebyg i'ch un chi.</li>
-      <li>Pan fyddwch wedi dod o hyd i awdurdod y credwch y gallai fod ganddo'r wybodaeth, defnyddiwch
+      <li>Pori neu chwilio WhatDoTheyKnow gan chwilio am geisiadau tebyg i’ch un chi.</li>
+      <li>Pan fyddwch wedi dod o hyd i awdurdod y credwch y gallai fod ganddo’r wybodaeth, defnyddiwch
       ddolen y "dudalen gartref" ar ochr dde eu dudalen i weld yr hyn y maent yn ei wneud ar eu gwefan.</li>
-      <li>Cysylltwch â'r awdurdod dros y ffôn neu e-bost i ofyn a ydynt yn dal y math o
+      <li>Cysylltwch â’r awdurdod dros y ffôn neu e-bost i ofyn a ydynt yn dal y math o
       wybodaeth yr hoffech ei chael.</li>
-      <li>Peidiwch â phoeni'n ormodol am gael yr awdurdod cywir. Os ydych yn ei gael yn anghywir, dylent eich
+      <li>Peidiwch â phoeni’n ormodol am gael yr awdurdod cywir. Os ydych yn ei gael yn anghywir, dylent eich
         cynghori chi i bwy y dylech wneud y cais yn lle.
       </li>
       <li>Os oes gennych achos dyrys, cysylltwch <a href="<%= help_contact_path %>">â ni</a> am gymorth.</li>
     </ul>
     </dd>
-    <dt id="missing_body">Does gennych chi mo'r awdurdod cyhoeddus yr wyf am
+    <dt id="missing_body">Does gennych chi mo’r awdurdod cyhoeddus yr wyf am
     wneud cais iddo! <a href="#missing_body">#</a> </dt>
     <dd>
     <p>
-      Cysylltwch <a href="<%= new_change_request_path %>">â ni</a> gydag enw'r awdurdod cyhoeddus ac,
+      Cysylltwch <a href="<%= new_change_request_path %>">â ni</a> gydag enw’r awdurdod cyhoeddus ac,
       os gallwch ddod o hyd ddo, eu cyswllt cyfeiriad e-bost ar gyfer ceisiadau Rhyddid Gwybodaeth.
     </p>
     <p>
@@ -32,30 +32,30 @@
     </p>
     </dd>
     <dt id="authorities">Pam eich bod yn cynnwys rhai awdurdodau nad ydynt yn ffurfiol
-    yn ddarostyngedig i'r Ddeddf Rhyddid Gwybodaeth?<a href="#authorities">#</a> </dt>
+    yn ddarostyngedig i’r Ddeddf Rhyddid Gwybodaeth?<a href="#authorities">#</a> </dt>
     <dd>
     <p>Mae WhatDoTheyKnow yn gadael i chi wneud ceisiadau am wybodaeth i ystod o
     sefydliadau:</p>
     <ul>
-      <li> Rhai sy'n ddarostyngedig yn ffurfiol i'r Ddeddf Rhyddid Gwybodaeth</li>
-      <li> Rhai sy'n ddarostyngedig yn ffurfiol i'r Rheoliadau Amgylcheddol (grŵp
+      <li> Rhai sy’n ddarostyngedig yn ffurfiol i’r Ddeddf Rhyddid Gwybodaeth</li>
+      <li> Rhai sy’n ddarostyngedig yn ffurfiol i’r Rheoliadau Amgylcheddol (grŵp
       nad yw wedi ei ddiffinio cystal)</li>
-      <li> Rhai sy'n cydymffurfio'n wirfoddol â'r Ddeddf Rhyddid Gwybodaeth</li>
-      <li> Rhai nad ydynt yn ddarostyngedig i'r Ddeddf, ond rydym yn meddwl y dylent
+      <li> Rhai sy’n cydymffurfio’n wirfoddol â’r Ddeddf Rhyddid Gwybodaeth</li>
+      <li> Rhai nad ydynt yn ddarostyngedig i’r Ddeddf, ond rydym yn meddwl y dylent
         fod, ar y sail fod ganddynt gyfrifoldebau cyhoeddus sylweddol
       </li>
     </ul>
-    <p>Yn yr achos olaf, rydym yn defnyddio'r safle i lobio am ehangu cwmpas y
+    <p>Yn yr achos olaf, rydym yn defnyddio’r safle i lobio am ehangu cwmpas y
       Ddeddf Rhyddid Gwybodaeth. Hyd yn oed os nad yw sefydliad yn rhwym yn gyfreithiol
-      i ymateb i gais Rhyddid Gwybodaeth, gallant wneud hynny'n wirfoddol.
+      i ymateb i gais Rhyddid Gwybodaeth, gallant wneud hynny’n wirfoddol.
     </p>
     </dd>
-    <dt id="focused">Pam mae'n rhaid i mi gadw fy nghais yn gryno? <a href="#focused">#</a> </dt>
+    <dt id="focused">Pam mae’n rhaid i mi gadw fy nghais yn gryno? <a href="#focused">#</a> </dt>
     <dd>
     <p>
       Dim ond yr hyn sydd ei angen ddylai fod yn eich cais fel y gall rhywun ddeall
       yn hawdd pa wybodaeth rydych yn gofyn amdani. <i>Peidiwch</i> â chynnwys unrhyw
-      un o'r canlynol:
+      un o’r canlynol:
     </p>
     <ul>
       <li>dadleuon am eich achos</li>
@@ -65,80 +65,80 @@
       Os byddwch yn gwneud hyn, efallai y bydd yn rhaid i ni dynnu eich cais er mwyn
       osgoi problemau gyda chyfraith enllib sydd yn boen i chi ac i ni. Mae negeseuon
       byr cryno yn ei wneud yn haws i awdurdodau dddeall yn glir pa wybodaeth rydych
-      yn gofyn amdani, sy'n golygu y byddwch yn cael ateb yn gynt.
+      yn gofyn amdani, sy’n golygu y byddwch yn cael ateb yn gynt.
     </p>
     <p>Os ydych am wybodaeth i gefnogi dadl neu ymgyrch, mae Rhyddid Gwybodaeth yn
-      arf pwerus. Er na chewch ddefnyddio'r wefan hon i redeg eich ymgyrch, rydym yn
-      eich annog i'w defnyddio i gael y wybodaeth rydych ei hangen. Rydym hefyd yn
+      arf pwerus. Er na chewch ddefnyddio’r wefan hon i redeg eich ymgyrch, rydym yn
+      eich annog i’w defnyddio i gael y wybodaeth rydych ei hangen. Rydym hefyd yn
       eich annog i redeg eich ymgyrch yn rhywle arall - un ffordd effeithiol a hawdd
       iawn yw i chi <%= link_to 'ddechrau eich blog eich hun', "http://cy.wordpress.com/"%>.
-      Mae croeso i chi greu cysylltiad â'ch ymgyrch o'r wefan hon mewn nodyn i'ch
-      cais (gallwch wneud nodiadau ar ôl cyflwyno'r cais).
+      Mae croeso i chi greu cysylltiad â’ch ymgyrch o’r wefan hon mewn nodyn i’ch
+      cais (gallwch wneud nodiadau ar ôl cyflwyno’r cais).
     </p>
     </dd>
-    <dt id="fees">Ydy'n costio i mi wneud cais? <a href="#fees">#</a> </dt>
+    <dt id="fees">Ydy’n costio i mi wneud cais? <a href="#fees">#</a> </dt>
     <dd>
     <p>Mae gwneud cais Rhyddid Gwybodaeth bron bob amser yn rhad ac am ddim.</p>
-    <p>Bydd awdurdodau'n aml yn cynnwys llith ddiangen, frawychus, wrth gydnabod
-      negeseuon yn dweud y "gallent" godi ffi. Anwybyddwch rybuddion o'r fath. Ni
+    <p>Bydd awdurdodau’n aml yn cynnwys llith ddiangen, frawychus, wrth gydnabod
+      negeseuon yn dweud y "gallent" godi ffi. Anwybyddwch rybuddion o’r fath. Ni
       fyddant bron byth mewn gwirionedd yn codi ffi. Os byddant yn codi ffi, dim ond
-      os ydych wedi cytuno'n benodol ymlaen llaw i dalu y gallant godi tâl arnoch.
+      os ydych wedi cytuno’n benodol ymlaen llaw i dalu y gallant godi tâl arnoch.
       <a
       href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#15">Rhagor o fanylion</a>
     gan y Comisiynydd Gwybodaeth.</p>
     <p>Weithiau bydd awdurdod yn gwrthod eich cais, gan ddweud bod y gost o
       drin yn fwy na £600 (ar gyfer llywodraeth ganolog) neu £450 (ar gyfer pob
       awdurdod cyhoeddus arall). Yn y fan hon, gallwch fireinio eich cais. e.e.
-      byddai'n llawer rhatach i awdurdod ddweud wrthych y swm a wariwyd ar malws
+      byddai’n llawer rhatach i awdurdod ddweud wrthych y swm a wariwyd ar malws
     melys y llynedd nag yn y deng mlynedd diwethaf.</p>
     </dd>
     <dt id="quickly_response">Pa mor gyflym y caf ymateb? <a href="#quickly_response">#</a> </dt>
     <dd>
-    <p>Yn ôl y gyfraith, mae'n rhaid i awdurdodau cyhoeddus ymateb yn <strong>brydlon</strong>} i geisiadau.
+    <p>Yn ôl y gyfraith, mae’n rhaid i awdurdodau cyhoeddus ymateb yn <strong>brydlon</strong>} i geisiadau.
     </p>
     <p>Hyd yn oed os nad ydynt yn brydlon, ym mron pob achos, rhaid iddynt ymateb
       o fewn 20 diwrnod gwaith. Os oedd rhaid i chi egluro eich cais, neu os oeddech
-      wedi gofyn i ysgol, ac mewn achos neu ddau arall, yna mae'n bosibl y cânt fwy
+      wedi gofyn i ysgol, ac mewn achos neu ddau arall, yna mae’n bosibl y cânt fwy
       o amser (<a href="<%= help_officers_path(:anchor => 'days') %>">manylion llawn</a>).
     </p>
     <p>Bydd WhatDoTheyKnow yn anfon e-bost atoch os nad ydych yn cael ymateb amserol.
-      Yna, gallwch anfon at yr awdurdod cyhoeddus neges i'w hatgoffa, ac yn dweud
-    wrthynt os ydynt yn torri'r gyfraith.</p>
+      Yna, gallwch anfon at yr awdurdod cyhoeddus neges i’w hatgoffa, ac yn dweud
+    wrthynt os ydynt yn torri’r gyfraith.</p>
     </dd>
     <dt id="no_response">Beth os na fyddaf byth yn cael ymateb?<a href="#no_response">#</a> </dt>
     <dd>
     <p>Mae nifer o bethau y gallwch eu gwneud os ydych byth yn cael ymateb.</p>
     <ul>
-      <li>Weithiau, mae problem go iawn wedi digwydd  ac nid yw'r awdurdod erioed
-        wedi derbyn y cais. Mae'n werth ffonio'r awdurdod a gwirio'n gwrtais eu bod
+      <li>Weithiau, mae problem go iawn wedi digwydd  ac nid yw’r awdurdod erioed
+        wedi derbyn y cais. Mae’n werth ffonio’r awdurdod a gwirio’n gwrtais eu bod
         wedi derbyn y cais. Cafodd ei anfon atynt drwy e-bost.
       </li>
       <li>Os nad ydynt wedi ei dderbyn, mwy na thebyg "hidlyddion sbam" fydd achos
         y broblem. Cyfeiriwch yr awdurdod at y mesurau yn yr ateb
-        '<a href="<%= help_officers_path(:anchor => 'spam_problems') %>">gallaf weld cais ar WhatDoTheyKnow, ond
-        chawsom ni mohono erioed drwy e-bost!</a>' yn yr adran i swyddogion rhyddid
+        ’<a href="<%= help_officers_path(:anchor => 'spam_problems') %>">gallaf weld cais ar WhatDoTheyKnow, ond
+        chawsom ni mohono erioed drwy e-bost!</a>’ yn yr adran i swyddogion rhyddid
       gwybodaeth yn yr adran help hon.</li>
-      <li>Os ydych chi'n dal heb unrhyw lwc, yna gallwch ofyn am adolygiad mewnol,
-        ac yna gwyno i'r Comisiynydd Gwybodaeth am yr awdurdod. Darllenwch
-        '<a href="<%= help_general_path(:template => 'unhappy') %>">ein tudalen Anhapus ynghylch yr ymateb a gawsoch?</a>'.
+      <li>Os ydych chi’n dal heb unrhyw lwc, yna gallwch ofyn am adolygiad mewnol,
+        ac yna gwyno i’r Comisiynydd Gwybodaeth am yr awdurdod. Darllenwch
+        ’<a href="<%= help_general_path(:template => 'unhappy') %>">ein tudalen Anhapus ynghylch yr ymateb a gawsoch?</a>’.
       </li>
     </ul>
     </dd>
-    <dt id="not_satifised">Beth os nad wyf yn fodlon ā'r ymateb? <a href="#not_satifised">#</a> </dt>
+    <dt id="not_satifised">Beth os nad wyf yn fodlon ā’r ymateb? <a href="#not_satifised">#</a> </dt>
     <dd>
     <p>Os na chawsoch y wybodaeth y gofynnoch amdani, neu os na dderbynioch chi
-      hi mewn pryd, yna darllenwch ein tudalen '<a href="<%= help_general_path(:template => 'unhappy') %>">Anhapus ynghylch yr ymateb a gawsoch?</a>'.
+      hi mewn pryd, yna darllenwch ein tudalen ’<a href="<%= help_general_path(:template => 'unhappy') %>">Anhapus ynghylch yr ymateb a gawsoch?</a>’.
     </p>
     </dd>
-    <dt id="reuse">Mae'n dweud na chaf i ddim ail-ddefnyddio'r wybodaeth a gefais! <a href="#reuse">#</a> </dt>
+    <dt id="reuse">Mae’n dweud na chaf i ddim ail-ddefnyddio’r wybodaeth a gefais! <a href="#reuse">#</a> </dt>
     <dd>
     <p>Bydd awdurdodau yn aml yn ychwanegu llith gyfreithiol
       am "<a href="http://www.legislation.gov.uk/uksi/2005/1515/contents/made">Reoliadau
       Ail-Defnyddio Gwybodaeth y Sector Cyhoeddus 2005</a>", sydd ar yr olwg gyntaf
-    yn awgrymu efallai na chewch chi wneud dim â'r wybodaeth.</p>
+    yn awgrymu efallai na chewch chi wneud dim â’r wybodaeth.</p>
     <p>Fe gewch chi, wrth gwrs, ysgrifennu erthyglau am yr wybodaeth neu ei
       chrynhoi, neu dyfynnu rhannau ohoni. Rydym hefyd yn meddwl y dylech chi
-      deimlo'n rhydd i ailgyhoeddi'r wybodaeth yn llawn, yn union fel rydym yn ei
+      deimlo’n rhydd i ailgyhoeddi’r wybodaeth yn llawn, yn union fel rydym yn ei
       wneud, er mewn damcaniaeth efallai na fydd caniatâd gennych i wneud hynny.
       Gweler <a href="<%= help_officers_path(:anchor => 'copyright') %>">ein polisi ar hawlfraint</a>.
     </p>
@@ -147,29 +147,29 @@
     <dd>
     <p>Edrychwch ar dudalennau  <a href="https://ico.org.uk/for-the-public/official-information/">mynediad
     i wybodaeth swyddogol</a> ar wefan y Comisiynydd Gwybodaeth.</p>
-    <p>Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus yn yr Alban, mae'r broses yn debyg iawn. Mae gwahaniaethau o gwmpas y terfynau amser ar gyfer cydymffurfio. Gweler <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">canllawiau  Comisiynydd Gwybodaeth yr Alban</a> am fanylion.</p>
+    <p>Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus yn yr Alban, mae’r broses yn debyg iawn. Mae gwahaniaethau o gwmpas y terfynau amser ar gyfer cydymffurfio. Gweler <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">canllawiau  Comisiynydd Gwybodaeth yr Alban</a> am fanylion.</p>
     </dd>
     <dt id="data_protection">A gaf i wneud cais am wybodaeth amdanaf fi fy hun? <a href="#data_protection">#</a> </dt>
     <dd>
-    <p>Na chewch. Mae ceisiadau sy'n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu gwneudd o dan y Ddeddf Rhyddid Gwybodaeth, ac ni allant eich helpu i ddod o hyd i wybodaeth am unigolyn preifat.</p>
-    <p>Os hoffech wybod pa wybodaeth y mae awdurdod cyhoeddus yn ei chadw amdanoch chi eich hun, dylech wneud &quot;Cais Gwrthrych am Wybodaeth&quot; yn breifat gan ddefnyddio gyfraith Diogelu Data. Mae'r daflen &quot; <a href="http://www.ico.org.uk/upload/documents/library/data_protection/introductory/subject_access_rights.pdf">Sut i gael mynediad at eich gwybodaeth</a> &quot;(ar wefan y Comisiynydd Gwybodaeth) yn esbonio sut i wneud hyn.</p>
+    <p>Na chewch. Mae ceisiadau sy’n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu gwneudd o dan y Ddeddf Rhyddid Gwybodaeth, ac ni allant eich helpu i ddod o hyd i wybodaeth am unigolyn preifat.</p>
+    <p>Os hoffech wybod pa wybodaeth y mae awdurdod cyhoeddus yn ei chadw amdanoch chi eich hun, dylech wneud &quot;Cais Gwrthrych am Wybodaeth&quot; yn breifat gan ddefnyddio gyfraith Diogelu Data. Mae’r daflen &quot; <a href="http://www.ico.org.uk/upload/documents/library/data_protection/introductory/subject_access_rights.pdf">Sut i gael mynediad at eich gwybodaeth</a> &quot;(ar wefan y Comisiynydd Gwybodaeth) yn esbonio sut i wneud hyn.</p>
     <p>Os byddwch yn gweld fod rhywun wedi cynnwys gwybodaeth bersonol, yn ddiarwybod o bosibl, mewn cais, <a href="<%= help_contact_path %>">cysylltwch â ni</a> ar unwaith er mwyn i ni ei symud.</p> </dd>
     <dt id="private_requests">Hoffwn gadw fy nghais yn gyfrinachol! (O leiaf nes i mi gyhoeddi fy stori) <a href="#private_requests">#</a> </dt>
     <dd>
     <p>Mae WhatDoTheyKnow wedi ei chynllunio ar hyn o bryd yn unig ar gyfer ceisiadau cyhoeddus. Cyhoeddir yr holl ymatebion a dderbyniwn yn awtomatig ar y wefan i unrhyw un eu darllen. </p>
-    <p>Dylech gysylltu â'r awdurdod cyhoeddus yn uniongyrchol os hoffech wneud cais yn breifat. Os oes gennych ddiddordeb mewn prynu system sy'n eich helpu i reoli ceisiadau Rhyddid Gwybodaeth yn y dirgel, ac yna <a href="<%= help_contact_path %>">cysylltwch â ni</a> . </p> </dd>
+    <p>Dylech gysylltu â’r awdurdod cyhoeddus yn uniongyrchol os hoffech wneud cais yn breifat. Os oes gennych ddiddordeb mewn prynu system sy’n eich helpu i reoli ceisiadau Rhyddid Gwybodaeth yn y dirgel, ac yna <a href="<%= help_contact_path %>">cysylltwch â ni</a> . </p> </dd>
     <dt id="eir">Pam dim ond gwybodaeth am yr amgylchedd y gallaf ofyn amdani gan rai awdurdodau? <a href="#eir">#</a> </dt>
     <dd>
     <p>Mae rhai awdurdodau cyhoeddus, megis <a href="http://www.whatdotheyknow.com/body/milford_haven_port_authority">Milford Haven Port Authority</a>, nad ydynt yn dod o dan y Ddeddf Rhyddid Gwybodaeth, ond yn dod o dan ddeddf arall, sef y Rheoliadau Gwybodaeth Amgylcheddol (EIR). </p>
-    <p>Mae'n gyfraith debyg iawn, ac fe wnewch gais iddynt gan ddefnyddio WhatDoTheyKnow yn union yr un ffordd â chais Rhyddid Gwybodaeth. Yr unig wahaniaeth yw y cewch eich atgoffa ar y dudalen lle byddwch yn ysgrifennu eich cais mai dim ond am &quot;wybodaeth amgylcheddol&quot; y cewch ofyn ac mae'n dweud wrthych beth mae hynny'n ei olygu. Mae'n eithaf eang. </p>
-    <p>Gallwch, wrth gwrs, wneud cais am wybodaeth amgylcheddol gan awdurdodau eraill. Gwnewch gais Rhyddid Gwybodaeth (FOI) fel arfer. Mae'n ddyletswydd ar yr awdurdod i weithio allan ai'r Rheoliadau Gwybodaeth Amgylcheddol (EIR) yw'r ddeddfwriaeth fwyaf priodol iddynt ymateb o dani. </p> </dd>
+    <p>Mae’n gyfraith debyg iawn, ac fe wnewch gais iddynt gan ddefnyddio WhatDoTheyKnow yn union yr un ffordd â chais Rhyddid Gwybodaeth. Yr unig wahaniaeth yw y cewch eich atgoffa ar y dudalen lle byddwch yn ysgrifennu eich cais mai dim ond am &quot;wybodaeth amgylcheddol&quot; y cewch ofyn ac mae’n dweud wrthych beth mae hynny’n ei olygu. Mae’n eithaf eang. </p>
+    <p>Gallwch, wrth gwrs, wneud cais am wybodaeth amgylcheddol gan awdurdodau eraill. Gwnewch gais Rhyddid Gwybodaeth (FOI) fel arfer. Mae’n ddyletswydd ar yr awdurdod i weithio allan ai’r Rheoliadau Gwybodaeth Amgylcheddol (EIR) yw’r ddeddfwriaeth fwyaf priodol iddynt ymateb o dani. </p> </dd>
     <dt id="multiple">A gaf i wneud yr un cais i lawer o awdurdodau, ee pob cyngor? <a href="#multiple">#</a> </dt>
-    <dd>Rydym yn gofyn i chi yn gyntaf anfon fersiwn brawf o'ch cais i ychydig o awdurdodau. Bydd eu hymatebion yn eich helpu i wella geiriad eich cais, er mwyn i chi gael y wybodaeth orau pan fyddwch yn anfon y cais i bob un o'r awdurdodau. Ar hyn o bryd nid oes system awtomataidd ar gyfer anfon y cais i'r awdurdodau eraill, rhaid i chi gopïo a gludo â llaw. </dd>
-    <dt id="offsite">Gwnes gais heb ddefnyddio'r wefan: sut y gallaf ei lwytho i'r archif?<a href="#offsite">#</a> </dt>
-    <dd>Mae WhatDoTheyKnow yn archif o geisiadau a wnaethpwyd trwy'r wefan, ac nid yw'n ceisio bod yn archif o bob cais Rhyddid Gwybodaeth. Fyddwn ni byth yn cynnal llwytho ceisiadau eraill i fyny. Yn un peth, ni fyddem yn gallu cadarnhau bod ymatebion eraill mewn gwirionedd yn dod oddi wrth yr awdurdod. Os yw hyn yn wir yn bwysig i chi, gallwch chi bob amser wneud yr un cais eto drwy WhatDoTheyKnow. </dd>
-    <dt id="moderation">Sut ydych chi'n cymedroli anodiadau ar gais? <a href="#moderation">#</a> </dt>
+    <dd>Rydym yn gofyn i chi yn gyntaf anfon fersiwn brawf o’ch cais i ychydig o awdurdodau. Bydd eu hymatebion yn eich helpu i wella geiriad eich cais, er mwyn i chi gael y wybodaeth orau pan fyddwch yn anfon y cais i bob un o’r awdurdodau. Ar hyn o bryd nid oes system awtomataidd ar gyfer anfon y cais i’r awdurdodau eraill, rhaid i chi gopïo a gludo â llaw. </dd>
+    <dt id="offsite">Gwnes gais heb ddefnyddio’r wefan: sut y gallaf ei lwytho i’r archif?<a href="#offsite">#</a> </dt>
+    <dd>Mae WhatDoTheyKnow yn archif o geisiadau a wnaethpwyd trwy’r wefan, ac nid yw’n ceisio bod yn archif o bob cais Rhyddid Gwybodaeth. Fyddwn ni byth yn cynnal llwytho ceisiadau eraill i fyny. Yn un peth, ni fyddem yn gallu cadarnhau bod ymatebion eraill mewn gwirionedd yn dod oddi wrth yr awdurdod. Os yw hyn yn wir yn bwysig i chi, gallwch chi bob amser wneud yr un cais eto drwy WhatDoTheyKnow. </dd>
+    <dt id="moderation">Sut ydych chi’n cymedroli anodiadau ar gais? <a href="#moderation">#</a> </dt>
     <dd>
-    <p>Mae anodiadau ar WhatDoTheyKnow i helpu pobl i gael y wybodaeth sy arnynt ei eisiau, neu i roi awgrymiadau i lefydd y gallant fynd i'w helpu i weithredu arno. Rydym yn cadw'r hawl i ddileu unrhyw beth arall. </p>
+    <p>Mae anodiadau ar WhatDoTheyKnow i helpu pobl i gael y wybodaeth sy arnynt ei eisiau, neu i roi awgrymiadau i lefydd y gallant fynd i’w helpu i weithredu arno. Rydym yn cadw’r hawl i ddileu unrhyw beth arall. </p>
     <p>Nid yw trafodaethau gwleidyddol diddiwedd yn cael eu caniatáu. Postiwch ddolen i fforwm addas neu wefan ymgyrch mewn man arall.</p>
     </dd>
   </dl>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #751 

## What does this do?
This PR swaps out the apostrophe character that we've used in some help pages.

## Why was this needed?
We've inconsistently used both `'` and `’` within help documents, which creates a slight semantic issue and makes the code slightly clunky to work with.

## Implementation notes
This is a straight swap of characters _in almost all_ cases - taking care not to mess with legitimate instances of the `'` character within links.

## Screenshots
N/A

## Notes to reviewer
I have intentionally skipped unhappy.html.erb since changes to this file will likely be committed elsewhere.

_This replaces a previous PR which contained a glitch that had been pushed in error._