### PR TITLE
[#838] Change references in help pages

### DIFF
--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -245,7 +245,7 @@
   <p>
     In those cases we bear in mind that our Freedom of Information law is
     “applicant blind”, so anyone in the world can request the same document and
-    get a copy of it. We also want to save taxpayers’ money by preventing
+    get a copy of it. We also want to save public money by preventing
     duplicate requests.
   </p>
   <h4 id="compassionate_grounds">

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -382,7 +382,7 @@
       </p>
       <p>
         However, it’s our belief that by publishing responses, you are saving
-        taxpayers’ money by preventing duplicate requests, and you’re also
+        public money by preventing duplicate requests, and you’re also
         fostering good public relations, so we always advise keeping it online.
         For more information please refer to the Copyright section of our
         <a href="<%= help_how_path %>">‘How we run


### PR DESCRIPTION
This PR has two commits to change the use of the word "taxpayers'" to "public".

As per the suggestion at #838 and the reasons given. Also recently came up on a review@ thread.

Fixes #838.