### PR TITLE
[#881] Add citrix sharefile notification address to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -112,5 +112,6 @@ Rails.configuration.to_prepare do
     DONOTREPLY@3csharedservices.vuelio.co.uk
     D&TCDIO_Office@justice.gov.uk
     FOI.Enquiries@ukaea.uk
+    mail@sf-notifications.com
   )
 end


### PR DESCRIPTION
## Relevant issue(s)
Fixes #881 

## What does this do?
This patch adds the Citrix ShareFile notification email address to model_patches.rb.

## Why was this needed?
This is needed to prevent users from sending messages to a no-reply address (which is unroutable) and falling into a loop.

## Implementation notes
Nothing specific, a minor change to long-standing code.

## Screenshots
N/A

## Notes to reviewer
N/A