### PR TITLE
Change references from GDPR to UK GDPR in Privacy Notice

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -767,9 +767,15 @@
   </h3>
   <p>
     You have the right to complain if you believe that we have mishandled
-    your personal data. In the UK, the relevant supervisory body is the
+    your personal data. Do <a href="<%= help_contact_path %>">contact us</a> first, 
+    so that we can try and help (see our
+    <a href="https://www.whatdotheyknow.com/help/complaints">complaints 
+    procedure here</a>).
+  </p>
+  <p>
+    In the UK, the relevant supervisory body is the
     Information Commissioner’s Office (ICO). Our data protection
-    registration number is<a href="https://ico.org.uk/ESDWebPages/Entry/Z9602302">
+    registration number is <a href="https://ico.org.uk/ESDWebPages/Entry/Z9602302">
     ZA9602302</a>.
   </p>
   <p>
@@ -787,10 +793,6 @@
       Water Lane, WILMSLOW, SK9 5AF
     </li>
     </ul>
-    &hellip;but do <a href="<%= help_contact_path %>">contact us</a> first,
-      so that we can try and help (see our
-      <a href="https://www.whatdotheyknow.com/help/complaints">complaints
-      procedure here</a>).
   </p>
 
   <h2 id="cookies">

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -766,13 +766,31 @@
     <a href="#right_to_complain">#</a>
   </h3>
   <p>
-    You have the right to complain if you believe that we have mishandled your
-    personal data. For the UK, the relevant supervisory body is the Information
-    Commissioner’s Office. <a href="https://ico.org.uk/concerns/handling/">
-    You can report a concern here</a> (but do contact us
-    first, so that we can try and help — see our
-    <a href="https://www.whatdotheyknow.com/help/complaints">
-    complaints procedure here</a>).
+    You have the right to complain if you believe that we have mishandled
+    your personal data. In the UK, the relevant supervisory body is the
+    Information Commissioner’s Office (ICO). Our data protection
+    registration number is<a href="https://ico.org.uk/ESDWebPages/Entry/Z9602302">
+    ZA9602302</a>.
+  </p>
+  <p>
+    You can contact the ICO using any of the following methods:
+    <ul>
+    <li>
+      Online:&nbsp;&nbsp; <a href="https://ico.org.uk/make-a-complaint/">
+      https://ico.org.uk/make-a-complaint/</a>
+    </li>
+    <li>
+      Phone:&nbsp;&nbsp; (0303) 123 1113
+    </li>
+    <li>
+      Post:&nbsp;&nbsp; Information Commissioner’s Office, Wycliffe House,
+      Water Lane, WILMSLOW, SK9 5AF
+    </li>
+    </ul>
+    &hellip;but do <a href="<%= help_contact_path %>">contact us</a> first,
+      so that we can try and help (see our
+      <a href="https://www.whatdotheyknow.com/help/complaints">complaints
+      procedure here</a>).
   </p>
 
   <h2 id="cookies">

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -560,7 +560,7 @@
   <p>
     In most cases our legal basis for processing personal information is
     "legitimate interest" (this is as laid out in <a
-    href="https://gdpr-info.eu/art-6-gdpr/">6(1)(f)</a> – of the GDPR, in force
+    href="https://www.legislation.gov.uk/eur/2016/679/article/6">6(1)(f)</a> – of the UK GDPR, in force
     from 25 May 2018). We believe that we are pursuing a legitimate interest in
     processing personal data to provide our service to benefit of our users and
     the benefit of society. There is a benefit to our users in that we offer an
@@ -583,11 +583,11 @@
     On rare occasions the legal basis of "compliance with a legal obligation"
     will apply when we are legally obliged to hold material, for example where
     a court order has been issued (<a
-    href="https://gdpr-info.eu/art-6-gdpr/">6(1)(c)</a> of the GDPR).
+    href="https://www.legislation.gov.uk/eur/2016/679/article/6">6(1)(c)</a> of the UK GDPR).
   </p>
   <p>
     In almost all cases our processing of personal information will be lawful
-    under Article 6 of the GDPR but we may also rely on <a
+    under Article 6 of the UK GDPR but we may also rely on <a
     href="http://www.legislation.gov.uk/ukpga/2018/12/part/6/crossheading/the-special-purposes/enacted"
     >the "special purposes" derogations in the Data Protection Act 2018</a>,
     especially those applying to academic and journalistic purposes. Often use
@@ -695,8 +695,8 @@
     Where these responses include the personal information of public servants,
     we consider the legal basis for our processing of this information to be
     that we have a legitimate interest as described in
-    <a href="https://gdpr-info.eu/art-6-gdpr/">Article 6(1)(f)</a>
-    of the GDPR). Our legitimate interest is in benefiting society by preserving and
+    <a href="https://www.legislation.gov.uk/eur/2016/679/article/6">Article 6(1)(f)</a>
+    of the UK GDPR). Our legitimate interest is in benefiting society by preserving and
     promoting transparency and openness, and the accountability of those in
     positions of power and in maintaining a historic public archive of Freedom of
     Information requests and responses.  We will consider requests to remove the
@@ -737,7 +737,7 @@
     <a href="#right_to_access">#</a>
   </h3>
   <p>
-    You may contact us at any time to ask to see what personal data we hold
+    You may <a href="<%= help_contact_path %>">contact us</a> at any time to ask to see what personal data we hold
     about you.  If you have used our service to make a request,  then the vast
     majority of information we hold about you is shown publicly on our website
     or visible to you on your user profile.
@@ -750,7 +750,7 @@
     See also <a href="#erasure">your right to erasure</a>.
     </p>
     <p>
-    The General Data Protection Regulation gives you the right to object to our
+    The General Data Protection Regulations (UK GDPR) give you the right to object to our
     processing of your personal information and to ask us to stop processing it.
     However, it also gives us the right to continue to process it if we can demonstrate
     compelling legitimate grounds for the processing that override your

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -560,8 +560,7 @@
   <p>
     In most cases our legal basis for processing personal information is
     "legitimate interest" (this is as laid out in <a
-    href="https://www.legislation.gov.uk/eur/2016/679/article/6">6(1)(f)</a> – of the UK GDPR, in force
-    from 25 May 2018). We believe that we are pursuing a legitimate interest in
+    href="https://www.legislation.gov.uk/eur/2016/679/article/6">6(1)(f)</a> – of the UK GDPR). We believe that we are pursuing a legitimate interest in
     processing personal data to provide our service to benefit of our users and
     the benefit of society. There is a benefit to our users in that we offer an
     easy way to make, track and publish Freedom of Information requests. The

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -684,7 +684,7 @@
     for sensitive information or large volumes of breached personal data we
     would appreciate being notified by anyone.
   </p>
-  <h4>
+  <h4 id="takedown">
     Removal of public servants’ personal information from responses
     <a href="#takedown">#</a>
   </h4>


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
This PR contains two commits, which change references to the GDPR, clarifying that they relate to the "UK GDPR" (as per sch1 of  [The Data Protection, Privacy and Electronic Communications (Amendments etc) (EU Exit) Regulations 2019](https://www.legislation.gov.uk/uksi/2019/419/schedule/1)).

It also clarifies how our supervisory authority can be contacted, should a user wish to do so.

## Why was this needed?
The UK's exit from the European Union (brexit) has resulted in changes being made to the Data Protection legislation that is applicable to WhatDoTheyKnow's operations.

## Implementation notes
There are no specific implementation notes, this is an update to existing HTML.

## Screenshots
N/A

## Notes to reviewer

This was created using the version of `privacy.html.erb` contained in master - there are also changes in #753  30d96be which could be applied simultaneously if preferred.