### PR TITLE
[#763] Add semantic tags to /lib/views/help/how.html.erb

### DIFF
--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -1,7 +1,7 @@
 <% @title = "How we run WhatDoTheyKnow" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
-  <h1 id="title"><%= @title %></h1>
+  <h1 id="title"><%= @title %> <a href="#title">#</a></h1>
   <p>
     WhatDoTheyKnow is administered by a small group of dedicated
     <a href="<%= help_credits_path(:anchor => 'volunteers') %>">volunteers</a>
@@ -11,7 +11,7 @@
     <a href="<%= help_about_path(:anchor => 'who') %>">Trustees</a>.
   </p>
   <h2 id="reactive_moderation">
-    Reactive moderation principle
+    Reactive moderation principle <a href="#reactive_moderation">#</a>
   </h2>
   <p>
     It would be impossible for the WhatDoTheyKnow volunteer team to moderate all
@@ -33,7 +33,7 @@
     investigate that.
   </p>
   <h2 id="what_happens">
-    What happens once a request is reported for attention?
+    What happens once a request is reported for attention? <a href="#what_happens">#</a>
   </h2>
   <p>
     Users report material on WhatDoTheyKnow for a wide range of different
@@ -58,7 +58,7 @@
     </li>
   </ul>
   <h3 id="policy">
-    Policy as a guide, not a rigid set of rules
+    Policy as a guide, not a rigid set of rules <a href="#policy">#</a>
   </h3>
   <p>
     Our policies have developed from the consideration and discussion of cases
@@ -78,7 +78,7 @@
     this group then leads to an agreed course of action.
   </p>
   <h3 id="information_removal">
-    Removal of information
+    Removal of information <a href="#information_removal">#</a>
   </h3>
   <p>
     <strong>Our default is to keep unproblematic information online.</strong>
@@ -114,7 +114,7 @@
     Executive will be the final arbiter.
   </p>
   <h4 id="accidentally_released">
-    Accidentally released personal information
+    Accidentally released personal information <a href="#accidentally_released">#</a>
   </h4>
   <p>
     Sometimes public bodies mistakenly release personal information, in breach
@@ -158,7 +158,7 @@
     review it and take any appropriate action.
   </p>
   <h4 id="potentially_libellous">
-    Potentially defamatory or libellous material
+    Potentially defamatory or libellous material <a href="#potentially_libellous">#</a>
   </h4>
   <p>
     Unfortunately, some people use WhatDoTheyKnow to post potentially
@@ -189,7 +189,7 @@
   </p>
 
   <h4 id="commercial_information">
-    Requests to remove commercial information
+    Requests to remove commercial information <a href="#commercial_information">#</a>
   </h4>
   <p>
     Takedown requests on matters such as commercial sensitivity and confidential
@@ -202,7 +202,7 @@
     cases.
   </p>
   <h4 id="copyright">
-    Copyright
+    Copyright <a href="#copyright">#</a>
   </h4>
   </p>
   <p>
@@ -226,7 +226,7 @@
     duplicate requests.
   </p>
   <h4 id="vexatious_requests">
-    How do we deal with vexatious requests?
+    How do we deal with vexatious requests? <a href="#vexatious">#</a>
   </h4>
   <p>
     We remove vexatious requests from our site when they are drawn to our
@@ -241,7 +241,7 @@
     position of the public body.
   </p>
   <h4 id="invalid_requests">
-    How do we deal with requests that are not valid?
+    How do we deal with requests that are not valid? <a href="#invalid_requests">#</a>
   </h4>
   <p>
     When we are made aware of it, we remove any correspondence from our site
@@ -260,7 +260,7 @@
     try to help others find more appropriate means of contacting public bodies.
   </p>
   <h4 id="email_addresses">
-    Why do we remove email addresses and mobile phone numbers from responses?
+    Why do we remove email addresses and mobile phone numbers from responses? <a href="#email_addresses">#</a>
   </h4>
   <p>
     To guard all parties against spam, and to encourage keeping all
@@ -278,7 +278,7 @@
     we’re asked to reveal it we may post it in an annotation.
   </p>
   <h4 id="send_errors">
-    How do we deal with requests that are not sent successfully?
+    How do we deal with requests that are not sent successfully? <a href="#send_errors">#</a>
   </h4>
   <ul>
     <li>
@@ -299,7 +299,7 @@
   </ul>
   <p>
     <h2 id="admin_team">
-      Membership of the admin team
+      Membership of the admin team <a href="#admin_team">#</a>
     </h2>
   </p>
   <p>
@@ -329,14 +329,14 @@
     given access to the administration interface.
   </p>
   <h2 id="user_accounts">
-      User accounts
+      User accounts <a href="#user_accounts">#</a>
   </h2>
   <p>
     If you sign up for an account on WhatDoTheyKnow, a profile listing any
     requests and annotations you have made will be publicly accessible.
   </p>
   <h3 id="anonymise_account">
-    Requests to remove or anonymise an account
+    Requests to remove or anonymise an account <a href="#anonymise_account">#</a>
   </h3>
   </p>
   <p>
@@ -366,7 +366,7 @@
     right to have removed from our service on request.
   </p>
   <h3 id="banning_users">
-    Banning users
+    Banning users <a href="#banning_users">#</a>
   </h3>
   <p>
     We ban users for persistent misuse of our service (e.g. going against our

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -148,9 +148,14 @@
   </p>
   <p>
     The ICO requests that serious breaches of data protection are reported to
-    them; their guidance on what constitutes serious is at: <a
-    href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/">
-    https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/</a>.
+    them; their guidance on what constitutes serious is <a
+    href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/" title="View guidance on Personal data breaches on the ICO website" alt="View guidance on Personal data breaches on the ICO website">
+    outlined on their website</a>.
+  </p>
+  <p>
+    If you become aware of a potential data breach, please
+    <a href="<%=  help_contact_path %>">get in touch</a> with us so that we can
+    review it and take any appropriate action.
   </p>
   <h4 id="potentially_libellous">
     Potentially defamatory or libellous material

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -41,20 +41,20 @@
   </p>
   <ul>
     <li>
-      Personal information which has been released by accident
+      <a href="#accidentally_released" title="Go to help section - Accidentally released personal information">Personal information which has been released by accident</a>
     </li>
     <li>
-      Potentially libellous or defamatory material published on the site
+      <a href="#potentially_libellous" title="Go to help section - Potentially defamatory or libellous material">Potentially libellous or defamatory material published on the site</a>
     </li>
     <li>
-      Copyright material
+      <a href="#copyright" title="Go to help section - Copyright">Copyright material</a>
     </li>
     <li>
-      Vexatious requests
+      <a href="#vexatious_requests" title="Go to help section - How do we deal with vexatious requests?">Vexatious requests</a>
     </li>
     <li>
-      Invalid requests, that is, requests that are not Freedom of Information
-      requests
+      <a href="#invalid_requests" title="Go to help section - How do we deal with requests that are not valid? ">Invalid requests, that is, requests that are not Freedom of Information
+      requests</a>
     </li>
   </ul>
   <h3 id="policy">

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -1,7 +1,7 @@
 <% @title = "How we run WhatDoTheyKnow" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
-  <h1><%= @title %></h1>
+  <h1 id="title"><%= @title %></h1>
   <p>
     WhatDoTheyKnow is administered by a small group of dedicated
     <a href="<%= help_credits_path(:anchor => 'volunteers') %>">volunteers</a>
@@ -10,7 +10,7 @@
     these volunteers, with support from mySociety’s Chief Executive and
     <a href="<%= help_about_path(:anchor => 'who') %>">Trustees</a>.
   </p>
-  <h2>
+  <h2 id="reactive_moderation">
     Reactive moderation principle
   </h2>
   <p>
@@ -32,7 +32,7 @@
     taking a view on if it is accurate or not, we don’t have the resources to
     investigate that.
   </p>
-  <h2>
+  <h2 id="what_happens">
     What happens once a request is reported for attention?
   </h2>
   <p>
@@ -57,7 +57,7 @@
       requests
     </li>
   </ul>
-  <h3>
+  <h3 id="policy">
     Policy as a guide, not a rigid set of rules
   </h3>
   <p>
@@ -77,8 +77,7 @@
     the team of other volunteers and specific mySociety staff. Discussion among
     this group then leads to an agreed course of action.
   </p>
-  <p>
-  <h3>
+  <h3 id="information_removal">
     Removal of information
   </h3>
   <p>
@@ -114,10 +113,9 @@
     If agreement cannot be reached for any reason, then mySociety’s Chief
     Executive will be the final arbiter.
   </p>
-    <strong>
-      Accidentally released personal information
-    </strong>
-  </p>
+  <h4 id="accidentally_released">
+    Accidentally released personal information
+  </h4>
   <p>
     Sometimes public bodies mistakenly release personal information, in breach
     of the Data Protection Act. Once the admin team has received a
@@ -154,11 +152,9 @@
     href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/">
     https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/personal-data-breaches/</a>.
   </p>
-  <p>
-    <strong>
-      Potentially defamatory or libellous material
-    </strong>
-  </p>
+  <h4 id="potentially_libellous">
+    Potentially defamatory or libellous material
+  </h4>
   <p>
     Unfortunately, some people use WhatDoTheyKnow to post potentially
     defamatory/libellous material. We take action, upon being informed, to
@@ -187,11 +183,9 @@
     the wider group, including mySociety’s CEO and Trustees</a>.
   </p>
 
-  <p>
-    <strong>
-      Requests to remove commercial information
-    </strong>
-  </p>
+  <h4 id="commercial_information">
+    Requests to remove commercial information
+  </h4>
   <p>
     Takedown requests on matters such as commercial sensitivity and confidential
     information such as contracts are infrequent but important. We deal with
@@ -202,10 +196,9 @@
     The law prohibiting a breach of confidence is our prime concern in such
     cases.
   </p>
-  <p>
-    <strong>
-      Copyright
-    </strong>
+  <h4 id="copyright">
+    Copyright
+  </h4>
   </p>
   <p>
     It is legitimate to request copyrighted material under Freedom of
@@ -227,11 +220,9 @@
     get a copy of it. We also want to save taxpayers’ money by preventing
     duplicate requests.
   </p>
-  <p>
-    <strong>
-      How do we deal with vexatious requests?
-    </strong>
-  </p>
+  <h4 id="vexatious_requests">
+    How do we deal with vexatious requests?
+  </h4>
   <p>
     We remove vexatious requests from our site when they are drawn to our
     attention.
@@ -244,11 +235,9 @@
     the ICO’s guidance on vexatious requests</a> and don’t always follow the
     position of the public body.
   </p>
-  <p>
-    <strong>
-      How do we deal with requests that are not valid?
-    </strong>
-  </p>
+  <h4 id="invalid_requests">
+    How do we deal with requests that are not valid?
+  </h4>
   <p>
     When we are made aware of it, we remove any correspondence from our site
     which is not a request for  information that anyone could expect a
@@ -265,11 +254,9 @@
     on making Subject Access requests under the Data Protection Act</a> and
     try to help others find more appropriate means of contacting public bodies.
   </p>
-  <p>
-    <strong>
-      Why do we remove email addresses and mobile phone numbers from responses?
-    </strong>
-  </p>
+  <h4 id="email_addresses">
+    Why do we remove email addresses and mobile phone numbers from responses?
+  </h4>
   <p>
     To guard all parties against spam, and to encourage keeping all
     correspondence on WhatDoTheyKnow, we automatically remove most email
@@ -285,11 +272,9 @@
     Occasionally, an email address forms an important part of a response and if
     we’re asked to reveal it we may post it in an annotation.
   </p>
-  <p>
-    <strong>
-      How do we deal with requests that are not sent successfully?
-    </strong>
-  </p>
+  <h4 id="send_errors">
+    How do we deal with requests that are not sent successfully?
+  </h4>
   <ul>
     <li>
       The admin team act to re-send requests/messages when we spot failed
@@ -308,7 +293,7 @@
     </li>
   </ul>
   <p>
-    <h2>
+    <h2 id="admin_team">
       Membership of the admin team
     </h2>
   </p>
@@ -338,17 +323,16 @@
     admin interface. If everyone concerned is comfortable, they may then be
     given access to the administration interface.
   </p>
-  <h2>
+  <h2 id="user_accounts">
       User accounts
   </h2>
   <p>
     If you sign up for an account on WhatDoTheyKnow, a profile listing any
     requests and annotations you have made will be publicly accessible.
   </p>
-  <p>
-    <strong>
-      Requests to remove or anonymise an account
-    </strong>
+  <h3 id="anonymise_account">
+    Requests to remove or anonymise an account
+  </h3>
   </p>
   <p>
     We think that well-written requests for information on important subjects
@@ -376,11 +360,9 @@
     requests and responses to be users’ personal information which they have a
     right to have removed from our service on request.
   </p>
-  <p>
-    <strong>
-      Banning users
-    </strong>
-  </p>
+  <h3 id="banning_users">
+    Banning users
+  </h3>
   <p>
     We ban users for persistent misuse of our service (e.g. going against our
     <a


### PR DESCRIPTION
## Relevant issue(s)
Fixes #763 

## What does this do?
This adds and improves the semantic tagging used within /lib/views/help/how.html.erb

## Why was this needed?
The current presentation of the file makes it difficult for users (and WDTK administrators) to easily cite individual parts of the guidance.

## Implementation notes
Nothing specific to note - the changes are, for the most part, minor additions to existing tags (e.g. addition of 'id' tags to specific elements); however, a number of `<strong>` tags have also been replaced with headings in order to improve presentation.

## Screenshots
N/A

## Notes to reviewer
The commit at 2f65cd1 adds links to the "What happens" section - I _think_ this makes sense, but any feedback is welcome.

The commit at 8d3b0ea adds a reference back to the contact form. We might want to replace this with a more specific link if we improve the forms in the future.