### PR TITLE
Remove calls to InfoRequest#is_batch_request_template?

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -24,7 +24,7 @@ Rails.configuration.to_prepare do
     def email_subject_request(opts = {})
       html = opts.fetch(:html, true)
       subject_title = html ? self.title : self.title.html_safe
-      if (!is_batch_request_template?) && (public_body && public_body.url_name == 'general_register_office')
+      if public_body && public_body.url_name == 'general_register_office'
         # without GQ in the subject, you just get an auto response
         _('{{law_used_full}} request GQ - {{title}}', law_used_full: legislation.to_s(:full),
           title: subject_title)

--- a/spec/model_patches_spec.rb
+++ b/spec/model_patches_spec.rb
@@ -15,15 +15,6 @@ RSpec.describe InfoRequest, "when creating an email subject for a request" do
       to eq("Freedom of Information request GQ - #{info_request.title}")
   end
 
-  it 'should be able to create an email subject request for a batch request template without
-      a public body' do
-    info_request = FactoryBot.build(:info_request)
-    info_request.public_body = nil
-    info_request.is_batch_request_template = true
-    expect(info_request.email_subject_request).
-      to eq("Freedom of Information request - #{info_request.title}")
-  end
-
 end
 
 RSpec.describe InfoRequest do


### PR DESCRIPTION
This has been removed upstream from Alaveteli.

See: https://github.com/mysociety/alaveteli/pull/7142