### PR TITLE
[#1106] Add ICO anonymisation code to wdtk-routes.rb and update outgoing mailer

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   get "/help/ico-guidance-for-authorities" => redirect("https://ico.org.uk/media/for-organisations/documents/how-to-disclose-information-safely-removing-personal-data-from-information-requests-and-datasets/2013958/how-to-disclose-information-safely.pdf"),
       as: :ico_guidance
 
+  get "/help/ico-anonymisation-code" => redirect("https://ico.org.uk/media/1061/anonymisation-code.pdf"),
+     as: :ico_anonymisation_code
+
   get '/help/principles' => 'help#principles',
       as: :help_principles
 

--- a/lib/views/outgoing_mailer/_followup_footer.text.erb
+++ b/lib/views/outgoing_mailer/_followup_footer.text.erb
@@ -5,6 +5,7 @@
 <%= _('For more detailed guidance on safely disclosing information, read the ' \
       'latest advice from the ICO:') %>
 <%= ico_guidance_url %>
+<%= ico_anonymisation_code_url %>
 
 <% if feature_enabled? :alaveteli_pro %>
 <%= _('Please note that in some cases publication of requests and ' \


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1106

## What does this do?
This adds the URL for the ICO anonymisation code to wdtk-routes.rb, and adds the corresponding URL to the outgoing mailer file _followup_footer.text.erb

## Why was this needed?
The URL is useful to have, for ease of use, when responding to public bodies who have disclosed data improperly. It is also helpful to include in outgoing mail, as this gives some clear and helpful guidance to those who might be unfamiliar with the correct way of disclosing statistical data.

This complements the existing ICO guidance we link (I wish we had named it more specifically!)

## Implementation notes
Nothing of note

## Screenshots
N/A

## Notes to reviewer

Hopefully nothing contentious, although please verify that I've added the link in _followup_footer.text.erb (70d2311ed10291eaa91caeaa201de73537834168) correctly.