### PR TITLE
[#1276 / #1286] Improve stylng of forms in /help/contact and improve copy

### DIFF
--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -79,7 +79,8 @@
         <ul>
             <li>
                 Directly contact the team that run WhatDoTheyKnow:
-
+            </li>
+            <li style="list-style-type:none;">
                 <%= foi_error_messages_for :contact %>
 
                 <%= render :partial => "help/contact_form",
@@ -108,7 +109,7 @@
                 involves, see
                 <%= link_to _("our get involved page"), help_volunteers_path %>.
             </li>
-            <li>
+            <li style="list-style-type:none;">
                 <%= foi_error_messages_for :contact %>
 
                 <%= render :partial => "help/contact_volunteer_form",
@@ -143,7 +144,8 @@
                     If your issue isn’t covered by our help pages, you can
                     directly contact the team that run WhatDoTheyKnow:
                 <% end %>
-
+            </li>
+            <li style="list-style-type:none;">
                 <%= foi_error_messages_for :contact %>
 
                 <%= render :partial => "help/contact_form",

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -93,8 +93,9 @@
                     run WhatDoTheyKnow Pro. 
                 <% else %>
                    If you still need help, you can contact the team that 
-                    run WhatDoTheyKnow. 
+                    run WhatDoTheyKnow.
                 <% end %>
+                <br>
                 It'd be helpful if you could let us know what information you 
                 are looking for, and which body you think might hold it.
             </li>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -88,13 +88,8 @@
                 <%= link_to _("our blog"), blog_path %>.
             </li>
             <li>
-                <% if @user && @user.is_pro? %>
-                    If you still need help, you can contact the team that 
-                    run WhatDoTheyKnow Pro. 
-                <% else %>
-                   If you still need help, you can contact the team that 
-                    run WhatDoTheyKnow.
-                <% end %>
+                If you still need help, you can contact the team that 
+                run WhatDoTheyKnow.
                 <br>
                 It'd be helpful if you could let us know what information you 
                 are looking for, and which body you think might hold it.
@@ -156,13 +151,8 @@
                 issues and questions you might have.
             </li>
             <li>
-                <% if @user && @user.is_pro? %>
-                    If your issue isn’t covered by our help pages, you can
-                    directly contact the team who run WhatDoTheyKnow Pro:
-                <% else %>
-                    If your issue isn’t covered by our help pages, you can
-                    directly contact the team that run WhatDoTheyKnow:
-                <% end %>
+                If your issue isn’t covered by our help pages, you can 
+                directly contact the team that run WhatDoTheyKnow:
             </li>
             <li style="list-style-type:none;">
                 <%= foi_error_messages_for :contact %>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -85,7 +85,7 @@
             </li>
             <li>
                 You can also find inspiration for your request on 
-                <a href="<%= link_to _("Read blog"), blog_path %>">our blog</a>.
+                <%= link_to _("our blog"), blog_path %>.
             </li>
             <li>
                 <% if @user && @user.is_pro? %>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -76,9 +76,27 @@
     <input class="houdini-input" type="radio" name="goals" id="goal3"
         <% if params["contact"] && params[:current_form] == 'writing-help' %>checked<% end %>>
     <div class="houdini-target contact-page__options">
+        <h3>If you need help writing a request, we've got you covered.</h3>
         <ul>
             <li>
-                Directly contact the team that run WhatDoTheyKnow:
+                Our <a href="<%= help_requesting_path %>">help pages</a> have 
+                guidance on how to make requests, including some top tips on 
+                how you can get the best response.
+            </li>
+            <li>
+                You can also find inspiration for your request on 
+                <a href="<%= link_to _("Read blog"), blog_path %>">our blog</a>.
+            </li>
+            <li>
+                <% if @user && @user.is_pro? %>
+                    If you still need help, you can contact the team that 
+                    run WhatDoTheyKnow Pro. 
+                <% else %>
+                   If you still need help, you can contact the team that 
+                    run WhatDoTheyKnow. 
+                <% end %>
+                It'd be helpful if you could let us know what information you 
+                are looking for, and which body you think might hold it.
             </li>
             <li style="list-style-type:none;">
                 <%= foi_error_messages_for :contact %>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1276
Fixes #1286

## What does this do?
This adds a slight bit of styling to the `<li>` element within the houdini goals where a contact form is rendered.

It also makes an attempt at improving the copy in goal 3 - "I need help writing a freedom of information request" and adds some variation within aforementioned for Pro.

## Why was this needed?

The volunteer contact form on /help/contact introduced a slight oddity of styling, where the form itself was contained in a separate list element of its own, which led to a slightly unsightly bullet point being rendered. This is a kludgy attempt at remedying this, without the expense of adding to the core stylesheet.

We were also somewhat light with the copy in goal 3, which is odd, as we've some pretty comprehensive information in the help pages. It seems wise to link there, and to the blog, as a first port of call.

## Implementation notes
Nothing of real interest here, it's simple html for the most part.

## Screenshots

### Volunteer form (goal 4)
#### original:
<img src="https://user-images.githubusercontent.com/249418/178630108-93a4d69c-2c62-4daa-87fe-88e6fe650057.png" width="500px" alt="Image of the WhatDoTheyKnow volunteer contact form, showing that there are three visible bullet points - two for the listing of options, and one for the form itself. An orange circle has been drawn over the bullet point for the form, and the annotation 'Why?' has been added">

#### revised:
<img src="https://user-images.githubusercontent.com/249418/178631163-fc3177cc-dc51-4732-b753-8fe6d3a185ef.png" width="500px" alt="Image of the WhatDoTheyKnow volunteer contact form, showing that the bullet points for the list items still exist, but that the bullet point appearing at the left hand side of the form has been removed. A green circle has been drawn where the bullet point ought to have been, and the annotation 'Bullet point removed, space preserved' has been overlaid.">

### Writing help
<img src="https://user-images.githubusercontent.com/249418/179050921-050a758a-7ea5-430e-9c09-7eb232bfa6b7.png" width="500px" alt="Image of the WhatDoTheyKnow writing help contact form, showing new text which has been added giving suggestions on how the user might find help in writing their request. The full text is within the commit">

## Notes to reviewer
It feels like we could cut the if/else for Pro in goal 5 (and by definition, my copy/paste in goal 3) down a bit. It isn't massively problematic though, it's not like maintainability is an issue.