### PR TITLE
Create PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Relevant issue(s)
+
+## What does this do?
+
+## Why was this needed?
+
+## Implementation notes
+
+## Screenshots
+
+## Notes to reviewer


### PR DESCRIPTION
## Relevant issue(s)
N/A

## What does this do?
Adds a template for pull requests, as [documented by GitHub](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository).

## Why was this needed?
We already have a PR template on the Alaveteli repo, but not on the WDTK theme, which makes for a slightly inconsistent experience. This corrects the apparent anomaly by re-using an existing mySoc template.

## Implementation notes

The suggested file is a copy of the [PR template](https://github.com/mysociety/alaveteli/blob/develop/.github/PULL_REQUEST_TEMPLATE.md) from the main Alaveteli repo.

## Screenshots
N/A

## Notes to reviewer

I didn't write the template - but given we re-use this one quite often, it does seem to make sense to include it in the repo.