### PR TITLE
[#939] Add Somerset West and Taunton Deane to model_patches.rb

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -115,6 +115,7 @@ Rails.configuration.to_prepare do
     mail@sf-notifications.com
     Paul.D.O'Shea@met.police.uk
     no-reply@somersetwestandtaunton.gov.uk
+    csfinanceplanning&performance.briefingteam@hmrc.gov.uk
   )
 
   User::EmailAlerts.instance_eval do

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -114,6 +114,7 @@ Rails.configuration.to_prepare do
     FOI.Enquiries@ukaea.uk
     mail@sf-notifications.com
     Paul.D.O'Shea@met.police.uk
+    no-reply@somersetwestandtaunton.gov.uk
   )
 
   User::EmailAlerts.instance_eval do


### PR DESCRIPTION
## Relevant issue(s)
#939 

## What does this do?
This change adds the no-reply address used by Somerset West & Taunton Deane council to model_patches.rb

## Why was this needed?
The council issues their replies from a no-reply address, which can get our users stuck in a loop.

## Implementation notes
Nothing specific, it's the usual tried and tested code.

Of slight note perhaps - the address directly above has an apostrophe in it, I'm not certain whether or not this needs to be escaped. I assume not, given the code hasn't malfunctioned, but I'm not 100% certain!

## Screenshots
N/A

## Notes to reviewer
N/A