### PR TITLE
[#1270] Resume rendering of the contact form

### DIFF
--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -68,12 +68,12 @@
 
 
     <h2 class="contact-page__goal" id="writing-help">
-        <label class="houdini-label" for="goal4">
+        <label class="houdini-label" for="goal3">
             I need <strong>help writing a freedom of information request</strong>.
         </label>
     </h2>
 
-    <input class="houdini-input" type="radio" name="goals" id="goal4"
+    <input class="houdini-input" type="radio" name="goals" id="goal3"
         <% if params["contact"] && params[:current_form] == 'writing-help' %>checked<% end %>>
     <div class="houdini-target contact-page__options">
         <ul>
@@ -90,12 +90,12 @@
 
 
     <h2 class="contact-page__goal" id="wdtk">
-        <label class="houdini-label" for="goal3">
+        <label class="houdini-label" for="goal4">
             I’d like to get involved and become a <strong>volunteer</strong>
         </label>
     </h2>
 
-    <input class="houdini-input" type="radio" name="goals" id="goal3"
+    <input class="houdini-input" type="radio" name="goals" id="goal4"
         <% if params["contact"] && params[:current_form] == 'wdtk' %>checked<% end %>>
     <div class="houdini-target contact-page__options">
         <ul>
@@ -119,14 +119,14 @@
 
 
     <h2 class="contact-page__goal" id="wdtk">
-        <label class="houdini-label" for="goal3">
+        <label class="houdini-label" for="goal5">
             I have another issue, or feedback relating to the
             WhatDoTheyKnow.com website, that I want to raise with the
             <strong>team that runs WhatDoTheyKnow</strong>.
         </label>
     </h2>
 
-    <input class="houdini-input" type="radio" name="goals" id="goal3"
+    <input class="houdini-input" type="radio" name="goals" id="goal5"
         <% if params["contact"] && params[:current_form] == 'wdtk' %>checked<% end %>>
     <div class="houdini-target contact-page__options">
         <ul>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1270 

## What does this do?
This patch resumes the rendering of the WDTK team contact form, which had not been rendering correctly owing to a bug.

## Why was this needed?
The fix in #1208 had renumbered the form to houdini goal 4, but this had not been factored into one of the labels - therefore the contact form would only render if the "I need help writing a freedom of information request." option was chosen.

## Implementation notes
I have noted that we render a different piece of help text on the "I need help writing a freedom of information request" and "I have another issue, or feedback relating to the WhatDoTheyKnow.com website, that I want to raise with the team that runs WhatDoTheyKnow" forms, therefore, rather than have them as the same goal, I've set the default contact form as houdini goal **5**.

I've also renumbered the preceding, so that they follow a logical numbering sequence.

## Screenshots
N/A - although, @WilliamWDTK has captured a video of the bug in #1270.

## Notes to reviewer

N/A