### PR TITLE
[#887] Add new invalid email address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -113,5 +113,6 @@ Rails.configuration.to_prepare do
     D&TCDIO_Office@justice.gov.uk
     FOI.Enquiries@ukaea.uk
     mail@sf-notifications.com
+    Paul.D.O'Shea@met.police.uk
   )
 end


### PR DESCRIPTION
This commit adds Paul.D.O'Shea@met.police.uk as an invalid reply to address to prevent Alaveteli attempting to send replies to it (which currently fail due to the apostrophe).

Fixes #887 