### PR TITLE
[#1011] Fix typo in ICO guidance

### DIFF
--- a/config/refusal_advice/section_12_actions.yml.erb
+++ b/config/refusal_advice/section_12_actions.yml.erb
@@ -37,7 +37,7 @@ foi:
       - { id: s12-q3, operator: is, value: 'yes' }
       advice:
         html: >
-          You may be able to argue against aggregation on the basis that by law, authorities must respond to requests within 20 working days. The ICO allow "the aggregation period to only run up to 20 days ‘forward’ from the date of any single request under consideration" and "up to 20 days ‘backwards’ from the date of any single request under consideration" and "the total aggregation period (running either forwards or backwards or a combination of both) from the date of any single request must not exceed 60 working days".
+          You may be able to argue against aggregation on the basis that by law, authorities must respond to requests within 20 working days. The ICO allow "the aggregation period to only run up to 20 days ‘forward’ from the date of any single request under consideration" and "up to 60 days ‘backwards’ from the date of any single request under consideration" and "the total aggregation period (running either forwards or backwards or a combination of both) from the date of any single request must not exceed 60 working days".
 
           Ask for an internal review, linking to <a href="https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf">ICO advice</a>.
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1011 

## What does this do?
This patch corrects a typo in the answer for S12-A10.

## Why was this needed?
A WhatDoTheyKnow user kindly alerted us to a typo, meaning that we had the the guidance in S12-A10 as to backward aggregation mixed up. As per paragraphs 49 and 50 of the [ICO guidance](https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf), the relevant period is **20 days ‘forward'** and **60 days ‘backwards’**, with the total aggregation period not exceeding 60 working days.

## Implementation notes
Nothing to note, it's changing a '2' to a '6'

## Screenshots
N/A

## Notes to reviewer

N/A