### PR TITLE
[#961] Change wording on contact form

### DIFF
--- a/lib/views/help/_contact_form.html.erb
+++ b/lib/views/help/_contact_form.html.erb
@@ -6,7 +6,7 @@
         <%= f.check_box :understand, :required => true %>
         <label for="contact_understand" class="form_label">
             I understand that WhatDoTheyKnow is <strong>not</strong> run by the
-            government, and the WhatDoTheyKnow volunteers <strong>cannot</strong>
+            government, and the WhatDoTheyKnow team <strong>cannot</strong>
             help me with personal matters relating to government services.
         </label>
     </p>
@@ -36,7 +36,7 @@
 
     <p>
         <label class="form_label" for="contact_message">
-            My message to the WhatDoTheyKnow volunteers:
+            My message to the WhatDoTheyKnow team:
         </label>
         <%= f.text_area :message, :rows => 10, :cols => 60, :required => true %>
     </p>
@@ -77,7 +77,7 @@
         //--></script>
         <%= hidden_field_tag(:current_form, form_id) %>
         <%= hidden_field_tag(:submitted_contact_form, 1) %>
-        <%= submit_tag "Send message to WhatDoTheyKnow volunteers", :data => { :disable_with => "Sending..." } %>
+        <%= submit_tag "Send message to WhatDoTheyKnow team", :data => { :disable_with => "Sending..." } %>
     </div>
 
 <% end %>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -78,7 +78,7 @@
     <div class="houdini-target contact-page__options">
         <ul>
             <li>
-                Directly contact the volunteers who run WhatDoTheyKnow:
+                Directly contact the team that run WhatDoTheyKnow:
 
                 <%= foi_error_messages_for :contact %>
 
@@ -112,7 +112,7 @@
                     directly contact the team who run WhatDoTheyKnow Pro:
                 <% else %>
                     If your issue isn’t covered by our help pages, you can
-                    directly contact the volunteers who run WhatDoTheyKnow:
+                    directly contact the team that run WhatDoTheyKnow:
                 <% end %>
 
                 <%= foi_error_messages_for :contact %>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #961 

## What does this do?
This change replaces "volunteers" with "team", along with minor phrasing changes, on /help/contact and in the relevant partial for the contact form.

## Why was this needed?

This is needed to better reflect the increased diversity of the team that handles user support correspondence, and the changing ways in which WhatDoTheyKnow / WhatDoTheyKnow Pro is administered. This is discussed in greater detail on the linked issue.

## Implementation notes
Nothing controversial, this is a series of minor changes to established code.

## Screenshots
N/A

## Notes to reviewer
N/A