### PR TITLE
Help page version history

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1491,6 +1491,18 @@ dd {
   }
 }
 
+.changes {
+  background-color: darken($body-bg, 2%);
+  border-radius: 2px;
+  border: 1px solid darken($body-bg, 12%);
+  font-size: smaller;
+  margin-top: 2em;
+  padding: 0.1em 1.5em;
+
+  h2 {
+    font-size: 1.65em;
+  }
+}
 
 
 /* Display of sidebars */

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -1,6 +1,8 @@
 # Please arrange overridden classes alphabetically.
 Rails.configuration.to_prepare do
   HelpController.class_eval do
+    before_action :set_history
+
     def principles; end
     def house_rules; end
     def how; end
@@ -9,6 +11,12 @@ Rails.configuration.to_prepare do
     def beginners; end
 
     private
+
+    def set_history
+      @history ||= HelpPageHistory.new(
+        lookup_context.find_template("#{controller_path}/#{action_name}")
+      )
+    end
 
     def set_recaptcha_required
       @recaptcha_required =

--- a/lib/help_page_history.rb
+++ b/lib/help_page_history.rb
@@ -1,0 +1,16 @@
+class HelpPageHistory
+  GITHUB_BASE =
+    'https://github.com/mysociety/whatdotheyknow-theme/commits/master'.freeze
+
+  def initialize(template)
+    @template = template
+  end
+
+  def commits_url
+    template.inspect.gsub(/lib\/themes\/whatdotheyknow-theme/, GITHUB_BASE)
+  end
+
+  protected
+
+  attr_reader :template
+end

--- a/lib/views/help/_history.html.erb
+++ b/lib/views/help/_history.html.erb
@@ -1,0 +1,17 @@
+<% if @history %>
+  <div class="changes">
+    <h2 id="changes">
+      Changes <a href="#changes">#</a>
+    </h2>
+
+    <p>
+      We keep these pages under review, and may make changes from time to
+      time to ensure that they remain up-to-date and accurate. You can find a
+      synopsis of changes we’ve made at our <%= link_to 'GitHub repository',
+        @history.commits_url,
+        alt: "Link to version history for WhatDoTheyKnow #{@title} (hosted on GitHub)" %>
+      but if you have any questions, please do
+      <%= link_to 'contact us', help_contact_path %>.
+    </p>
+  </div>
+<% end %>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -169,5 +169,8 @@
     <strong>Next</strong>, read about
     <a href="<%= help_requesting_path %>">making requests</a> --&gt;
   </p>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/alaveteli.html.erb
+++ b/lib/views/help/alaveteli.html.erb
@@ -21,5 +21,8 @@
   <p>Read more on the <a href="http://alaveteli.org">Alaveteli
   website</a>, or <a href="mailto:hello@alaveteli.org">drop us an
 email</a>.</p>
+
+  <%= render partial: 'history' %>
+
 <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -110,5 +110,8 @@
     Please <a href="<%= help_contact_path %>">contact us</a> if you need a
     feature that we don’t currently provide.
   </p>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/beginners.html.erb
+++ b/lib/views/help/beginners.html.erb
@@ -24,4 +24,6 @@
     If you need further advice, you can <a href="<%=  help_contact_path
     %>">contact</a> the WhatDoTheyKnow volunteer administration team.
   </p>
+
+  <%= render partial: 'history' %>
 </div>

--- a/lib/views/help/complaints.html.erb
+++ b/lib/views/help/complaints.html.erb
@@ -52,4 +52,6 @@
       </p>
     </dd>
   </dl>
+
+  <%= render partial: 'history' %>
 </div>

--- a/lib/views/help/credits.html.erb
+++ b/lib/views/help/credits.html.erb
@@ -139,5 +139,8 @@
       </p>
     <dd>
   </dl>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -83,5 +83,8 @@
     that your intentions are not malicious, we will contact you first so that we
     can give advice on how better to use the service.
   </p>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -394,4 +394,6 @@
     misuse. After an account has been banned, the WhatDoTheyKnow volunteer team
     write to the user to explain the reasons that led to this decision.
   </p>
+
+  <%= render partial: 'history' %>
 </div>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -412,5 +412,8 @@
     <br><strong>Otherwise</strong>, the <a href="<%= help_credits_path %>">
     credits</a> or the <a href="<%= help_api_path %>">programmers API</a> --&gt;
   </p>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/principles.html.erb
+++ b/lib/views/help/principles.html.erb
@@ -100,5 +100,8 @@
       </ul>
     </dd>
   </dl>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -913,23 +913,12 @@
     gov.uk cookies page</a> (under the Open Government Licence).
   </p>
 
-  <h2 id="changes-to-privacy-notice">
-    Changes to our privacy policy
-    <a href="#changes-to-privacy-notice">#</a>
-  </h2>
-
-  <p>
-    We keep our privacy policy under review, and may make changes from time to
-    time to ensure that it remains up-to-date and accurate. You can find a
-    synopsis of changes we’ve made at our
-    <a href="https://git.io/JU14r" alt="Link to version history for WhatDoTheyKnow Privacy notice (hosted on GitHub)">GitHub repository</a>,
-    but if you have any questions, please do
-    <%= link_to 'contact us', help_contact_path %>.
-  </p>
-
-
   <p><strong>Learn more</strong> from the help for
     <a href="<%= help_officers_path %>">FOI officers</a> --&gt;
   </p>
+
+  <span id="changes-to-privacy-notice"></span>
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/pro.html.erb
+++ b/lib/views/help/pro.html.erb
@@ -192,4 +192,6 @@
     <%= link_to 'responsible requests',
       help_requesting_path(anchor: 'responsible') %>.
   </p>
+
+  <%= render partial: 'history' %>
 </div>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -712,5 +712,8 @@
     </dd>
   </dl>
   <p><strong>Next</strong>, read about <a href="<%= help_privacy_path %>">your privacy</a> --&gt;
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -172,4 +172,6 @@
   <li>You could form a small local campaign group and arrange a meeting
   with staff from the authority.</li>
 </ul>
+
+  <%= render partial: 'history' %>
 </div>

--- a/lib/views/help/volunteers.html.erb
+++ b/lib/views/help/volunteers.html.erb
@@ -97,4 +97,6 @@
       </p>
     </dd>
   </dl>
+
+  <%= render partial: 'history' %>
 </div>

--- a/spec/help_page_history_spec.rb
+++ b/spec/help_page_history_spec.rb
@@ -1,0 +1,21 @@
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'whatdotheyknow-theme'
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..','spec','spec_helper'))
+
+describe HelpPageHistory do
+  describe '#commits_url' do
+    subject { described_class.new(template).commits_url }
+
+    context 'with a custom help page' do
+      let(:template) do
+        double(inspect: 'lib/themes/whatdotheyknow-theme/lib/views/' \
+                        'help/house_rules.html.erb')
+      end
+
+      it do
+        is_expected.to eq('https://github.com/mysociety/whatdotheyknow-theme/' \
+                          'commits/master/lib/views/help/house_rules.html.erb')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a generic "changes" section to the bottom of most help pages.

Avoids having to write this individually each time we think we need it (#700, #754) and keeps things like the page anchors consistent.

![Screenshot 2021-02-02 at 13 29 14](https://user-images.githubusercontent.com/282788/106607006-b4389080-655a-11eb-84c8-2f852a7220cf.png)
