### PR TITLE
[alaveteli#6237] Add exemption titles to wizard labels

### DIFF
--- a/config/refusal_advice/exemptions.yml.erb
+++ b/config/refusal_advice/exemptions.yml.erb
@@ -4,15 +4,15 @@ foi:
     label:
       plain: <%= _('Did the authority mention any of these exemptions when refusing your request?') %>
     options:
-    #- { label: <%= _('Section 11') %>, value: section-11 }
-    - { label: <%= _('Section 12') %>, value: section-12 }
-    - { label: <%= _('Section 14') %>, value: section-14 }
-    - { label: <%= _('Section 21') %>, value: section-21 }
-    - { label: <%= _('Section 22') %>, value: section-22 }
-    - { label: <%= _('Section 30') %>, value: section-30 }
-    - { label: <%= _('Section 31') %>, value: section-31 }
-    - { label: <%= _('Section 35') %>, value: section-35 }
-    - { label: <%= _('Section 38') %>, value: section-38 }
-    - { label: <%= _('Section 40') %>, value: section-40 }
-    - { label: <%= _('Section 41') %>, value: section-41 }
-    - { label: <%= _('Section 43') %>, value: section-43 }
+    #- { label: <%= _('Section 11 - Means by which communication to be made') %>, value: section-11 }
+    - { label: <%= _('Section 12 - Cost of Compliance') %>, value: section-12 }
+    - { label: <%= _('Section 14 - Vexatious and repeated requests') %>, value: section-14 }
+    - { label: <%= _('Section 21 - Information Accessible By Other Means') %>, value: section-21 }
+    - { label: <%= _('Section 22 - Information Intended For Future Publication') %>, value: section-22 }
+    - { label: <%= _('Section 30 - Investigations And Proceedings Conducted By Public Authorities') %>, value: section-30 }
+    - { label: <%= _('Section 31 - Law Enforcement') %>, value: section-31 }
+    - { label: <%= _('Section 35 - Formulation Of Government Policy') %>, value: section-35 }
+    - { label: <%= _('Section 38 - Health And Safety') %>, value: section-38 }
+    - { label: <%= _('Section 40 - Personal Information') %>, value: section-40 }
+    - { label: <%= _('Section 41 - Information Provided In Confidence') %>, value: section-41 }
+    - { label: <%= _('Section 43 - Commercial Interests') %>, value: section-43 }


### PR DESCRIPTION
Add short title to each exemption for better user understanding.

I used a hyphen rather than a colon because after processing the ERB the
YAML interpreter was expecting the whole string to be quoted. This means
we'd have to do something like `<%= _(%q("Section 12: Foo")) %>` which
is pretty gross.

Ideally these labels would support HTML rendering so that we could bold
the section number, but this is the easiest fix for now.

Fixes https://github.com/mysociety/alaveteli/issues/6237

![Screenshot 2021-05-13 at 17 52 29](https://user-images.githubusercontent.com/282788/118159112-880f9400-b414-11eb-92a0-dde3db1b3037.png)
