### PR TITLE
Update intro section of how help page

### DIFF
--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -6,11 +6,11 @@
     <a href="#title">#</a>
   </h1>
   <p>
-    WhatDoTheyKnow is administered by a small group of dedicated
+    WhatDoTheyKnow is administered by a small team of mySociety staff and dedicated
     <a href="<%= help_credits_path(:anchor => 'volunteers') %>">volunteers</a>
     who have extensive knowledge and experience of Freedom of Information, and
     who support it. Decisions about the administration of the site are taken by
-    these volunteers, with support from mySociety’s Chief Executive and
+    this administration team, with support from mySociety’s Chief Executive and
     <a href="<%= help_about_path(:anchor => 'who') %>">Trustees</a>.
   </p>
   <h2 id="reactive_moderation">


### PR DESCRIPTION
Fixes #1190.

Updates introduction section of 'How we run WhatDoTheyKnow' help page to better reflect increased staff involvement and bring in line with support email footer.

Screenshot of new help text:
![image](https://user-images.githubusercontent.com/47503358/179036417-bee6312b-5ca5-4412-90c4-ec879181d558.png)
