### PR TITLE
[#931] Prevent disabling of Internal Admin email alerts

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -115,4 +115,18 @@ Rails.configuration.to_prepare do
     mail@sf-notifications.com
     Paul.D.O'Shea@met.police.uk
   )
+
+  User::EmailAlerts.instance_eval do
+    module DisableWithProtection
+      def disable
+        if user.url_name == 'internal_admin_user'
+          raise "Email alerts should not be disabled for #{user.name}!"
+        end
+
+        super
+      end
+    end
+
+    prepend DisableWithProtection
+  end
 end

--- a/spec/model_patches_spec.rb
+++ b/spec/model_patches_spec.rb
@@ -144,3 +144,16 @@ RSpec.describe PublicBody do
   end
 
 end
+
+RSpec.describe User::EmailAlerts do
+  describe '#disable' do
+    context 'with the internal admin user' do
+      let(:user) { double(name: 'Admin', url_name: 'internal_admin_user') }
+
+      it 'prevents alerts being disabled' do
+        expect { described_class.new(user).disable }.
+          to raise_error('Email alerts should not be disabled for Admin!')
+      end
+    end
+  end
+end


### PR DESCRIPTION
For some reason we keep seeing email alerts getting disabled for the
Internal Admin User on WhatDoTheyKnow.

We think this is somehow related to the Unsubscribe link rendered via
`app/views/track_mailer/event_digest`. Perhaps someone is mistakenly
clicking it, or an email client is pre-emptively clicking it to cache
content? Who knows!?

This commit checks that the user is _not_ the Internal Admin before
disabling. I used a new module with `prepend` so that we can call
`super` to rely on core behaviour, rather than having to keep the main
method definition in sync.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/931.

To test:

```ruby
admin_token = User::EmailAlerts.token(User.internal_admin_user)
app.users_disable_email_alerts_url(token: admin_token)
# => click link - exception raised

user_token = User::EmailAlerts.token(User.first)
app.users_disable_email_alerts_url(token: user_token)
# => click link - alerts disabled
```