### PR TITLE
[#796, #802] Add addresses for Highways England and 3C Shared Services to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -171,6 +171,8 @@ Rails.configuration.to_prepare do
     foi&dparequest@nmc-uk.org
     lambethinformationrequests@lambeth.gov.uk
     myaccount@coventry.gov.uk
+    C&PCCC@highwaysengland.co.uk
+    DONOTREPLY@3csharedservices.vuelio.co.uk
   )
 
   # Add survey methods to RequestMailer


### PR DESCRIPTION
## Relevant issue(s)
Fixes #796; Fixes #802 

## What does this do?
This patch adds two new addresses to model_patches.rb, for bodies Highways England and 3C Shared Services. The latter relates to three Councils (Cambridge City, Huntingdonshire District, and South Cambridgeshire District Councils)

## Why was this needed?
Correspondence being issued from the 3C Shared Services bodies is being sent from 'no-reply' email addresses which our users were unable to respond to.

In addition, the Highways England address has an ampersand, which currently causes a system error. The root cause of this is being investigated upstream [mysociety/alaveteli#3465 (comment)](https://github.com/mysociety/alaveteli/issues/3465#issuecomment-810978437), but putting a workaround in place while we wait on a fix is a good thing to do from a user-experience perspective.

## Implementation notes
Nothing of note here, it's our usual code.

## Screenshots
N/A

## Notes to reviewer
Nothing specific 😄 