### PR TITLE
[#856] Consistent capitalisation of refusals

### DIFF
--- a/config/refusal_advice/exemptions.yml.erb
+++ b/config/refusal_advice/exemptions.yml.erb
@@ -6,14 +6,14 @@ foi:
     options:
     # Update `Legislation.refusals` in model_patches.rb when adding new sections
     - { label: <%= _('Section 11 - Means by which communication to be made') %>, value: section-11 }
-    - { label: <%= _('Section 12 - Cost of Compliance') %>, value: section-12 }
+    - { label: <%= _('Section 12 - Cost of compliance') %>, value: section-12 }
     - { label: <%= _('Section 14 - Vexatious and repeated requests') %>, value: section-14 }
-    - { label: <%= _('Section 21 - Information Accessible By Other Means') %>, value: section-21 }
-    - { label: <%= _('Section 22 - Information Intended For Future Publication') %>, value: section-22 }
-    - { label: <%= _('Section 30 - Investigations And Proceedings Conducted By Public Authorities') %>, value: section-30 }
-    - { label: <%= _('Section 31 - Law Enforcement') %>, value: section-31 }
-    - { label: <%= _('Section 35 - Formulation Of Government Policy') %>, value: section-35 }
-    - { label: <%= _('Section 38 - Health And Safety') %>, value: section-38 }
-    - { label: <%= _('Section 40 - Personal Information') %>, value: section-40 }
-    - { label: <%= _('Section 41 - Information Provided In Confidence') %>, value: section-41 }
-    - { label: <%= _('Section 43 - Commercial Interests') %>, value: section-43 }
+    - { label: <%= _('Section 21 - Information accessible by other means') %>, value: section-21 }
+    - { label: <%= _('Section 22 - Information intended for future publication') %>, value: section-22 }
+    - { label: <%= _('Section 30 - Investigations and proceedings conducted by public authorities') %>, value: section-30 }
+    - { label: <%= _('Section 31 - Law enforcement') %>, value: section-31 }
+    - { label: <%= _('Section 35 - Formulation of government policy') %>, value: section-35 }
+    - { label: <%= _('Section 38 - Health and safety') %>, value: section-38 }
+    - { label: <%= _('Section 40 - Personal information') %>, value: section-40 }
+    - { label: <%= _('Section 41 - Information provided in confidence') %>, value: section-41 }
+    - { label: <%= _('Section 43 - Commercial interests') %>, value: section-43 }


### PR DESCRIPTION
mySociety house style is to capitalise the first letter of a title but
not for subsequent words. The legislation [1] uses this style too.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/856.

[1] https://www.legislation.gov.uk/ukpga/2000/36/section/11