### PR TITLE
Add NMC invalid email address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -167,6 +167,7 @@ Rails.configuration.to_prepare do
     noreply@aberdeencity.gov.uk
     NoReply.FOI@worcester.gov.uk
     auto-reply@castlepoint.gov.uk
+    foi&dparequest@nmc-uk.org
   )
 
   # Add survey methods to RequestMailer


### PR DESCRIPTION
Adds a new email address to the Reply To Address validator in model patches to prevent replies being sent to this address.

Any email sent by Alaveteli to this email address will fail due to https://github.com/mysociety/alaveteli/issues/3465