### PR TITLE
[#791] Fix wording of citizen rights

### DIFF
--- a/lib/views/general/_frontpage_how_it_works.html.erb
+++ b/lib/views/general/_frontpage_how_it_works.html.erb
@@ -5,7 +5,7 @@
         <h2><%= _("How it works") %></h2>
         <p class="hiw__subtitle">
           <%= _("You have the <strong>right</strong> to request information " \
-                "from any publicly-funded body, and get answers. " \
+                "from any public body, and get answers. " \
                 "{{site_name}} helps you make a Freedom of Information " \
                 "request. It also publishes all requests online.",
                 :site_name => site_name) %>


### PR DESCRIPTION
> FOI and similar access to information laws apply to public bodies, not
> publicly-funded bodies.

Minor part of https://github.com/mysociety/whatdotheyknow-theme/issues/791