### PR TITLE
[#793] Add address for Coventry City Council to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -170,6 +170,7 @@ Rails.configuration.to_prepare do
     system@share.ons.gov.uk
     foi&dparequest@nmc-uk.org
     lambethinformationrequests@lambeth.gov.uk
+    myaccount@coventry.gov.uk
   )
 
   # Add survey methods to RequestMailer


### PR DESCRIPTION
## Relevant issue(s)
Fixes #793 

## What does this do?
This patch adds a new no-reply addresses for Coventry City Council to model_patches.rb

## Why was this needed?
Correspondence being issued from public bodies from 'no-reply' email addresses which our users were unable to respond to; therefore, to prevent our users being _"sent to coventry"_, this patch will actually allow their messages to be sent to Coventry City Council instead! 😀

## Implementation notes
N/A

## Screenshots
N/A

## Notes to reviewer
Nothing of note - happy days.

I'll get me coat for the terrible pun though!