### PR TITLE
[#749] Add guidance re acronyms to requesting.html.erb

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -185,7 +185,7 @@
       </p>
       <ul>
         <li>
-          <strong>Send it to the right place</strong>
+          <strong>Send it to the right place:</strong>
           Make an effort to ensure that your request
           is directed to the appropriate body. We appreciate that’s not always
           easy, and if you’re not sure after doing some research, by all means
@@ -197,7 +197,7 @@
         </li>
         <li>
           <p>
-            <strong>Don’t carpet-bomb</strong>
+            <strong>Don’t carpet-bomb:</strong>
             You might be planning to make a request to, for
             example, all local councils, or even all public bodies in the country,
             but  it’s worth stopping to reflect. Such bulk requests result in a
@@ -217,7 +217,7 @@
           </p>
         </li>
         <li>
-          <strong>Word your question carefully</strong>
+          <strong>Word your question carefully:</strong>
           It can be worth specifying the format
           you’d like your response in, and making sure that you ask for exactly
           the data you need, or you may find that, when making requests to a
@@ -225,7 +225,13 @@
           can’t compare like with like.
         </li>
         <li>
-          <strong>Fine-tune your request</strong>  Make the right request the
+        <strong>Avoid acronyms and ambiguous terms:</strong> Acronyms and jargon
+        whose meaning might appear obvious to you may not be understood by 
+        officers receiving your request. Consider expanding acronyms, explaining 
+        highly technical terms, and pre-empting potential requests for clarification.
+        </li>
+        <li>
+          <strong>Fine-tune your request:</strong>  Make the right request the
           first time, and you won’t have to return for further information
           later. So, consider what you want to do with the information when you
           receive it and whether you will need additional information to put the
@@ -234,7 +240,7 @@
           with context such as the figures for previous years.
         </li>
         <li>
-          <strong>But don’t ask for too much</strong> On the flip side, one of
+          <strong>But don’t ask for too much:</strong> On the flip side, one of
           the reasons that authorities can turn down a request is that it would
           take too many resources (ie staff time and financial cost) to answer
           fully — so only ask for what you need. Restricting your request to
@@ -243,14 +249,14 @@
           broad to deal with.
         </li>
         <li>
-          <strong>Stay courteous</strong> The FOI officer is often the defender
+          <strong>Stay courteous:</strong> The FOI officer is often the defender
           of the public’s right to information within an authority.  They may
           well be acting as your advocate within the public body, and you’ll
           find that they’re often  keen to help you. They’ll remain all the more
           so if you treat them politely.
         </li>
         <li>
-          <strong>Remember it’s all going online</strong> So take care not to
+          <strong>Remember it’s all going online:</strong> So take care not to
           include any defamatory material in your request, such as allegations
           of illegal or abusive behaviour. Not only can such material cause
           serious problems for us, it can put you at risk of committing libel,
@@ -258,7 +264,7 @@
           receive a response.
         </li>
         <li>
-          <strong>Consider asking for proactive publication</strong>
+          <strong>Consider asking for proactive publication:</strong>
           To save you from having to make a similar request again in the future
           you might want to ask the public body to consider starting to
           proactively publish the information on their website. In some cases,


### PR DESCRIPTION
## Relevant issue(s)
Fixes #749 

## What does this do?
This changes updates guidance for requestors by adding a note about the use of acronyms  and ambiguous terms.

It also makes a minor stylistic change to help with readability.

## Why was this needed?
This change was needed to help improve the clarity of our guidance for potential requestors, and to add guidance which explains why it may be beneficial to _clarify_ acronyms or ambiguous terms _before_ submitting a request.

## Implementation notes
N/A - minor update to existing code

## Screenshots
N/A

## Notes to reviewer
This change also adds a couple of colons to the list under #responsible - this helps with readability, but you can back them out if you'd prefer.