### PR TITLE
Update help page history URLs

### DIFF
--- a/lib/help_page_history.rb
+++ b/lib/help_page_history.rb
@@ -7,7 +7,7 @@ class HelpPageHistory
   end
 
   def commits_url
-    template.inspect.gsub(/lib\/themes\/whatdotheyknow-theme/, GITHUB_BASE)
+    template.short_identifier.gsub(/lib\/themes\/whatdotheyknow-theme/, GITHUB_BASE)
   end
 
   protected

--- a/spec/help_page_history_spec.rb
+++ b/spec/help_page_history_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe HelpPageHistory do
 
     context 'with a custom help page' do
       let(:template) do
-        double(inspect: 'lib/themes/whatdotheyknow-theme/lib/views/' \
-                        'help/house_rules.html.erb')
+        double(short_identifier: 'lib/themes/whatdotheyknow-theme/lib/views/' \
+                                 'help/house_rules.html.erb')
       end
 
       it do


### PR DESCRIPTION
Since updating to Rails 6.0 the URLs generated to the GitHub help page
history has been broken due to a change in `ActionView::Template`.

See: https://github.com/rails/rails/commit/dcb13470991539ab581e02670738900c39976ff4
Fixes #893