### PR TITLE
[#754] Add version information to House Rules

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -83,5 +83,18 @@
     that your intentions are not malicious, we will contact you first so that we
     can give advice on how better to use the service.
   </p>
+  <h2 id="changes-to-house-rules">
+  Changes to our House Rules
+  <a href="#changes-to-house-rules">#</a>
+</h2>
+
+<p>
+  We keep these rules under review, and may make changes from time to
+  time to ensure that they remain up-to-date and accurate. You can find a
+  synopsis of changes we’ve made at our
+  <a href="https://git.io/JtZ5Y" alt="Link to version history for WhatDoTheyKnow House Rules (hosted on GitHub)">GitHub repository</a>,
+  but if you have any questions, please do <%= link_to 'contact us', help_contact_path %>.
+</p>
+
   <div id="hash_link_padding"></div>
 </div>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #754 

## What does this do?
This change adds a link back to the version control logs, allowing users to identify when changes have been made to the House Rules.

## Why was this needed?
We didn't have a specific link within the House Rules to allow users to see changes that had been made.

## Implementation notes
This implements a new paragraph with semantic tagging towards the bottom of /lib/views/help/house_rules.html.erb - it is based on the text already used in the privacy notice, with an updated URL and some minor tweaks.

## Screenshots
N/A

## Notes to reviewer
N/A