### PR TITLE
[#1133] Fix company names on /cy/help/about

### DIFF
--- a/lib/views/help/about.cy.html.erb
+++ b/lib/views/help/about.cy.html.erb
@@ -31,7 +31,7 @@
     Pwy sy’n gwneud WhatDoTheyKnow? <a href="#who">#</a>
     </dt>
     <dd>
-    Cafodd WhatDoTheyKnow ei greu gan <a href="http://www.mysociety.org/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a> ac mae’n cael ei gynnal ganddi. Ar y dechrau cafodd <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/?utm_source=whatdotheyknow.com&utm_medium=link">ei ariannu gan Ymddiriedolaeth Elusennol JRSST</a>. Mae mySociety yn brosiect yr elusen gofrestredig <a href="https://www.mysociety.org/about/structure-and-governance/?utm_source=whatdotheyknow.com&utm_medium=link">Democratiaeth Dinasyddion Ar-lein y DG</a>. Os ydych yn hoffi’r hyn rydym yn ei wneud, yna gallwch <a href="<%= donation_url %>">roi rhodd</a>.
+      Cafodd WhatDoTheyKnow ei greu gan <a href="http://www.mysociety.org/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a> ac mae’n cael ei gynnal ganddi. Ar y dechrau cafodd <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/?utm_source=whatdotheyknow.com&utm_medium=link">ei ariannu gan Ymddiriedolaeth Elusennol JRSST</a>. Mae <a href="https://www.mysociety.org/about/structure-and-governance/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a> yn elusen gofrestredig (<a href="https://register-of-charities.charitycommission.gov.uk/cy/charity-search/-/charity-details/3078648">1076346</a>) ac yn gwmni wedi'i gofrestru yng Nghymru a Lloegr (<a href="http://opencorporates.com/companies/gb/03277032">03277032</a>). Os ydych yn hoffi’r hyn rydym yn ei wneud, yna gallwch <a href="<%= donation_url %>">roi rhodd</a>.
     </dd>
     <dt id="updates">
     Sut y gallaf gadw i fyny gyda newyddion am WhatDoTheyKnow?<a href="#updates">#</a>


### PR DESCRIPTION
Still mentions UKCOD, in Welsh.

Thanks to @FOIMonkey for the translation.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/1133.

![Screenshot 2022-05-16 at 09 28 10](https://user-images.githubusercontent.com/282788/168551250-09040b29-05e9-4b38-8b33-e0b8f8828066.png)

