### PR TITLE
Add LSE questions

### DIFF
--- a/lib/public_body_questions.rb
+++ b/lib/public_body_questions.rb
@@ -1,7 +1,17 @@
 Rails.configuration.to_prepare do
   next unless ActiveRecord::Base.connection.data_source_exists?(:public_bodies)
 
+  ## Specify public bodies which should be evaluated
+
   home_office = PublicBody.find_by_url_name('home_office')
+  ## LSE
+  lse_tsai = PublicBody.find_by_url_name('lse')
+  uol_tsai = PublicBody.find_by_url_name('university_of_london')
+  uolww_tsai = PublicBody.find_by_url_name('university_of_london_worldwide')
+
+  ## Generic boilerplate templates for reuse
+
+  ## public body specific templates
 
   home_office_deny_response = _(
     <<-HTML.strip_heredoc.squish
@@ -16,7 +26,7 @@ Rails.configuration.to_prepare do
       </p>
 
       <p>
-        You could also try contacting the Home Office by email at: <a
+          You could also try contacting the Home Office by email at: <a
         href="mailto:public.enquiries@homeoffice.gov.uk">public.enquiries@
         homeoffice.gov.uk</a>.
       </p>
@@ -29,6 +39,83 @@ Rails.configuration.to_prepare do
       </p>
     HTML
   )
+
+  ## LSE
+
+  lse_tsai_deny_response = _(
+    <<-HTML.strip_heredoc.squish
+    <article>
+    <section>  
+      <h3>
+        We've noticed a lot of people asking about this.
+      </h3>
+      <p>
+        We know that many people have asked about Dr Tsai Ing-Wen's thesis and 
+        qualifications.
+      </p>
+      <p>
+        You cannot request this information on WhatDoTheyKnow, but here's some 
+        information that might help:
+      </p>
+      <ul>
+        <li>
+          The <abbr title="London School of Economics and Political Science">LSE
+          </abbr> has issued a statement, 
+          <a href="https://www.lse.ac.uk/News/Latest-news-from-LSE/2019/j-October-2019/LSE-statement-on-PhD-of-Dr-Tsai-Ing-wen"
+          target="_blank"
+          title="LSE statement on PhD of Dr Tsai Ing-wen (opens in a new window)">
+          on their website</a>, which confirms the timelines surrounding 
+          Dr Tsai's PhD.
+        </li>
+        <li>
+          The University of London has also confirmed its position 
+          <a href="https://london.ac.uk/university-london-statement-missing-thesis"
+          target="_blank"
+          title="University of London statement (opens in a new window)">
+          on its website</a>.
+        </li>
+        <li>
+          You can read Dr Tsai's thesis at the 
+          <a href="http://etheses.lse.ac.uk/3976/"
+          target="_blank"
+          title="View Dr Tsai Ing-Wen's thesis on the LSE Theses Online website
+          (opens in a new window)"><abbr title="London School of Economics and 
+          Political Science">LSE</abbr> Theses Online website</a>.
+        </li>
+        <li>
+          The Information Commissioner has received queries about this topic. 
+          You can find their reply 
+          <a href="https://ico.org.uk/about-the-ico/our-information/disclosure-log/requests-about-taiwanese-president-tsai-ing-wen-s-phd-thesis-the-uol-and-lse/"
+          target="_blank"
+          title="View the Information Commissioner's reply to queries about Dr
+          Tsai Ing-Wen's theses and the replies from LSE and University of 
+          London (opens in a new window)">on their website</a>.
+        </li>
+      </ul>
+      </section>
+      <hr>
+      <section>
+      <p>
+        <h4>Important</h4>
+        Please don't use our website to ask for comments from public bodies on 
+        this topic, and take care to read our 
+        <a href="/help/house_rules">House Rules</a>. These rules tell you how 
+        we expect you to use our site, and they also tell you what we might do 
+        if you misuse it.
+      </p>
+      <div style="text-align:center">
+        <a class="button" 
+        href="/help/house_rules"
+        title="View our House Rules">
+        View our House Rules »
+        </a>
+      </div>
+      <section>
+      </article>
+      HTML
+  )
+
+  ## build public body questions
 
   PublicBodyQuestion.build(
     public_body: home_office,
@@ -49,6 +136,52 @@ Rails.configuration.to_prepare do
     public_body: home_office,
     key: :foi,
     question: _('Asking for recorded information held by a public body that ' \
+                'anyone could reasonably request and expect to receive?'),
+    response: :allow
+  )
+
+  ## LSE
+
+  PublicBodyQuestion.build(
+    public_body: lse_tsai,
+    key: :tsai,
+    question: _('Find out about Dr Tsai Ing-Wen (蔡英文)'),
+    response: lse_tsai_deny_response
+  )
+  PublicBodyQuestion.build(
+    public_body: uol_tsai,
+    key: :tsai,
+    question: _('Find out about Dr Tsai Ing-Wen (蔡英文)'),
+    response: lse_tsai_deny_response
+  )
+  PublicBodyQuestion.build(
+    public_body: uolww_tsai,
+    key: :tsai,
+    question: _('Find out about Dr Tsai Ing-Wen (蔡英文)'),
+    response: lse_tsai_deny_response
+  )
+
+  PublicBodyQuestion.build(
+    public_body: lse_tsai,
+    key: :foi,
+    question: _('Ask for recorded information held by a public body ' \
+                '<strong>on any other topic</strong> that ' \
+                'anyone could reasonably request and expect to receive?'),
+    response: :allow
+  )
+  PublicBodyQuestion.build(
+    public_body: uol_tsai,
+    key: :foi,
+    question: _('Ask for recorded information held by a public body ' \
+                '<strong>on any other topic</strong> that ' \
+                'anyone could reasonably request and expect to receive?'),
+    response: :allow
+  )
+  PublicBodyQuestion.build(
+    public_body: uolww_tsai,
+    key: :foi,
+    question: _('Ask for recorded information held by a public body ' \
+                '<strong>on any other topic</strong> that ' \
                 'anyone could reasonably request and expect to receive?'),
     response: :allow
   )


### PR DESCRIPTION
**Queries to: https://www.whatdotheyknow.com/help/contact**

## Relevant issue(s)
Fixes #1008 

## What does this do?
This adds public body questions for bodies 525, 1294, and 12848.

## Why was this needed?
To reduce a misuse vector, and improve the quality of our advice to site users.

## Implementation notes
Copy has been done relatively quickly, feel free to suggest  any amendments.

This will work best once https://github.com/mysociety/alaveteli/pull/6807 is deployed, but it's by no means compulsory - it's just a heading difference.

## Screenshots
N/A

## Notes to reviewer

As discussed on review@ - this is a follow-up to the mockup version.