### PR TITLE
Add public body questions for Social Security agencies

### DIFF
--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -42,6 +42,7 @@ Rails.configuration.to_prepare do
       </p>
     HTML
   )
+  ## Generic boilerplate templates for reuse
 
   ## LSE
 
@@ -134,7 +135,7 @@ Rails.configuration.to_prepare do
     HTML
     # we reuse this multiple times with #{generic_deny_boilerplate}
   )
-  
+
   generic_deny_askcouncil  = _(<<-HTML.strip_heredoc.squish
       <p>
         Your local Council might also offer a Welfare Rights 
@@ -160,6 +161,140 @@ Rails.configuration.to_prepare do
       <hr>
     HTML
     # we reuse this multiple times with #{generic_deny_gdpr_rightofaccess}
+  )
+  
+  home_office_deny_response_immi = _(
+    <<-HTML.strip_heredoc.squish
+      <h3>
+        You cannot do this using WhatDoTheyKnow
+      </h3>
+      <p>
+        We understand that it can be difficult to get a response from the Home
+        Office to personal immigration queries - but you must not use 
+        WhatDoTheyKnow to contact the Home Office about this.
+      </p>
+      <p>
+        You can contact the Home Office, or UK Visas and Immigration, by:
+        <ul>
+          <li>
+            contacting the 
+            <a href="https://www.gov.uk/contact-ukvi-inside-outside-uk">
+            UKVI helpline</a>
+          </li>
+          <li>
+            sending an email to 
+            <a href="mailto:public.enquiries@homeoffice.gov.uk">
+            public.enquiries@homeoffice.gov.uk</a>
+          </li>
+          <li>
+            calling or writing to the 
+            <a href="https://www.homeoffice.gov.uk#org-contacts">
+            Direct Communications Unit</a>
+          </li>
+        </ul>
+      </p>
+      <h4>If you're having trouble getting an answer</h4>
+      <section>
+      <p>
+        If you are in the UK, we suggest writing to the Home Office via a local 
+        Member of Parliament. Your MP (or their staff) can pass your query onto 
+        on to the Home Office and ensure you get a response. This has the 
+        benefit of highlighting difficulties communicating with the Home Office 
+        to MPs.
+      </p>
+      <div style="text-align:center">
+        <a class="button" 
+        onclick="if (ga) { ga('send','event','Outbound Link','Write To Them Exit','Public Body Questions',1) };" 
+        href="http://www.writetothem.com">
+        Send a message to your MP using WriteToThem »
+        </a>
+      </div>
+      <p>
+        You could also seek help from:
+        <ul>
+          <li>
+            <a href="https://www.migranthelpuk.org/contact">
+            Migrant Help</a>
+          </li>
+          <li>
+            <a href="https://www.citizensadvice.org.uk/immigration/">
+            Citizens Advice</a>
+          </li>
+          <li>
+            <a href="https://www.jcwi.org.uk/our-helplines">
+            the <abbr title="Joint Council for the Welfare of Immigrants">
+            JCWI</abbr> </a>
+          </li>
+          <li>
+            <a href="https://www.libertyhumanrights.org.uk/advice_information/i-need-immigration-advice/">
+            your local advice services</a>
+          </li>
+          <li>
+            <a href="https://www.gov.uk/find-an-immigration-adviser">
+            a registered Immigration Adviser
+            </a>
+          </li>
+        </ul>
+      <strong>Please note: WhatDoTheyKnow are unable to provide you with advice 
+      regarding Immigration matters.</strong>
+      </section>
+      &nbsp;
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  home_office_deny_response_passport = _(<<-HTML.strip_heredoc.squish
+      <h3>
+        You cannot do this using WhatDoTheyKnow
+      </h3>
+      <p>
+        Passports are handled by 
+        <a href="/body/hm_passport_office">HM Passport Service</a>, 
+        which is an agency of the Home Office. 
+      </p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.gov.uk/browse/abroad/passports">
+        Find out about Passports on gov.uk »
+        </a>
+      </div>
+      <h4>How do I contact HM Passport Service?</h4>
+      <p>
+        You can find contact details for the Passport Advice Line on the 
+        <a href="https://www.gov.uk/passport-advice-line">gov.uk website</a>.
+      </p>
+      &nbsp;
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  home_office_deny_response_rightofaccess = _(<<-HTML.strip_heredoc.squish 
+      #{generic_deny_gdpr_rightofaccess}
+      <h4>
+        Getting access to your personal information held by the Home Office 
+        and its agencies
+      </h4>
+      <p>
+        Sometimes, you don't need to make a formal request - if you simply need 
+        proof of your immigration status, or have a query, contacting the 
+        office that handles your case can often be quicker.
+      </p>
+      <p>  
+        You can find details on how to make a <strong>Right of Access request
+        </strong> to the Home Office and its agencies 
+        <a href="https://www.gov.uk/government/organisations/home-office/about/personal-information-charter#how-to-ask-for-your-personal-information">
+        on gov.uk</a>.
+      </p>
+      <p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.gov.uk/government/organisations/home-office/about/personal-information-charter#how-to-ask-for-your-personal-information">
+        Make a Right of Access request on the Home Office website»
+        </a>
+      </div>
+      &nbsp;
+      #{generic_deny_boilerplate}
+    HTML
   )
 
   dfc_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
@@ -991,23 +1126,44 @@ socsecscot_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
   PublicBodyQuestion.build(
     public_body: home_office,
     key: :visa,
-    question: _('Asking about your Visa?'),
-    response: home_office_deny_response
+    question: _('Get information about my Visa'),
+    response: home_office_deny_response_immi
+  )
+
+  PublicBodyQuestion.build(
+    public_body: home_office,
+    key: :immigration,
+    question: _('Get advice on my immigration case'),
+    response: home_office_deny_response_immi
   )
 
   PublicBodyQuestion.build(
     public_body: home_office,
     key: :brp,
-    question: _('Asking about Biometric Residence Permit (BRP) replacements ' \
-                'or refunds?'),
-    response: home_office_deny_response
+    question: _('Find out about Biometric Residence Permit (BRP) ' \
+                'replacements or refunds?'),
+    response: home_office_deny_response_immi
+  )
+
+  PublicBodyQuestion.build(
+    public_body: home_office,
+    key: :passport,
+    question: _('Get or replace a passport'),
+    response: home_office_deny_response_passport
+  )
+
+  PublicBodyQuestion.build(
+    public_body: home_office,
+    key: :contact_rightofaccess,
+    question: _('Get a copy of information held about me'),
+    response: home_office_deny_response_rightofaccess
   )
 
   PublicBodyQuestion.build(
     public_body: home_office,
     key: :foi,
-    question: _('Asking for recorded information held by a public body that ' \
-                'anyone could reasonably request and expect to receive?'),
+    question: _('Ask for recorded information that <strong>anyone</strong> ' \
+                'could reasonably request and expect to receive'),
     response: :allow
   )
 

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -1267,6 +1267,9 @@ socsecscot_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
     key: :foi,
     question: _('Ask for recorded information held by a public body ' \
                 '<strong>on any other topic</strong> that ' \
+                'anyone could reasonably request and expect to receive?'),
+    response: :allow
+  )
   ## Department for Communities
 
   PublicBodyQuestion.build(

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -12,6 +12,7 @@ Rails.configuration.to_prepare do
   ## Generic boilerplate templates for reuse
 
   ## public body specific templates
+  dfc = PublicBody.find_by_url_name('dfc')
   dwp = PublicBody.find_by_url_name('dwp')
 
   home_office_deny_response = _(
@@ -149,6 +150,207 @@ Rails.configuration.to_prepare do
       <hr>
     HTML
     # we reuse this multiple times with #{generic_deny_gdpr_rightofaccess}
+  )
+
+  dfc_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot do this using WhatDoTheyKnow</h3>
+
+      <p>
+        You can find information about how to claim benefits on the
+        <a href="https://www.nidirect.gov.uk/campaigns/unclaimed-benefits">
+        NIDirect website</a>.
+      </p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.nidirect.gov.uk/campaigns/unclaimed-benefits">
+        Find out about benefits on NIDirect »</a>
+      </div>
+      <p>
+        Information you might find useful:
+        <ul>
+          <li>
+            You can get free advice on what benefits you may be entitled to  
+            from the 
+            <a href="https://www.nidirect.gov.uk/contacts/make-call-service">
+            Make the Call service</a>.
+          </li>
+          <li>
+            You can use an independent 
+            <a href="https://www.nidirect.gov.uk/articles/benefits-calculator">
+            benefits calculator</a> to find out what benefits and services that 
+            you may be entitled to.
+          </li>
+          <li>
+            In <strong>other parts of the UK</strong>, most benefits are managed 
+            directly by the 
+            <a href="/body/dwp">Department for Work and Pensions</a> or 
+            <a href="/body/social_security_scotland">
+            Social Security Scotland</a>. 
+            You can find further information on 
+            <a href="https://www.gov.uk/browse/benefits">
+            gov.uk</a> and 
+            <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>.
+          </li>
+          <li>
+            If you are unsure about benefits and need advice, contact 
+            <a href="https://www.adviceni.net/benefits">
+            Advice NI</a>, or your local 
+            <a href="https://www.adviceni.net/local-advice">Advice Agency</a> 
+            for independent help and support. <br><br>
+            Your local Council might also offer a Welfare Rights service, or be 
+            able to signpost you to a service in your area that can help.
+          </li>
+        </ul>
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+  
+  dfc_deny_response_benefits_contact = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot do this using WhatDoTheyKnow</h3>
+
+      <p>
+        You should contact the office that handles your claim directly with any 
+        concerns that you might have. You'll find their details on the  
+        <a href="https://www.communities-ni.gov.uk/social-security-phone-services">
+        Department for Communities website</a>, or below.<br><br>
+      </p>
+      <hr>
+        To contact the Department for Communities about your benefits, 
+        you will need to do so using another method. If you're unsure who to 
+        contact, ask the 
+        <a href="https://www.communities-ni.gov.uk/contacts/customer-service-social-security">
+        Customer Services team</a> for help.
+      </p>
+      <section>
+      <h4>Employment and Support Allowance (ESA)</h4>
+       <ul>
+          <li>
+            To contact <strong>Attendance Allowance</strong>, 
+            <strong>Carers Allowance</strong>, or
+            <strong>Disability Living Allowance</strong>, visit the
+            <a href="https://www.nidirect.gov.uk/contacts/employment-and-support-allowance-centre">
+            NIDirect website</a>.
+          </li>
+        </ul>
+      </section>
+      <section>
+      <h4>Jobs and Benefit Offices</h4>
+        <ul>
+          <li>
+            To contact your local Jobs and Benefit Office via phone, email, or 
+            Video Relay, find their details on the
+            <a href="https://www.nidirect.gov.uk/contacts/jobs-and-benefits-offices">
+            NIDirect website</a>
+          </li>
+        </ul>
+      </section>
+      <section>
+      <h4>Disability Benefits</h4>
+        <ul>
+          <li>
+            To contact <strong>Attendance Allowance</strong>, 
+            <strong>Carers Allowance</strong>, or
+            <strong>Disability Living Allowance</strong>, visit the
+            <a href="https://www.nidirect.gov.uk/contacts/disability-and-carers-service">
+            NIDirect website</a>.
+          </li>
+          <li>
+            <strong>Personal Independence Payment</strong> is handled by the 
+            PIP Centre. You can find their details 
+            <a href="https://www.nidirect.gov.uk/contacts/personal-independence-payment-pip-centre">
+            here</a>.
+          </li>
+        </ul>
+      </section>
+      <section>
+      <h4>Universal Credit</h4>
+      <p>
+        <ul>
+          <li>
+            You can find out more about Universal Credit on the 
+            <a href="https://www.nidirect.gov.uk/campaigns/universal-credit">
+            NIDirect website</a>.
+          </li>
+          <li>
+            If you've an <strong>existing claim</strong> you can manage it, and 
+            send messages to the Universal Credit Service Centre via the 
+            <a href="https://www.universal-credit.service.gov.uk/sign-in">
+            Universal Credit journal</a>.
+          </li>
+          <li>
+            You can also contact the 
+            <a href="https://www.nidirect.gov.uk/contacts/universal-credit-service-centre">
+            Universal Credit Service Centre</a> by phone or video relay.
+          </li>
+          <li>
+            You can also find details about <strong>other help and financial
+            support</strong> on the
+            <a href="https://www.adviceni.net/benefits/universal-credit">
+            Advice NI</a> website.
+          </li>
+        </ul>
+      </p>
+      </section>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  dfc_deny_response_make_dfc_complaint = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot make a complaint using WhatDoTheyKnow</h3>
+
+      <p>
+        You should contact the office that handles your claim directly.
+        You can find their complaints procedure and contact details on the 
+        <a href="https://www.communities-ni.gov.uk/social-security-complaints">
+        NIDirect website</a>.
+          <ul>
+          <li>
+            You could also try emailing DfC Customer Services team directly at 
+            <a href="mailto:customerservice.unit@communities-ni.gov.uk">
+            customerservice.unit@communities-ni.gov.uk
+            </a>
+          </li>
+          <li>
+            You can also <a onclick="if (ga) { ga('send','event','Outbound Link','Write To Them Exit','Public Body Questions',1) };" 
+            href="http://www.writetothem.com">
+            write to your elected members</a> for help.
+          </li>
+          <li>
+            You can also seek independent advice, from 
+            <a href="https://www.adviceni.net/benefits">Advice NI</a>, a local 
+            <a href="https://www.adviceni.net/local-advice">Advice Agency</a>, 
+            or the <a href="https://www.lawcentreni.org/">Law Centre</a> 
+          </li>
+        </ul> 
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  dfc_deny_response_rightofaccess = _(<<-HTML.strip_heredoc.squish 
+      #{generic_deny_gdpr_rightofaccess}
+      <h4>Getting access to information held by Department for Communities</h4>
+      <p>
+        Sometimes, you don't need to make a formal request - if you simply need 
+        proof of your benefits, contacting the Benefit Office that handles your 
+        claim can often be quicker.
+      </p>
+      <p>  
+        You can find details on how to make a <strong>Right of Access request
+        </strong> to the Department for Communities and its agencies 
+        <a href="https://www.communities-ni.gov.uk/right-access-request">
+        on nidirect.gov.uk</a>.
+      </p>
+      <p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.communities-ni.gov.uk/right-access-request">
+        Make a Right of Access request on the DfC website»</a>
+      </div>
+      &nbsp;
+      #{generic_deny_boilerplate}
+    HTML
   )
 
   dwp_deny_response_contact_boilerplate = _(<<-HTML.strip_heredoc.squish
@@ -620,6 +822,50 @@ Rails.configuration.to_prepare do
     question: _('Ask for recorded information held by a public body ' \
                 '<strong>on any other topic</strong> that ' \
   PublicBodyQuestion.build(
+    public_body: dfc,
+    key: :dfc_claim_benefits,
+    question: _('Make a claim for Social Security benefits'),
+    response: dfc_deny_response_benefits_claim
+  )
+
+  PublicBodyQuestion.build(
+    public_body: dfc,
+    key: :dfc_claim_pension,
+    question: _('Claim my State Pension'),
+    response: dwp_deny_response_claim_pension
+    # We reuse the DWP response here as it is substantively the same.
+  )
+
+  PublicBodyQuestion.build(
+    public_body: dfc,
+    key: :dfc_contact_benefits,
+    question: _('Contact DfC about my Social Security benefits'),
+    response: dfc_deny_response_benefits_contact
+  )
+  
+  PublicBodyQuestion.build(
+    public_body: dfc,
+    key: :contact_rightofaccess,
+    question: _('Get a copy of information held about me'),
+    response: dfc_deny_response_rightofaccess
+  )
+
+  PublicBodyQuestion.build(
+    public_body: dfc,
+    key: :make_dfc_complaint,
+    question: _('Make a complaint'),
+    response: dfc_deny_response_make_dfc_complaint
+  )
+
+  PublicBodyQuestion.build(
+    public_body: dfc,
+    key: :foi,
+    question: _('Ask for recorded information that <strong>anyone</strong> ' \
+                'could reasonably request and expect to receive'),
+    response: :allow
+  )
+
+  PublicBodyQuestion.build(
     public_body: dwp,
     key: :claim_benefits,
     question: _('Claim social security benefits'),
@@ -707,8 +953,8 @@ Rails.configuration.to_prepare do
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :foi,
-    question: _('Ask for recorded information held by a public body that ' \
-                'anyone could reasonably request and expect to receive'),
+    question: _('Ask for recorded information that <strong>anyone</strong> '\
+                'could reasonably request and expect to receive'),
     response: :allow
   )
 end

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -140,7 +140,7 @@ Rails.configuration.to_prepare do
             nidirect.gov.uk</a>
           </li>
           <li>
-            In Scotland, some benefits are managed directly by 
+            In <b>Scotland</b>, some benefits are managed directly by 
             <a href="/body/social_security_scotland">Social Security Scotland</a>.
             You can find information on
             <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>
@@ -161,13 +161,13 @@ Rails.configuration.to_prepare do
       <p>
         Information you might find useful:
         <ul>
-          <li>In <b>Northern Ireland</b> you need to contact the 
+          <li>In <b>Northern Ireland</b>, you need to contact the 
           <a href="/body/dfc">Department for Communities</a> to make your claim.
            You can find more information on:
            <a href="https://www.nidirect.gov.uk/services/get-your-state-pension">
            nidirect.gov.uk</a>.
           </li>
-          <li>If you are <b>outside the UK</b> you need to contact the 
+          <li>If you are <b>outside the UK</b>, you need to contact the 
           <a href="https://www.gov.uk/state-pension-if-you-retire-abroad">
           International Pensions Centre</a> to make your claim.
           </li>
@@ -254,7 +254,7 @@ Rails.configuration.to_prepare do
     question: _('Claim my State Pension'),
     response: dwp_deny_response_2
   )
-  
+
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :foi,

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -119,6 +119,7 @@ Rails.configuration.to_prepare do
   ## build public body questions
 
   dwp_deny_response_1 = _(<<-HTML.strip_heredoc.squish
+  dwp_deny_response_claim_benefits = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot make a claim using WhatDoTheyKnow</h3>
 
       <p>
@@ -129,20 +130,21 @@ Rails.configuration.to_prepare do
         Information you might find useful:
         <ul>
           <li>
-            You can use a <a href="https://www.gov.uk/benefits-calculators">
+            You can use an independent 
+            <a href="https://www.gov.uk/benefits-calculators">
             benefits calculator</a> to find out what you may be entitled to.
           </li>
           <li>
-            In <b>Northern Ireland</b>, some benefits are managed directly by
-            the <a href="/body/dfc">Department for Communities</a>. You can find
-            information on 
+            In <strong>Northern Ireland</strong>, some benefits are managed 
+            directly by the <a href="/body/dfc">Department for Communities</a>. 
+            You can find further information on 
             <a href="https://www.nidirect.gov.uk/campaigns/unclaimed-benefits">
             nidirect.gov.uk</a>
           </li>
           <li>
-            In <b>Scotland</b>, some benefits are managed directly by 
+            In <strong>Scotland</strong>, some benefits are managed directly by 
             <a href="/body/social_security_scotland">Social Security Scotland</a>.
-            You can find information on
+            You can find further information on
             <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>
           </li>
         </ul>
@@ -151,7 +153,7 @@ Rails.configuration.to_prepare do
     HTML
   )
 
-  dwp_deny_response_2 = _(<<-HTML.strip_heredoc.squish
+  dwp_deny_response_claim_pension = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot claim your State Pension using WhatDoTheyKnow</h3>
 
       <p>
@@ -245,16 +247,58 @@ Rails.configuration.to_prepare do
     public_body: dwp,
     key: :claim_benefits,
     question: _('Claim social security benefits'),
-    response: dwp_deny_response_1
+    response: dwp_deny_response_claim_benefits
   )
 
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :claim_pension,
     question: _('Claim my State Pension'),
-    response: dwp_deny_response_2
+    response: dwp_deny_response_claim_pension
   )
 
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :contact_disabilitycentre,
+    question: _('Contact the Disability Service Centre (AA / ESA / PIP)'),
+    response: dwp_deny_response_contact_dwp
+  )
+  
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :contact_jcp,
+    question: _('Contact Jobcentre Plus'),
+    response: dwp_deny_response_contact_dwp
+  )
+  
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :contact_universalcredit,
+    question: _('Contact Universal Credit'),
+    response: dwp_deny_response_contact_dwp
+  )
+  
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :challenge_a_decision,
+    question: _('Challenge a decision'),
+    response: dwp_deny_response_challenge_dwp
+  )
+  
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :manage_child_maintenance,
+    question: _('Manage your Child Maintenance / Support case'),
+    response: dwp_deny_response_manage_csa
+  )
+  
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :make_dwp_complaint,
+    question: _('Make a complaint'),
+    response: dwp_deny_response_make_dwp_complaint
+  )
+  
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :foi,

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -178,6 +178,36 @@ Rails.configuration.to_prepare do
     HTML
   )
 
+  dwp_deny_response_contact_dwp = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot use WhatDoTheyKnow to do this.</h3>
+
+      <p>
+      </p>
+    HTML
+  )
+  dwp_deny_response_challenge_dwp = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot challenge a benefits decision using WhatDoTheyKnow</h3>
+
+      <p>
+      </p>
+    HTML
+  )
+  dwp_deny_response_manage_csa = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot use WhatDoTheyKnow to manage your Child Support case</h3>
+
+      <p>
+      </p>
+    HTML
+  )
+  dwp_deny_response_make_dwp_complaint = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot make a complaint using WhatDoTheyKnow</h3>
+
+      <p>
+      </p>
+    HTML
+  )
+
+
   PublicBodyQuestion.build(
     public_body: home_office,
     key: :visa,

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -14,6 +14,7 @@ Rails.configuration.to_prepare do
   ## public body specific templates
   dfc = PublicBody.find_by_url_name('dfc')
   dwp = PublicBody.find_by_url_name('dwp')
+  socsecscot = PublicBody.find_by_url_name('social_security_scotland')
 
   home_office_deny_response = _(
     <<-HTML.strip_heredoc.squish
@@ -133,7 +134,16 @@ Rails.configuration.to_prepare do
     HTML
     # we reuse this multiple times with #{generic_deny_boilerplate}
   )
-
+  
+  generic_deny_askcouncil  = _(<<-HTML.strip_heredoc.squish
+      <p>
+        Your local Council might also offer a Welfare Rights 
+        service, or be able to signpost you to a service in your area 
+        that can help.
+      </p>
+    HTML
+    # we reuse this multiple times with #{generic_deny_askcouncil}
+  )
   generic_deny_gdpr_rightofaccess = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot do this using WhatDoTheyKnow</h3>
       <p>
@@ -192,13 +202,27 @@ Rails.configuration.to_prepare do
             <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>.
           </li>
           <li>
-            If you are unsure about benefits and need advice, contact 
-            <a href="https://www.adviceni.net/benefits">
-            Advice NI</a>, or your local 
-            <a href="https://www.adviceni.net/local-advice">Advice Agency</a> 
-            for independent help and support. <br><br>
-            Your local Council might also offer a Welfare Rights service, or be 
-            able to signpost you to a service in your area that can help.
+            If you are unsure about benefits and need advice, you could contact 
+            You can also seek independent advice, from:
+            <ul>
+              <li>
+                <a href="https://www.adviceni.net/benefits">
+                Advice NI</a>
+              <li>
+                your local 
+                <a href="https://www.adviceni.net/local-advice">
+                Advice Agency</a>
+              </li>
+              <li>
+              <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
+              </li>
+              <li>
+                or your local 
+                <a href="https://www.lawcentreni.org/">
+                Law Centre</a>.
+              </li>
+            </ul>
+            #{generic_deny_askcouncil}
           </li>
         </ul>
       </p>
@@ -213,7 +237,7 @@ Rails.configuration.to_prepare do
         You should contact the office that handles your claim directly with any 
         concerns that you might have. You'll find their details on the  
         <a href="https://www.communities-ni.gov.uk/social-security-phone-services">
-        Department for Communities website</a>, or below.<br><br>
+        Department for Communities website</a>, or below.
       </p>
       <hr>
         To contact the Department for Communities about your benefits, 
@@ -224,7 +248,7 @@ Rails.configuration.to_prepare do
       </p>
       <section>
       <h4>Employment and Support Allowance (ESA)</h4>
-       <ul>
+      <ul>
           <li>
             To contact <strong>Attendance Allowance</strong>, 
             <strong>Carers Allowance</strong>, or
@@ -296,7 +320,7 @@ Rails.configuration.to_prepare do
     HTML
   )
 
-  dfc_deny_response_make_dfc_complaint = _(<<-HTML.strip_heredoc.squish
+  dfc_deny_response_make_complaint = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot make a complaint using WhatDoTheyKnow</h3>
 
       <p>
@@ -317,10 +341,26 @@ Rails.configuration.to_prepare do
             write to your elected members</a> for help.
           </li>
           <li>
-            You can also seek independent advice, from 
-            <a href="https://www.adviceni.net/benefits">Advice NI</a>, a local 
-            <a href="https://www.adviceni.net/local-advice">Advice Agency</a>, 
-            or the <a href="https://www.lawcentreni.org/">Law Centre</a> 
+            You can also seek independent advice, from:
+            <ul>
+              <li>
+                <a href="https://www.adviceni.net/benefits">
+                Advice NI</a>
+              <li>
+                your local 
+                <a href="https://www.adviceni.net/local-advice">
+                Advice Agency</a>
+              </li>
+              <li>
+              <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
+              </li>
+              <li>
+                or your local 
+                <a href="https://www.lawcentreni.org/">
+                Law Centre</a>.
+              </li>
+            </ul>
+            #{generic_deny_askcouncil}
           </li>
         </ul> 
       </p>
@@ -385,8 +425,8 @@ Rails.configuration.to_prepare do
           <li>
             You can use an independent 
             <a href="https://www.gov.uk/benefits-calculators">
-            benefits calculator</a> to find out what benefits and services that 
-            you may be entitled to.
+            benefits calculator</a> to find out what benefits and services 
+            that you may be entitled to.
           </li>
           <li>
             In <strong>Northern Ireland</strong>, some benefits are managed 
@@ -396,18 +436,33 @@ Rails.configuration.to_prepare do
             nidirect.gov.uk</a>
           </li>
           <li>
-            In <strong>Scotland</strong>, some benefits are managed directly by 
-            <a href="/body/social_security_scotland">
+            In <strong>Scotland</strong>, some benefits are managed directly 
+            by <a href="/body/social_security_scotland">
             Social Security Scotland</a>. You can find further information on
             <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>
           </li>
           <li>
-            If you are unsure about benefits and need advice, contact 
-            <a href="https://www.citizensadvice.org.uk/benefits/">
-            Citizens Advice</a>, or your local Citizens Advice Bureaux for 
-            independent help and support. <br><br>
-            Your local Council might also offer a Welfare Rights service, or be 
-            able to signpost you to a service in your area that can help.
+            If you are unsure about benefits and need advice, you could get 
+            independent help and support by contacting:
+            <ul>
+              <li>
+                <a href="https://www.citizensadvice.org.uk/benefits/">
+                Citizens Advice</a>
+              <li>
+                your local 
+                <a href="https://www.citizensadvice.org.uk/about-us/contact-us/contact-us/search-for-your-local-citizens-advice/">
+                Citizens Advice Bureaux</a>
+              </li>
+              <li>
+              <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
+              </li>
+              <li>
+                or your local 
+                <a href="https://www.lawcentres.org.uk/i-am-looking-for-advice">
+                Law Centre</a>.
+              </li>
+            </ul>
+            #{generic_deny_askcouncil}
           </li>
         </ul>
       </p>
@@ -464,9 +519,9 @@ Rails.configuration.to_prepare do
       #{dwp_deny_response_contact_boilerplate}
       <h4>Disability and Carers Benefits
         (<abbr title="Attendance Allowance">AA</abbr> /
-         <abbr title="Carers Allowance">CA</abbr> /
-         <abbr title="Disability Living Allowance">DLA</abbr> /
-         <abbr title="Personal Independence Payment">PIP</abbr>)</h4>
+        <abbr title="Carers Allowance">CA</abbr> /
+        <abbr title="Disability Living Allowance">DLA</abbr> /
+        <abbr title="Personal Independence Payment">PIP</abbr>)</h4>
       <p>
         <ul>
           <li>
@@ -699,7 +754,7 @@ Rails.configuration.to_prepare do
     HTML
   )
 
-  dwp_deny_response_make_dwp_complaint = _(<<-HTML.strip_heredoc.squish
+  dwp_deny_response_make_complaint = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot make a complaint using WhatDoTheyKnow</h3>
 
       <p>
@@ -750,6 +805,183 @@ Rails.configuration.to_prepare do
         <a class="button" 
         href="https://www.gov.uk/guidance/request-your-personal-information-from-the-department-for-work-and-pensions#if-you-need-a-copy-of-any-other-information-that-dwp-holds-about-you">
         Make a Right of Access request on the DWP website»</a>
+      </div>
+      &nbsp;
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+socsecscot_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot do this using WhatDoTheyKnow</h3>
+
+      <p>
+        You can find information about how to claim benefits on the
+        <a href="https://www.mygov.scot/browse/benefits/how-to-find-out">
+        mygov.scot website</a>.
+      </p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.mygov.scot/browse/benefits/how-to-find-out">
+        Find out about benefits on mygov.scot »</a>
+      </div>
+      <p>
+        Information you might find useful:
+        <ul>
+          <li>
+            Not all benefits in Scotland are 
+            <a href="https://www.gov.scot/publications/responsibility-for-benefits-overview/">
+            devolved</a>, meaning that some are looked after by the 
+            <a href="/body/dwp">Department for Work and Pensions</a> instead.
+            <br><br>
+            You can find more infomation about other benefits on the
+            <a href="https://www.gov.uk/browse/benefits">gov.uk website</a>.
+          </li>
+          <li>
+            You can get free, independent advice on what benefits you may be   
+            entitled to from the 
+            <a href="https://moneytalkteam.org.uk/services/accessing-benefits">
+            Money Talk Team</a>, part of Citizens Advice Scotland.
+          </li>
+          <li>
+            You can use an independent 
+            <a href="https://www.gov.uk/benefits-calculators">
+            benefits calculator</a> to find out what benefits and services that 
+            you may be entitled to.
+          </li>
+          <li>
+            If you are unsure about benefits and need advice, you could get 
+            independent help and support by contacting:
+            <ul>
+              <li>
+                <a href="https://www.citizensadvice.org.uk/scotland/">
+                Citizens Advice Scotland</a>
+              <li>
+                your local 
+                <a href="https://www.cas.org.uk/bureaux">
+                Citizens Advice Bureaux</a>
+              </li>
+              <li>
+              <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
+              </li>
+              <li>
+                or your local 
+                <a href="https://scotland.shelter.org.uk/housing_advice/complaints_and_court_action/legal_representation/law_centres">
+                Law Centre</a>.
+              </li>
+            </ul>
+            #{generic_deny_askcouncil}
+          </li>
+        </ul>
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+  
+  socsecscot_deny_response_benefits_contact = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot do this using WhatDoTheyKnow</h3>
+
+      <p>
+        You should contact the office that handles your claim directly with any 
+        concerns that you might have. You'll find their details on the  
+        <a href="https://www.mygov.scot/contact-social-security-scotland">
+        mygov.scot website</a>. You can usually contact them via 
+        Web Chat, the telephone, Contact Scotland BSL, or by post.
+      </p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.mygov.scot/contact-social-security-scotland">
+        Contact Social Security Scotland »</a>
+      </div>
+      <section>
+        <h4>Are you contacting the correct agency?</h4>
+        <p>
+          Not all benefits in Scotland are 
+          <a href="https://www.gov.scot/publications/responsibility-for-benefits-overview/">
+          devolved</a>, meaning that some are looked after by the 
+          <a href="/body/dwp">Department for Work and Pensions</a> instead.
+        </p>
+        <p>
+          You can find more infomation on how to contact the DWP on the
+          <a href="https://www.gov.uk/browse/benefits">gov.uk website</a>
+        </p>
+      </section>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  socsecscot_deny_response_make_complaint = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot make a complaint using WhatDoTheyKnow</h3>
+
+      <p>
+        You should contact the office that handles your claim directly.
+        You can find their complaints procedure and contact details on the 
+        <a href="https://www.mygov.scot/complain-social-security-scotland">
+        mygov.scot website</a>.
+          <ul>
+          <li>
+            You could also try contacting the agency directly, using their web 
+            chat service at: 
+            <a href="https://chat.socialsecurity.gov.scot/">
+            chat.socialsecurity.gov.scot
+            </a>
+          </li>
+          <li>
+            You can make a complaint 
+            <a href="https://www.socialsecurity.gov.scot/contact/feedback/how-to-make-a-complaint">
+            online</a>, via the telephone, Contact Scotland BSL, or by post.
+          <li>
+            You can also <a onclick="if (ga) { ga('send','event','Outbound Link','Write To Them Exit','Public Body Questions',1) };" 
+            href="http://www.writetothem.com">
+            write to your elected members</a> for help.
+          </li>
+          <li>
+            You can also seek independent advice, from:
+            <ul>
+              <li>
+                <a href="https://www.citizensadvice.org.uk/scotland/">
+                Citizens Advice Scotland</a>
+              <li>
+                your local 
+                <a href="https://www.cas.org.uk/bureaux">
+                Citizens Advice Bureaux</a>
+              </li>
+              <li>
+              <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
+              </li>
+              <li>
+                or your local 
+                <a href="https://scotland.shelter.org.uk/housing_advice/complaints_and_court_action/legal_representation/law_centres">
+                Law Centre</a>.
+              </li>
+            </ul>
+            #{generic_deny_askcouncil}
+          </li>
+        </ul> 
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  socsecscot_deny_response_rightofaccess = _(<<-HTML.strip_heredoc.squish 
+      #{generic_deny_gdpr_rightofaccess}
+      <h4>Getting access to information held by Social Security Scotland</h4>
+      <p>
+        Sometimes, you don't need to make a formal request - if you simply need 
+        proof of your benefits, contacting the Benefit Office that handles your 
+        claim can often be quicker.
+      </p>
+      <p>  
+        You can find details on how to make a <strong>Right of Access request
+        </strong> to the Social Security Scotland and its agencies 
+        <a href="https://www.mygov.scot/social-security-data">
+        on mygov.scot</a>.
+      </p>
+      <p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.socialsecurity.gov.scot/contact/subject-access">
+        Make a Right of Access request on the Social Security Scotland website»
+        </a>
       </div>
       &nbsp;
       #{generic_deny_boilerplate}
@@ -842,6 +1074,14 @@ Rails.configuration.to_prepare do
     question: _('Contact DfC about my Social Security benefits'),
     response: dfc_deny_response_benefits_contact
   )
+
+  PublicBodyQuestion.build(
+    public_body: dfc,
+    key: :manage_child_maintenance,
+    question: _('Manage your Child Maintenance / Support case'),
+    response: dwp_deny_response_manage_csa
+    # We reuse the DWP response here as it is substantively the same.
+  )
   
   PublicBodyQuestion.build(
     public_body: dfc,
@@ -854,7 +1094,7 @@ Rails.configuration.to_prepare do
     public_body: dfc,
     key: :make_dfc_complaint,
     question: _('Make a complaint'),
-    response: dfc_deny_response_make_dfc_complaint
+    response: dfc_deny_response_make_complaint
   )
 
   PublicBodyQuestion.build(
@@ -921,7 +1161,6 @@ Rails.configuration.to_prepare do
     response: dwp_deny_response_contact_dwp_other
   )
 
-
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :manage_child_maintenance,
@@ -940,7 +1179,7 @@ Rails.configuration.to_prepare do
     public_body: dwp,
     key: :make_dwp_complaint,
     question: _('Make a complaint'),
-    response: dwp_deny_response_make_dwp_complaint
+    response: dwp_deny_response_make_complaint
   )
 
   PublicBodyQuestion.build(
@@ -954,6 +1193,58 @@ Rails.configuration.to_prepare do
     public_body: dwp,
     key: :foi,
     question: _('Ask for recorded information that <strong>anyone</strong> '\
+                'could reasonably request and expect to receive'),
+    response: :allow
+  )
+
+  PublicBodyQuestion.build(
+    public_body: socsecscot,
+    key: :socsecscot_claim_benefits,
+    question: _('Make a claim for Social Security benefits'),
+    response: socsecscot_deny_response_benefits_claim
+  )
+
+  PublicBodyQuestion.build(
+    public_body: socsecscot,
+    key: :socsecscot_claim_pension,
+    question: _('Claim my State Pension'),
+    response: dwp_deny_response_claim_pension
+    # We reuse the DWP response here as it isn't a devolved benefit
+  )
+
+  PublicBodyQuestion.build(
+    public_body: socsecscot,
+    key: :socsecscot_contact_benefits,
+    question: _('Contact Social Security Scotland about my benefits'),
+    response: socsecscot_deny_response_benefits_contact
+  )
+
+  PublicBodyQuestion.build(
+    public_body: socsecscot,
+    key: :manage_child_maintenance,
+    question: _('Manage your Child Maintenance / Support case'),
+    response: dwp_deny_response_manage_csa
+    # We reuse the DWP response here as it isn't a devolved service
+  )
+
+  PublicBodyQuestion.build(
+    public_body: socsecscot,
+    key: :socsecscot_contact_rightofaccess,
+    question: _('Get a copy of information held about me'),
+    response: socsecscot_deny_response_rightofaccess
+  )
+
+  PublicBodyQuestion.build(
+    public_body: socsecscot,
+    key: :make_socsecscot_complaint,
+    question: _('Make a complaint'),
+    response: socsecscot_deny_response_make_complaint
+  )
+
+  PublicBodyQuestion.build(
+    public_body: socsecscot,
+    key: :foi,
+    question: _('Ask for recorded information that <strong>anyone</strong> ' \
                 'could reasonably request and expect to receive'),
     response: :allow
   )

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -119,6 +119,52 @@ Rails.configuration.to_prepare do
   ## build public body questions
 
   dwp_deny_response_1 = _(<<-HTML.strip_heredoc.squish
+  generic_deny_boilerplate = _(<<-HTML.strip_heredoc.squish
+      <hr>  
+      <p>
+        <strong>Remember:</strong> Misusing our service, <strong><u>which makes 
+        all correspondence public</u></strong>, won't help you pursue your 
+        individual case. This is because, to keep your personal information 
+        safe, organisations will not discuss your personal circumstances when
+        you contact them using our service. Please read our 
+        <a href="/help/house_rules">House Rules</a> for further details.
+      </p>
+    HTML
+    # we reuse this multiple times with #{generic_deny_boilerplate}
+  )
+
+  generic_deny_gdpr_rightofaccess = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot do this using WhatDoTheyKnow</h3>
+      <p>
+        You have the right to access personal information that an organisation 
+        holds about you. This can sometimes be called a Subject Access or Right
+        of Access Request (SAR / RoAR).
+      </p>
+      <p>
+        Each organisation will have their own processes for this; but it is 
+        generally quick, and free of charge. You can get advice on your rights, 
+        at no cost, from the <a href="https://ico.org.uk/your-data-matters/">
+        Information Commisioner's Office</a>.
+      </p>
+      <hr>
+    HTML
+    # we reuse this multiple times with #{generic_deny_gdpr_rightofaccess}
+  )
+
+  dwp_deny_response_contact_boilerplate = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot do this using WhatDoTheyKnow</h3>
+      <p>
+        You should contact the office that handles your claim directly with any 
+        concerns that you might have. You'll find their details at 
+        <a href="http://www.dwp.gov.uk">dwp.gov.uk</a>, or below.<br><br>
+        In Northern Ireland, most benefits are managed by the
+        <a href="/body/dfc">Department for Communities</a>.
+      </p>
+      <hr>
+    HTML
+    # we reuse this multiple times with #{dwp_deny_response_contact_boilerplate}
+  )
+
   dwp_deny_response_claim_benefits = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot make a claim using WhatDoTheyKnow</h3>
 
@@ -126,13 +172,19 @@ Rails.configuration.to_prepare do
         You can find information about how to claim benefits on the
         <a href="https://www.gov.uk/browse/benefits">gov.uk website</a>.
       </p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.gov.uk/browse/benefits">
+        Find out about benefits on gov.uk »</a>
+      </div>
       <p>
         Information you might find useful:
         <ul>
           <li>
             You can use an independent 
             <a href="https://www.gov.uk/benefits-calculators">
-            benefits calculator</a> to find out what you may be entitled to.
+            benefits calculator</a> to find out what benefits and services that 
+            you may be entitled to.
           </li>
           <li>
             In <strong>Northern Ireland</strong>, some benefits are managed 
@@ -143,13 +195,21 @@ Rails.configuration.to_prepare do
           </li>
           <li>
             In <strong>Scotland</strong>, some benefits are managed directly by 
-            <a href="/body/social_security_scotland">Social Security Scotland</a>.
-            You can find further information on
+            <a href="/body/social_security_scotland">
+            Social Security Scotland</a>. You can find further information on
             <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>
+          </li>
+          <li>
+            If you are unsure about benefits and need advice, contact 
+            <a href="https://www.citizensadvice.org.uk/benefits/">
+            Citizens Advice</a>, or your local Citizens Advice Bureaux for 
+            independent help and support. <br><br>
+            Your local Council might also offer a Welfare Rights service, or be 
+            able to signpost you to a service in your area that can help.
           </li>
         </ul>
       </p>
-
+      #{generic_deny_boilerplate}
     HTML
   )
 
@@ -157,56 +217,342 @@ Rails.configuration.to_prepare do
       <h3>You cannot claim your State Pension using WhatDoTheyKnow</h3>
 
       <p>
-        You can find information about how to claim benefits on the
+        You can find information about how to start a claim for the State
+        Pension on the
         <a href="https://www.gov.uk/get-state-pension">gov.uk website</a>.
       </p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.gov.uk/get-state-pension">
+        Find out about the State Pension on gov.uk »</a>
+      </div>
       <p>
         Information you might find useful:
         <ul>
-          <li>In <b>Northern Ireland</b>, you need to contact the 
-          <a href="/body/dfc">Department for Communities</a> to make your claim.
-           You can find more information on:
-           <a href="https://www.nidirect.gov.uk/services/get-your-state-pension">
-           nidirect.gov.uk</a>.
+          <li>
+            In <b>Northern Ireland</b>, you need to contact the 
+            <a href="/body/dfc">Department for Communities</a> to make your 
+            claim. You can find more information on:
+            <a href="https://www.nidirect.gov.uk/services/get-your-state-pension">
+            nidirect.gov.uk</a>.
           </li>
-          <li>If you are <b>outside the UK</b>, you need to contact the 
-          <a href="https://www.gov.uk/state-pension-if-you-retire-abroad">
-          International Pensions Centre</a> to make your claim.
+          <li>
+            If you are <b>outside the UK</b>, you need to contact the 
+            <a href="https://www.gov.uk/state-pension-if-you-retire-abroad">
+            International Pensions Centre</a> to make your claim.
+          </li>
+          <li>
+            Advice on retirement options is available on the 
+            <a href="https://www.gov.uk/plan-for-retirement">
+            gov.uk website</a>, and from 
+            <a href="http://moneyhelper.org.uk/pensionwise">Pension Wise</a>, a 
+            free government service provided by 
+            <a href="/body/maps">MoneyHelper</a>.
+          </li>
+        </ul>
+        <strong>Protect yourself against pension scams</strong> by following the 
+        <a href="https://www.actionfraud.police.uk/a-z-of-fraud/pension-scams">
+        useful tips</a> provided by Action Fraud.
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  dwp_deny_response_contact_dwp_disability = _(<<-HTML.strip_heredoc.squish 
+      #{dwp_deny_response_contact_boilerplate}
+      <h4>Disability and Carers Benefits
+        (<abbr title="Attendance Allowance">AA</abbr> /
+         <abbr title="Carers Allowance">CA</abbr> /
+         <abbr title="Disability Living Allowance">DLA</abbr> /
+         <abbr title="Personal Independence Payment">PIP</abbr>)</h4>
+      <p>
+        <ul>
+          <li>
+            You can find direct contact details for the Disability Service 
+            Centre on the 
+            <a href="https://www.gov.uk/disability-benefits-helpline">
+            gov.uk website</a>.
+          </li>
+          <li>
+            There's different details for the Carers Allowance Unit. You can 
+            find them on the <a href="https://www.gov.uk/carers-allowance-unit">
+            gov.uk website</a>
+        </ul>
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  dwp_deny_response_contact_dwp_jcp = _(<<-HTML.strip_heredoc.squish 
+      #{dwp_deny_response_contact_boilerplate}
+      <h4>JobCentre Plus services (including 
+        <abbr title="Employment and Support Allowance">ESA</abbr> /
+        <abbr title="Jobseekers Allowance">JSA</abbr> /
+        <abbr title="Incapacity Benefit">IB</abbr> /
+        <abbr title="Income Support">IS</abbr>)
+      </h4>
+      <p>
+        <ul>
+          <li>
+            You can find direct contact details for JobCentre Plus services on  
+            the <a href="https://www.gov.uk/contact-jobcentre-plus">
+            gov.uk website</a>.
+          </li>
+          <li>
+            There's also specific information available for Access to Work on
+            the <a href="https://www.gov.uk/access-to-work/apply#access-to-work-helpline">
+            gov.uk website</a>
+          <li>
+            You can also find out where your local JobCentre Plus office is 
+            located, along with their contact details, on the 
+            <a href="https://find-your-nearest-jobcentre.dwp.gov.uk/">
+            Local Office Search</a> website.
           </li>
         </ul>
       </p>
+      #{generic_deny_boilerplate}
     HTML
   )
 
-  dwp_deny_response_contact_dwp = _(<<-HTML.strip_heredoc.squish
-      <h3>You cannot use WhatDoTheyKnow to do this.</h3>
-
+  dwp_deny_response_contact_dwp_pensions = _(<<-HTML.strip_heredoc.squish 
+      #{dwp_deny_response_contact_boilerplate}
+      <h4>The Pensions Service</h4>
       <p>
+        <ul>
+          <li>
+            You can find details on how to contact The Pension Service on the 
+            <a href="https://www.gov.uk/contact-pension-service">
+            gov.uk website</a>.
+          </li>
+          <li>
+            In <strong>Northern Ireland</strong>, you should contact the 
+            <a href="https://www.nidirect.gov.uk/contacts/northern-ireland-pension-centre">
+            Northern Ireland Pension Centre</a>, which is part of the
+            <a href="/body/dfc">Department for Communities</a>.
+          </li>
+          <li>
+            If you are <strong>outside of the UK</strong>, you should contact 
+            the <a href="https://www.gov.uk/international-pension-centre">
+            International Pensions Centre</a>.
+          </li>
+        </ul>
       </p>
+      #{generic_deny_boilerplate}
     HTML
   )
+
+  dwp_deny_response_contact_dwp_uc = _(<<-HTML.strip_heredoc.squish 
+      #{dwp_deny_response_contact_boilerplate}
+      <h4>Universal Credit</h4>
+      <p>
+        <ul>
+          <li>
+            You can find details on how to contact Universal Credit, on the 
+            <a href="https://www.gov.uk/universal-credit/contact-universal-credit#guide-contents">
+            gov.uk website</a>.
+          </li>
+          <li>
+            If you've an <strong>existing claim</strong> you can manage it, and 
+            send messages to the Universal Credit Service Centre via the 
+            <a href="https://www.universal-credit.service.gov.uk/sign-in">
+            Universal Credit journal</a>.
+          </li>
+          <li>
+            You can also find details about <strong>other help and financial
+            support</strong> on the
+            <a href="https://www.gov.uk/universal-credit/other-financial-support">
+            gov.uk</a> and 
+            <a href="https://www.citizensadvice.org.uk/benefits/universal-credit/">
+            Citizens Advice</a> websites.
+          </li>
+        </ul>
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
+  dwp_deny_response_contact_dwp_other = _(<<-HTML.strip_heredoc.squish 
+      #{dwp_deny_response_contact_boilerplate}
+      <h4>Other DWP benefits and services</h4>
+        <ul>
+          <li>
+            You can find a full list of DWP services, along with their contact 
+            details on their website at: 
+            <a href="http://www.dwp.gov.uk#what-we-do">dwp.gov.uk</a>.
+          </li>
+          <li>
+            If you have questions, you can contact the DWP Ministerial 
+            Correspondence Team via the 
+            <a href="https://www.gov.uk/guidance/contact-the-department-for-work-and-pensions-about-its-policies">
+            gov.uk website</a>.
+          </li>
+        </ul>
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
   dwp_deny_response_challenge_dwp = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot challenge a benefits decision using WhatDoTheyKnow</h3>
 
       <p>
+        WhatDoTheyKnow isn't the right place to challenge a benefits decision, 
+        as your correspondence would be automatically published for everyone
+        to see.
       </p>
-    HTML
-  )
-  dwp_deny_response_manage_csa = _(<<-HTML.strip_heredoc.squish
-      <h3>You cannot use WhatDoTheyKnow to manage your Child Support case</h3>
-
       <p>
+        Here's what to do:
+        <ul>
+          <li>
+            Contact your benefits centre 
+            <a href="https://www.gov.uk/mandatory-reconsideration">
+            for assistance</a>.
+          </li>
+          <li>
+            You can also ask a Welfare Rights service, an advocacy charity, or 
+            <a href="https://www.citizensadvice.org.uk/benefits/benefits-introduction/problems-with-benefits-and-tax-credits/challenging-benefit-decisions/">
+            Citizens Advice for help</a>.
+          </li>
+          <li>
+            You can also contact your <a onclick="if (ga) { ga('send','event','Outbound Link','Write To Them Exit','Public Body Questions',1) };" 
+            href="http://www.writetothem.com">elected members</a> for help.
+          </li>
+        </ul>
       </p>
+      #{generic_deny_boilerplate}
     HTML
   )
+
+  dwp_deny_response_manage_csa = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot manage your Child Support case using WhatDoTheyKnow</h3>
+      <p>
+        WhatDoTheyKnow isn't the right place to manage your Child Support,
+        as your correspondence would be automatically published for everyone
+        to see.
+      </p>      
+      <h4>To set up Child Maintenance</h4>
+      <p>
+        <ul>
+          <li>
+            Visit the 
+            <a href="https://www.gov.uk/making-child-maintenance-arrangement">
+            gov.uk website</a> to learn more about your options
+          </li>
+          <li>
+            contact an advice service, such as 
+            <a href="https://www.gingerbread.org.uk/what-we-do/contact-us/">
+            Gingerbread</a>, or 
+            <a href="https://www.citizensadvice.org.uk/family/children-and-young-people/child-maintenance1">
+            Citizens Advice</a>.
+          </li>
+        </ul>
+      </p>
+      <h4>To manage your Child Maintenance case</h4>
+      <p>
+        To manage an existing Child Maintenance case, or if you have queries,
+        you should:
+        <ul>
+          <li>
+            Manage your case on the
+            <a href="https://childmaintenanceservice.direct.gov.uk">
+            Child Maintenance Service website</a>.
+          </li>
+          <li>
+            Contact the 
+            <a href="https://www.gov.uk/manage-child-maintenance-case/contact">
+            Child Maintenance Service</a> directly.
+          </li>
+          <li>
+            In <strong>Northern Ireland</strong>, you should contact the 
+            <a href="https://www.nidirect.gov.uk/contacts/child-maintenance-service">
+            Northern Ireland Child Maintenance Service</a> instead.
+          </li>
+        </ul>
+      </p>
+      <h4>If you are unhappy</h4>
+      <p>  
+        If you are unhappy with a decision made by Child Maintenance Service, 
+        you may wish to:
+        <ul>
+          <li>
+            contact an advice service, such as 
+            <a href="https://www.gingerbread.org.uk/what-we-do/contact-us/">
+            Gingerbread</a>, or 
+            <a href="https://www.citizensadvice.org.uk/family/children-and-young-people/child-maintenance1">
+            Citizens Advice</a>.
+          </li>
+          <li>
+            make a complaint to the 
+            <a href="https://www.gov.uk/manage-child-maintenance-case/complaints-and-appeals">
+            Child Maintenance Service
+            </a>
+          </li>
+          <li>
+            write to your <a onclick="if (ga) { ga('send','event','Outbound Link','Write To Them Exit','Public Body Questions',1) };" 
+              href="http://www.writetothem.com">elected members</a> for help.
+          </li>
+        </ul>
+      </p>
+      #{generic_deny_boilerplate}
+    HTML
+  )
+
   dwp_deny_response_make_dwp_complaint = _(<<-HTML.strip_heredoc.squish
       <h3>You cannot make a complaint using WhatDoTheyKnow</h3>
 
       <p>
+        You should contact the DWP Complaints team directly.
+        You can find their complaints procedure and contact details on the 
+        <a href="https://www.gov.uk/government/organisations/department-for-work-pensions/about/complaints-procedure">
+        gov.uk website</a>.
+          <ul>
+          <li>
+            You could also try emailing DWP directly at 
+            <a href="mailto:correspondence@dwp.gov.uk">
+            correspondence@dwp.gov.uk
+            </a>
+          </li>
+          <li>
+            You can also <a onclick="if (ga) { ga('send','event','Outbound Link','Write To Them Exit','Public Body Questions',1) };" 
+            href="http://www.writetothem.com">
+            write to your elected members</a> for help.
+          </li>
+          <li>
+            There's also information on what to do if you are unhappy with the 
+            DWP response to your complaint on the 
+            <a href="https://www.gov.uk/government/publications/how-to-take-a-complaint-to-the-independent-case-examiner">
+            Independent Case Examiner's website</a>.
+          </li>
+        </ul> 
       </p>
+      #{generic_deny_boilerplate}
     HTML
   )
 
+  dwp_deny_response_rightofaccess = _(<<-HTML.strip_heredoc.squish 
+      #{generic_deny_gdpr_rightofaccess}
+      <h4>Getting access to information held by the DWP</h4>
+      <p>
+        Sometimes, you don't need to make a formal request - if you simply need 
+        proof of your benefits, contacting the Benefit Office that handles your 
+        claim can often be quicker.
+      </p>
+      <p>  
+        You can find details on how to make a <strong>Right of Access request
+        </strong> to the DWP and its agencies 
+        <a href="https://www.gov.uk/guidance/request-your-personal-information-from-the-department-for-work-and-pensions">
+        on gov.uk</a>.
+      </p>
+      <p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="https://www.gov.uk/guidance/request-your-personal-information-from-the-department-for-work-and-pensions#if-you-need-a-copy-of-any-other-information-that-dwp-holds-about-you">
+        Make a Right of Access request on the DWP website»</a>
+      </div>
+      &nbsp;
+      #{generic_deny_boilerplate}
+    HTML
+  )
 
   PublicBodyQuestion.build(
     public_body: home_office,
@@ -290,50 +636,79 @@ Rails.configuration.to_prepare do
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :contact_disabilitycentre,
-    question: _('Contact the Disability Service Centre (AA / ESA / PIP)'),
-    response: dwp_deny_response_contact_dwp
+    question: _('Contact the Disability Service Centre ('\
+      '<abbr title="Attendance Allowance">AA</abbr> / '\
+      '<abbr title="Carers Allowance">CA</abbr> / '\
+      '<abbr title="Disability Living Allowance">DLA</abbr> / '\
+      '<abbr title="Personal Independence Payment">PIP</abbr>)'),
+    response: dwp_deny_response_contact_dwp_disability
   )
   
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :contact_jcp,
-    question: _('Contact Jobcentre Plus'),
-    response: dwp_deny_response_contact_dwp
+    question: _('Contact Jobcentre Plus (including '\
+      '<abbr title="Employment and Support Allowance">ESA</abbr> / '\
+      '<abbr title="Jobseekers Allowance">JSA</abbr> / '\
+      '<abbr title="Incapacity Benefit">IB</abbr> / '\
+      '<abbr title="Income Support">IS</abbr> )'),
+    response: dwp_deny_response_contact_dwp_jcp
   )
   
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :contact_pensionservice,
+    question: _('Contact The Pensions Service'),
+    response: dwp_deny_response_contact_dwp_pensions
+  )
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :contact_universalcredit,
     question: _('Contact Universal Credit'),
-    response: dwp_deny_response_contact_dwp
+    response: dwp_deny_response_contact_dwp_uc
   )
-  
+
   PublicBodyQuestion.build(
     public_body: dwp,
-    key: :challenge_a_decision,
-    question: _('Challenge a decision'),
-    response: dwp_deny_response_challenge_dwp
+    key: :contact_dwp_other,
+    question: _('Contact DWP about other benefits and services'),
+    response: dwp_deny_response_contact_dwp_other
   )
-  
+
+
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :manage_child_maintenance,
     question: _('Manage your Child Maintenance / Support case'),
     response: dwp_deny_response_manage_csa
   )
-  
+
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :challenge_a_decision,
+    question: _('Challenge a decision'),
+    response: dwp_deny_response_challenge_dwp
+  )
+    
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :make_dwp_complaint,
     question: _('Make a complaint'),
     response: dwp_deny_response_make_dwp_complaint
   )
+
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :contact_rightofaccess,
+    question: _('Get a copy of information held about me'),
+    response: dwp_deny_response_rightofaccess
+  )
   
   PublicBodyQuestion.build(
     public_body: dwp,
     key: :foi,
-    question: _('Asking for recorded information held by a public body that ' \
-                'anyone could reasonably request and expect to receive?'),
+    question: _('Ask for recorded information held by a public body that ' \
+                'anyone could reasonably request and expect to receive'),
     response: :allow
   )
 end

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -122,6 +122,8 @@ Rails.configuration.to_prepare do
   ## build public body questions
 
   dwp_deny_response_1 = _(<<-HTML.strip_heredoc.squish
+  ## public body specific templates
+
   generic_deny_boilerplate = _(<<-HTML.strip_heredoc.squish
       <hr>  
       <p>
@@ -307,7 +309,10 @@ Rails.configuration.to_prepare do
       </p>
       <div style="text-align:center">
         <a class="button" 
-        href="https://www.nidirect.gov.uk/campaigns/unclaimed-benefits">
+        href="https://www.nidirect.gov.uk/campaigns/unclaimed-benefits"
+        target="_blank"
+        title="Find out more about benefits on the NIDirect website
+        (opens in a new window)">
         Find out about benefits on NIDirect »</a>
       </div>
       <p>
@@ -316,12 +321,17 @@ Rails.configuration.to_prepare do
           <li>
             You can get free advice on what benefits you may be entitled to  
             from the 
-            <a href="https://www.nidirect.gov.uk/contacts/make-call-service">
+            <a href="https://www.nidirect.gov.uk/contacts/make-call-service"
+            target="_blank"
+            title="Find out more about the Make the Call service on the 
+            NIDirect website (opens in a new window)">
             Make the Call service</a>.
           </li>
           <li>
             You can use an independent 
-            <a href="https://www.nidirect.gov.uk/articles/benefits-calculator">
+            <a href="https://www.nidirect.gov.uk/articles/benefits-calculator"
+            target="_blank"
+            title="Use a benefits calculator (opens in a new window)">
             benefits calculator</a> to find out what benefits and services that 
             you may be entitled to.
           </li>
@@ -332,28 +342,47 @@ Rails.configuration.to_prepare do
             <a href="/body/social_security_scotland">
             Social Security Scotland</a>. 
             You can find further information on 
-            <a href="https://www.gov.uk/browse/benefits">
+            <a href="https://www.gov.uk/browse/benefits"
+            target="_blank"
+            title="Find out about UK wide benefits on gov.uk 
+            (opens in a new window)">
             gov.uk</a> and 
-            <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>.
+            <a href="https://www.mygov.scot/browse/benefits" 
+            target="_blank"
+            title="Find out about benefits from Social Security Scotland  
+            on mygov.scot (opens in a new window)">
+            mygov.scot</a>.
           </li>
           <li>
             If you are unsure about benefits and need advice, you could contact 
             You can also seek independent advice, from:
             <ul>
               <li>
-                <a href="https://www.adviceni.net/benefits">
+                <a href="https://www.adviceni.net/benefits"
+                target="_blank"
+                title="Link to the Advice NI website (opens in a new window)">
                 Advice NI</a>
               <li>
                 your local 
-                <a href="https://www.adviceni.net/local-advice">
+                <a href="https://www.adviceni.net/local-advice"
+                target="_blank"
+                title="Find a local advice agency on the Advice NI website 
+                (opens in a new window)">
                 Advice Agency</a>
               </li>
               <li>
-              <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
+                <a href="https://advicefinder.turn2us.org.uk/"
+                target="_blank"
+                title="Link a local advice charity or service on the Turn2Us
+                website (opens in a new window)">
+                Turn2Us</a>
               </li>
               <li>
                 or your local 
-                <a href="https://www.lawcentreni.org/">
+                <a href="https://www.lawcentreni.org/"
+                target="_blank"
+                title="Link to the Law Centre NI website 
+                (opens in a new window)">
                 Law Centre</a>.
               </li>
             </ul>
@@ -1148,6 +1177,10 @@ socsecscot_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
     HTML
   )
 
+  ## build public body questions
+
+  ## Home Office
+  
   PublicBodyQuestion.build(
     public_body: home_office,
     key: :visa,
@@ -1234,6 +1267,8 @@ socsecscot_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
     key: :foi,
     question: _('Ask for recorded information held by a public body ' \
                 '<strong>on any other topic</strong> that ' \
+  ## Department for Communities
+
   PublicBodyQuestion.build(
     public_body: dfc,
     key: :dfc_claim_benefits,
@@ -1285,6 +1320,8 @@ socsecscot_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
                 'could reasonably request and expect to receive'),
     response: :allow
   )
+
+  ## DWP
 
   PublicBodyQuestion.build(
     public_body: dwp,
@@ -1377,6 +1414,8 @@ socsecscot_deny_response_benefits_claim = _(<<-HTML.strip_heredoc.squish
                 'could reasonably request and expect to receive'),
     response: :allow
   )
+
+  ## Social Security Scotland
 
   PublicBodyQuestion.build(
     public_body: socsecscot,

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -586,7 +586,12 @@ Rails.configuration.to_prepare do
               <li>
                 your local 
                 <a href="https://www.citizensadvice.org.uk/about-us/contact-us/contact-us/search-for-your-local-citizens-advice/">
-                Citizens Advice Bureaux</a>
+                Citizens Advice Bureaux</a> (in England or Wales)
+              </li>
+              <li>
+                your local 
+                <a href="https://www.cas.org.uk/bureaux">
+                Citizens Advice Bureaux</a> (in Scotland)
               </li>
               <li>
               <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
@@ -801,9 +806,29 @@ Rails.configuration.to_prepare do
             for assistance</a>.
           </li>
           <li>
-            You can also ask a Welfare Rights service, an advocacy charity, or 
-            <a href="https://www.citizensadvice.org.uk/benefits/benefits-introduction/problems-with-benefits-and-tax-credits/challenging-benefit-decisions/">
-            Citizens Advice for help</a>.
+            You can ask for help from:
+            <ul>
+              <li>
+                <a href="https://www.citizensadvice.org.uk/benefits/benefits-introduction/problems-with-benefits-and-tax-credits/challenging-benefit-decisions/">
+                Citizens Advice</a>
+              <li>
+                your local 
+                <a href="https://www.citizensadvice.org.uk/about-us/contact-us/contact-us/search-for-your-local-citizens-advice/">
+                Citizens Advice Bureaux</a> (in England or Wales)
+              </li>
+              <li>
+                your local 
+                <a href="https://www.cas.org.uk/bureaux">
+                Citizens Advice Bureaux</a> (in Scotland)
+              </li>
+              <li>
+              <a href="https://advicefinder.turn2us.org.uk/">Turn2Us</a>
+              </li>
+              <li>
+                an advocacy charity, Welfare Rights adviser, or law centre.
+              </li>
+            </ul>
+            #{generic_deny_askcouncil}
           </li>
           <li>
             You can also contact your <a onclick="if (ga) { ga('send','event','Outbound Link','Write To Them Exit','Public Body Questions',1) };" 

--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -12,6 +12,7 @@ Rails.configuration.to_prepare do
   ## Generic boilerplate templates for reuse
 
   ## public body specific templates
+  dwp = PublicBody.find_by_url_name('dwp')
 
   home_office_deny_response = _(
     <<-HTML.strip_heredoc.squish
@@ -117,6 +118,64 @@ Rails.configuration.to_prepare do
 
   ## build public body questions
 
+  dwp_deny_response_1 = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot make a claim using WhatDoTheyKnow</h3>
+
+      <p>
+        You can find information about how to claim benefits on the
+        <a href="https://www.gov.uk/browse/benefits">gov.uk website</a>.
+      </p>
+      <p>
+        Information you might find useful:
+        <ul>
+          <li>
+            You can use a <a href="https://www.gov.uk/benefits-calculators">
+            benefits calculator</a> to find out what you may be entitled to.
+          </li>
+          <li>
+            In <b>Northern Ireland</b>, some benefits are managed directly by
+            the <a href="/body/dfc">Department for Communities</a>. You can find
+            information on 
+            <a href="https://www.nidirect.gov.uk/campaigns/unclaimed-benefits">
+            nidirect.gov.uk</a>
+          </li>
+          <li>
+            In Scotland, some benefits are managed directly by 
+            <a href="/body/social_security_scotland">Social Security Scotland</a>.
+            You can find information on
+            <a href="https://www.mygov.scot/browse/benefits">mygov.scot</a>
+          </li>
+        </ul>
+      </p>
+
+    HTML
+  )
+
+  dwp_deny_response_2 = _(<<-HTML.strip_heredoc.squish
+      <h3>You cannot claim your State Pension using WhatDoTheyKnow</h3>
+
+      <p>
+        You can find information about how to claim benefits on the
+        <a href="https://www.gov.uk/get-state-pension">gov.uk website</a>.
+      </p>
+      <p>
+        Information you might find useful:
+        <ul>
+          <li>In <b>Northern Ireland</b> you need to contact the 
+          <a href="/body/dfc">Department for Communities</a> to make your claim.
+           You can find more information on:
+           <a href="https://www.nidirect.gov.uk/services/get-your-state-pension">
+           nidirect.gov.uk</a>.
+          </li>
+          <li>If you are <b>outside the UK</b> you need to contact the 
+          <a href="https://www.gov.uk/state-pension-if-you-retire-abroad">
+          International Pensions Centre</a> to make your claim.
+          </li>
+        </ul>
+      </p>
+    HTML
+  )
+
   PublicBodyQuestion.build(
     public_body: home_office,
     key: :visa,
@@ -182,6 +241,24 @@ Rails.configuration.to_prepare do
     key: :foi,
     question: _('Ask for recorded information held by a public body ' \
                 '<strong>on any other topic</strong> that ' \
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :claim_benefits,
+    question: _('Claim social security benefits'),
+    response: dwp_deny_response_1
+  )
+
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :claim_pension,
+    question: _('Claim my State Pension'),
+    response: dwp_deny_response_2
+  )
+  
+  PublicBodyQuestion.build(
+    public_body: dwp,
+    key: :foi,
+    question: _('Asking for recorded information held by a public body that ' \
                 'anyone could reasonably request and expect to receive?'),
     response: :allow
   )


### PR DESCRIPTION
## Relevant issue(s)
Fixes #745 
Partly solves #722 

## What does this do?

This implements a series of public body questions for the three Social Security agencies in the UK:

- Department for Communities (Northern Ireland) `(dfc - 57878)`
- Department for Work and Pensions `(dwp - 24)`
- Social Security Scotland `(social_security_scotland - 89236)`

It also refactors the questions we have for the Home Office `(home_office - body 7)`, and improves the generic answer that we have for said body, by including some specific pointers.

Key themes:

- Claim benefits / state pension
- Ask about a benefit claim
- Ask for a copy of records (e.g. RoAR / SAR)
- Ask about Visas
- Ask about Passports

## Why was this needed?

We consistently see users contacting these bodies in regard to matters which concern their own personal circumstances and in no way relate to a FOI or EIR request. This can result in personally identifiable information, which is often hard to remove, being published.

Being able to signpost users to relevant _external resources_ and dissuade them from misusing our service _may_ help reduce misuse, which takes significant administrative resources to resolve.

## Implementation notes
This will work best if https://github.com/mysociety/alaveteli/pull/6807 is implemented, as the questions tie into the simplified heading that has been used here.

The public body name for Social Security Scotland (e.g. social_security_scotland) has been shortened to `socsecscot` in the code - this has been tested on a dev instance and showed no issues.

There are a couple of generic boilerplate statements (`generic_deny_boilerplate`, `generic_deny_askcouncil`,`generic_deny_gdpr_rightofaccess`) to save repetition and improve maintainability. The first is essentially a facsimile of the original misuse text from the Home Office, which has been refactored and simplified.

## Screenshots

A short video showing some of the options:

https://user-images.githubusercontent.com/249418/155139904-ed18da96-b7ea-43be-9b5e-8263a7f85c3a.mov

Home Office:
- <img src="https://user-images.githubusercontent.com/249418/155142402-5f36aeed-2779-4b29-a774-20b11d17f693.png" width="500px">
- <img src="https://user-images.githubusercontent.com/249418/155142615-a5a7095a-3485-425f-b146-36cedd7544ac.png" width="500px">

DfC:
- <img src="https://user-images.githubusercontent.com/249418/155143026-1634786f-663c-43c8-9ae6-935bab40d3d6.png" width="500px">
- <img src="https://user-images.githubusercontent.com/249418/155143153-9b82905e-6b5e-40c5-99e5-299eecf728c5.png" width="500px">

Social Security Scotland
- <img src="https://user-images.githubusercontent.com/249418/155143905-a10f2ecd-b680-414c-a3b7-63eba9e2004d.png" width="500px">
- <img src="https://user-images.githubusercontent.com/249418/155144165-47380d28-b623-4ba6-9456-0862904796eb.png" width="500px">

## Notes to reviewer

There is a bug of sorts - but it appears to exist in core Alaveteli - when a radio button is clicked, we don't automatically focus the browser on the relevant text, meaning the user needs to scroll. This isn't a _massive_ thing, but it might be slightly more intuitive if we did that.

Some care has been taken to ensure our responses are neutral, in that we don't express an opinion regarding a public bodies policies or procedures - the links to external resources, which are from reputable organisations such as Citizens Advice, can do that much better than we can - as they have the resources to let them keep data _up-to-date_.

Some of the off-site links are, unfortunately, rather long - sorry about that.