### PR TITLE
[#767] Add information about "backpaging"

### DIFF
--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -335,7 +335,7 @@
     When a request on WhatDoTheyKnow is "backpaged" meta-tags are added to the
     header of the request page, and linked attachments, to ask external search
     engines not to index the material. This feature is rarely used, but can
-    help us continue to publish material we might otherwise have to remove.
+    help us continue to publish material we might otherwise remove.
   </p>
   <p>
     Backpaging reduces the impact of our publication, it can, for example, be

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -320,10 +320,10 @@
       response.
     </li>
   </ul>
-  <h3 id="backpaging">
+  <h4 id="backpaging">
     Backpaging
     <a href="#backpaging">#</a>
-  </h3>
+  </h4>
   <p>
     Administrators can "backpage" a request thread, this means the page is
     accessible to those who have the direct link to it, but it is not included

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -320,6 +320,29 @@
       response.
     </li>
   </ul>
+  <h3 id="backpaging">
+    Backpaging
+    <a href="#backpaging">#</a>
+  </h3>
+  <p>
+    Administrators can "backpage" a request thread, this means the page is
+    accessible to those who have the direct link to it, but it is not included
+    in lists of requests or search results on the site. This is similar to
+    YouTube's "unlisted" or GoogleDoc's "anyone with the link" accessibility
+    settings.
+  </p>
+  <p>
+    When a request on WhatDoTheyKnow is "backpaged" meta-tags are added to the
+    header of the request page, and linked attachments, to ask external search
+    engines not to index the material. This feature is rarely used, but can
+    help us continue to publish material we might otherwise have to remove.
+  </p>
+  <p>
+    Backpaging reduces the impact of our publication, it can, for example, be
+    used to make it more likely that our interests in processing and publishing
+    material outweigh any negative impacts on those whose personal information
+    is involved.
+  </p>
   <h2 id="admin_team">
     Membership of the admin team
     <a href="#admin_team">#</a>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #767 

## What does this do?
This adds information about "backpaging" of requests, indicating what we mean by the term and when it might be used.

## Why was this needed?
In https://github.com/mysociety/whatdotheyknow-theme/issues/767#issue-806005649, WhatDoTheyKnow administrators have noted that we do not have guidance in the help pages about the 'backpaging' feature.

## Implementation notes
I have added this at Heading level 3, rather than adding as a new level 4 heading under the 'Removal of information' section - feel free to move this into h4 if it'd make more sense.

## Screenshots
N/A

## Notes to reviewer
Nothing of note