### PR TITLE
[#774] Update help pages to better describe requests for personal information

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -19,8 +19,8 @@
   <ul>
     <li>
       Use WhatDoTheyKnow only to request specific information, not for general
-      correspondence with public authorities, and certainly not for
-      correspondence about your own personal circumstances.
+      correspondence with public authorities, and certainly not for personal
+      correspondence.
     </li>
     <li>
       Do not include potentially defamatory/potential libellous comments (such

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -31,12 +31,15 @@
       threatening, harmful, obscene, discriminatory or profane
     </li>
     <li>
-      Do not use WhatDoTheyKnow to request your personal information from
-      authorities. You should request this information privately via a Subject
-      Access request, a procedure that is distinct from a Freedom of Information
-      request. See
-      <a href="https://ico.org.uk/for-the-public/personal-information/">advice
-      on this from the Information Commissioner’s Office</a>.
+      Only use WhatDoTheyKnow.com to request information which anyone could
+      expect to obtain if they requested it. If you have a specific right to
+      information, for example because you are seeking your own personal 
+      information, then you should correspond privately with the public body
+      concerned to request it. Requests for your own personal information are
+      known as Subject Access requests and
+      <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/"
+      title="Guidance from the Information Commissioner on your right of access">
+      the Information Commissioner has published advice on making such requests</a>.
     </li>
     <li>
       Keep messages sent via our service concise and tightly focused on the

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -259,7 +259,7 @@
   </p>
   <p>
     Where requests relate to deceased individuals we have a presumption towards 
-    removing material on compassionate grounds, where the request is by a 
+    removing material on compassionate grounds where the request is by a 
     family member or friend who may not have considered the consequences of 
     using our service.
   </p>

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -60,6 +60,10 @@
         material</a>
     </li>
     <li>
+      <a href="#compassionate_grounds" title="Go to help section -
+      Compassionate Grounds">Compassionate grounds</a>
+    </li>
+    <li>
       <a href="#vexatious_requests" title="Go to help section - How do we deal
         with vexatious requests?">Vexatious requests</a>
     </li>
@@ -243,6 +247,21 @@
     “applicant blind”, so anyone in the world can request the same document and
     get a copy of it. We also want to save taxpayers’ money by preventing
     duplicate requests.
+  </p>
+  <h4 id="compassionate_grounds">
+  Removal of information on compassionate grounds
+  <a href="#compassionate_grounds">#</a>
+  </h4>
+  <p>
+    On rare occasions, in exceptional circumstances, an editorial decision may be
+    taken to remove requests, and/or responses, on compassionate grounds. Such
+    cases are treated sensitively on a case-by case basis.
+  </p>
+  <p>
+    Where requests relate to deceased individuals we have a presumption towards 
+    removing material on compassionate grounds, where the request is by a 
+    family member or friend who may not have considered the consequences of 
+    using our service.
   </p>
   <h4 id="vexatious_requests">
     How do we deal with vexatious requests?

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -525,8 +525,8 @@
       This website does not allow for such requests, not least because we
       publish correspondence online, where anyone would be able to see the
       potentially sensitive information that can result from such requests.
-      <a href="https://ico.org.uk/for-the-public/personal-information/">The
-      Information Commissioner’s website</a> provides advice on how to make a
+      <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">
+      The Information Commissioner’s website</a> provides advice on how to make a
       Subject Access request.
     </p>
     <p>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -590,7 +590,7 @@
         making requests to large numbers of bodies to carefully consider if
         doing so is justified. Thought should be given to the potential cost to
         the public sector, the reputation of Freedom of Information and
-        WhatDoTheyKnow.com as well as the potential benefits of having the
+        WhatDoTheyKnow as well as the potential benefits of having the
         information released.
       </p>
       <p>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -535,6 +535,39 @@
       contact us</a> immediately so we can remove it.
     </p>
     </dd>
+    <dt id="data_protection_deceased_persons">
+      Can I request information about a deceased person?
+      <a href="#data_protection_deceased_persons">#</a>
+    </dt>
+    <dd>
+      <p>
+        When seeking information relating to a deceased person please carefully
+        consider if a Freedom of Information request via WhatDoTheyKnow is
+        appropriate and think about the potential impacts of making the request,
+        and receiving a response, in public.
+      </p>
+      <p>
+        WhatDoTheyKnow is only for making requests for information which anyone
+        could expect to obtain if they requested it. There are some laws, and
+        procedures, which give certain people special rights to information, 
+        such as the
+        <a href="https://www.nhs.uk/common-health-questions/nhs-services-and-treatments/can-i-access-the-medical-records-health-records-of-someone-who-has-died/"
+        title="NHS England guidance on the Access to Health Records Act 1990">
+        Access to Health Records Act (1990)</a> and the
+        <a href="https://www.gov.uk/guidance/request-records-of-deceased-service-personnel"
+        title="MoD Guidance: Request records of deceased service personnel">
+        Ministry of Defence procedure for accessing records of deceased service
+        personnel</a>. Where the requester has a special right to the
+        information being sought requests should be made privately and directly
+        and not via WhatDoTheyKnow.
+      </p>
+      <p>
+        If you think there is information about a deceased person that we
+        should remove, please refer to our
+        <%= link_to 'policy', help_how_path(:anchor => 'compassionate_grounds') %>
+        , and <%= link_to 'contact us', help_contact_path %> with any queries.
+      </p>
+    </dd>
     <dt id="private_requests">
       I&rsquo;d like to keep my request secret! (At least until I publish my story)
       <a href="#private_requests">#</a>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #774 

## What does this do?
This implements a series of changes that clarify:

- the House Rules around personal correspondence
- access to personal information held by a public body (Right of Access / SAR)
- access to records held by a public body about a deceased person
- scenarios where we may remove information on "compassionate grounds"

## Why was this needed?

In  https://github.com/mysociety/whatdotheyknow-theme/issues/774#issue-809324455, WhatDoTheyKnow volunteers have noted that the existing House Rule regarding _"personal circumstances"_ is sometimes interpreted too broadly as restricting requests that concern policy/process around _"personal circumstances"_, whereas, the intent is actually restrict _"personal correspondence"_.

It has also been noted that the existing guidance around _right of access / SAR_ requests was in need of generalisation, and that it would be helpful to include specific information on access to the records of a deceased person / signposting to specific rights of access for next-of-kin/relatives.

In https://github.com/mysociety/whatdotheyknow-theme/issues/774#issuecomment-779851725, it was suggested that we add specific guidance on scenarios where an editorial decision may be made to remove content based on compassionate grounds.

## Implementation notes
Nothing particular to note.

## Screenshots
N/A

## Notes to reviewer
The commit in cbaf73c (lib/views/help/requesting.html.erb) relies on the change in 9ffcccc (lib/views/help/how.html.erb) being implemented, otherwise the anchor referenced in the link to our policy won't go anywhere.