### PR TITLE
Add Lambeth BC invalid email address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -167,6 +167,7 @@ Rails.configuration.to_prepare do
     noreply@aberdeencity.gov.uk
     NoReply.FOI@worcester.gov.uk
     auto-reply@castlepoint.gov.uk
+    lambethinformationrequests@lambeth.gov.uk
   )
 
   # Add survey methods to RequestMailer


### PR DESCRIPTION
This PR adds an email address for Lambeth Borough Council to the list of invalid reply addresses.

It seems that LBC are automatically bouncing replies sent to this email address unless they contain the unique reference number.

Per support mail received by WDTK support.