### PR TITLE
Add no reply emails for Tewkesbury BC and Publica Group

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -123,6 +123,8 @@ Rails.configuration.to_prepare do
     foi@dudley.gov.uk
     no-reply@sharepointonline.com
     dvla.donotreply@dvla.gov.uk
+    noreply@my.tewkesbury.gov.uk
+    donotreply.foi@publicagroup.uk
   )
 
   User::EmailAlerts.instance_eval do


### PR DESCRIPTION
## Relevant issue(s)
Fixes  #1273
Fixes  #1274

## What does this do?
Adds no-reply email addresses for Tewekesbury BC and Publica Group to model_patches.rb

## Why was this needed?
Public bodies responding from no-reply email addresses, which causes frustration for users.

## Implementation notes
Nothing special to note.

## Screenshots
N/A

## Notes to reviewer
N/A