### PR TITLE
Fix phrasing of legal basis for processing

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -578,11 +578,9 @@
   </p>
   <p>
     We believe that our processing of our users’ data is as they would expect
-    when they use our service. If you use WhatDoTheyKnow to make a FOI request,
-    you are consenting to your data being processed as described on this page.
-    We make clear how we handle users’ data, and link to this page, at
-    appropriate places within our service, including during the process of
-    signing up, and making a request.
+    when they use our service. We make clear how we handle users’ data, and
+    link to this page, at appropriate places within our service, including
+    during the process of signing up, and making a request.
   </p>
   <p>
     On rare occasions the legal basis of "compliance with a legal obligation"


### PR DESCRIPTION
We process all GDPR RTE requests under the legal basis of Legitimate Interests,
so using the word "consent" in this particular context is a little confusing given
it's a specific term for another legal basis for processing.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/1035