### PR TITLE
Add email for MoJ Digital and Technology to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -110,5 +110,6 @@ Rails.configuration.to_prepare do
     myaccount@coventry.gov.uk
     C&PCCC@highwaysengland.co.uk
     DONOTREPLY@3csharedservices.vuelio.co.uk
+    D&TCDIO_Office@justice.gov.uk
   )
 end


### PR DESCRIPTION
## Relevant issue(s)
Fixes #860 

## What does this do?
This patch adds the email address for the Ministry of Justice Digital and Technology team to model_patches.rb 

## Why was this needed?
Workaround for known bug which causes issues with email addresses where special characters are present.

## Implementation notes
Nothing specific, this is the usual 'tried and tested' change to mitigate the issue described in https://github.com/mysociety/alaveteli/issues/3465

## Screenshots
N/A

## Notes to reviewer
N/A