### PR TITLE
Add no reply address for Cambridgeshire County Council

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -117,6 +117,7 @@ Rails.configuration.to_prepare do
     no-reply@somersetwestandtaunton.gov.uk
     csfinanceplanning&performance.briefingteam@hmrc.gov.uk
     foi.foi@lincs.police.uk
+    mft@cambridgeshire.gov.uk
   )
 
   User::EmailAlerts.instance_eval do


### PR DESCRIPTION
When information is sent via the file transfer service it comes from a no reply email address. This address then gets picked up as the reply address for WhatDoTheyKnow users creating a bounce message rather than going through to the authority