### PR TITLE
[#819] Tweak advice we give for asking EU authorities

### DIFF
--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -192,9 +192,7 @@
     <% if can_ask_the_eu?(@country_code) %>
       <li>
         Try <%= link_to 'asking for the information from the European Union',
-        'http://www.asktheeu.org' %>. Every one of the 500 million people
-        living in the European Union (both citizens and residents) has the
-        legally guaranteed right to ask for information from EU authorities.
+        'http://www.asktheeu.org' %>.
         <%= link_to 'AskTheEU.org', 'http://www.asktheeu.org' %> is a version of
         this website for the European Union.
       </li>


### PR DESCRIPTION
We had a user support query around whether British citizens can make FOI
requests to the EU.

* Many WDTK users may be EU citizens and British residents.
* The withdrawal agreement has a section on this [1] (p182 of the document,
  p187 of the PDF). it looks as if UK people and entities still have a
  right of access to EU documents: "in connection with activities of the
  Union pursuant to this Agreement".
* AskTheEU's help page suggests that most people can ask anyway [2]

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/819

[1] https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/840655/Agreement_on_the_withdrawal_of_the_United_Kingdom_of_Great_Britain_and_Northern_Ireland_from_the_European_Union_and_the_European_Atomic_Energy_Community.pdf
[2] https://www.asktheeu.org/en/help/about

![Screenshot 2021-05-26 at 17 44 49](https://user-images.githubusercontent.com/282788/119699478-20147100-be4a-11eb-9895-8869342d66f0.png)
