### PR TITLE
Accessibility issues: WDTK

### DIFF
--- a/app/assets/stylesheets/responsive/_mixins.scss
+++ b/app/assets/stylesheets/responsive/_mixins.scss
@@ -47,7 +47,7 @@
 
 @mixin button-secondary {
   @include button-base;
-  background-color: $color_light_grey;
+  background-color: mix($color_light_grey, $color_yellow, 95%);
   color: $color_black;
   font-weight: normal;
   &:hover,

--- a/app/assets/stylesheets/responsive/_mixins.scss
+++ b/app/assets/stylesheets/responsive/_mixins.scss
@@ -102,7 +102,7 @@
 /* Menu items */
 @mixin menu-item {
   text-decoration: none;
-  color: transparentize($main_menu-link_text, 0.2);
+  color: transparentize($main_menu-link_text, 0.1);
   @include ie8 {
     color: $main_menu-link_text;
   }

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1,5 +1,5 @@
 $color_orange: #f4a140;
-$color_blue: #419BE8;
+$color_blue: #2078C2;
 $color_green: #62b356;
 $color_yellow: #ffd836;
 $color_red: #e04b4b;
@@ -14,7 +14,7 @@ $color_white: #ffffff;
 $color_pro_blue: #5A7687;
 
 $mysociety-banner: $color_black;
-$link-color: darken($color_blue, 20%);
+$link-color: darken($color_blue, 10%);
 $body-font-color: $color_black;
 $body-bg: $color_off_white;
 $button-bg: $color_blue;

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -311,7 +311,7 @@ a.link_button_green_large {
 }
 
 .form_item_note {
-  color: $color_mid_grey;
+  color: $color_dark_grey;
 }
 
 /* Popups */

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -839,7 +839,7 @@ $mysoc-footer-breakpoint-sm: 42em;
   .action-menu__button {
     @include button-secondary;
     &:after {
-      border-color: #a5a5a5 transparent transparent transparent;
+      border-color: #8c8a8a transparent transparent transparent;
       right: 7%;
     }
   }

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1768,6 +1768,7 @@ p.locale-list-trigger {
 
     li {
       margin-bottom: 0.5rem;
+      padding: 5px 0;
     }
   }
 }


### PR DESCRIPTION
This pull request contains some fixes for accessibility issues found in the WDTK theme.

### $color_blue is now a darker, richer version that passes the contrast test:

<img width="682" alt="Screenshot 2022-04-21 at 07 36 10" src="https://user-images.githubusercontent.com/13790153/164389391-dd9a6eba-1b0b-4727-8f78-1e12fc5ce64d.png">
<img width="1440" alt="Screenshot 2022-04-21 at 07 35 45" src="https://user-images.githubusercontent.com/13790153/164389403-655bab64-dfe9-4c46-b1b4-8073c177af37.png">
<img width="1440" alt="Screenshot 2022-04-21 at 07 35 28" src="https://user-images.githubusercontent.com/13790153/164389413-e34884df-9ad7-4f34-9247-54f0b2d407bd.png">

### Items on subnav pass contrast test
<img width="716" alt="Screenshot 2022-04-21 at 08 27 40" src="https://user-images.githubusercontent.com/13790153/164401030-7ae685b7-0fbb-495b-9cfc-029d8054c454.png">

### Secondary button a bit darker

<img width="1014" alt="Screenshot 2022-04-21 at 08 50 38" src="https://user-images.githubusercontent.com/13790153/164406371-bede5c54-9aa3-4ecc-80c0-384809272100.png">


### Increase vertical padding for list items on help page

<img width="982" alt="Screenshot 2022-04-21 at 07 37 53" src="https://user-images.githubusercontent.com/13790153/164389705-1a436ffd-9fae-44fb-9be1-e8ce509bb8a0.png">

### When creating a new request the footer notes now pass the contrast test
<img width="716" alt="Screenshot 2022-04-21 at 07 40 26" src="https://user-images.githubusercontent.com/13790153/164390203-5788bc8f-a12c-4ed3-a053-125236551772.png">

Fixes part of: #1138 
The rest of the issues, will be fixed on the Alaveteli core.

