### PR TITLE
[#1059] Add outlook recall information to /help/officers

### DIFF
--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -378,18 +378,19 @@
         both the sender and recipient are on the same email system.
       </p>
       <p>
-      <p>
         This functionality is unlikely to work on other platforms; and it is not a 
         function that is supported on WhatDoTheyKnow. Further information about 
         this function, and its limitations, may be found on the 
         <a href="https://support.microsoft.com/en-us/office/recall-or-replace-an-email-message-that-you-sent-35027f88-d655-4554-b4f8-6c0729a723a0?ui=en-us&rs=en-us&ad=us"
         title="Find out about message recalls on the Microsoft website">
         Microsoft website</a>.
+      </p>
       <p>
         If you’ve spotted an issue with a request, please 
         <a href="<%= help_contact_path %>">contact us</a>, giving as much detail 
         as possible, and we’ll help.
-      <p>
+      </p>
+    </dd>
     <dt id="copyright">
       What is your policy on copyright of documents?
       <a href="#copyright">#</a>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -368,6 +368,28 @@
         service is not suited to requests for email contact details.
       </p>
     </dd>
+    <dt id="recall">
+      I tried recalling a message - why hasn’t it worked?
+      <a href="#recall">#</a>
+    </dt>
+    <dd>
+      <p>
+        The recall function provided in Microsoft Outlook generally only works if 
+        both the sender and recipient are on the same email system.
+      </p>
+      <p>
+      <p>
+        This functionality is unlikely to work on other platforms; and it is not a 
+        function that is supported on WhatDoTheyKnow. Further information about 
+        this function, and its limitations, may be found on the 
+        <a href="https://support.microsoft.com/en-us/office/recall-or-replace-an-email-message-that-you-sent-35027f88-d655-4554-b4f8-6c0729a723a0?ui=en-us&rs=en-us&ad=us"
+        title="Find out about message recalls on the Microsoft website">
+        Microsoft website</a>.
+      <p>
+        If you’ve spotted an issue with a request, please 
+        <a href="<%= help_contact_path %>">contact us</a>, giving as much detail 
+        as possible, and we’ll help.
+      <p>
     <dt id="copyright">
       What is your policy on copyright of documents?
       <a href="#copyright">#</a>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1059 

## What does this do?

This adds text to /help/officers (in English only) detailing why "recall" messages sent through Microsoft Outlook (Microsoft Exchange email systems) will fail to work.

## Why was this needed?

Public bodies try to use the "recall" function to remove information from WDTK; however, this is not supported on the majority of platforms - ours included.

## Implementation notes
Straight HTML - there's an annoyingly _massive_ Microsoft link which is breaking line length - Microsoft haven't made a short url available, we could create one if really needed.

## Screenshots
N/A

## Notes to reviewer

This is probably the first step - the ticket upstream (https://github.com/mysociety/alaveteli/issues/6884) will allow us to consider something more substantive in the Alaveteli codebase to handle these nuisance messages in a more elegant way.