### PR TITLE
[#1292] Add unique identifier to Volunteer contact form results

### DIFF
--- a/lib/views/contact_mailer/volunteer_message.text.erb
+++ b/lib/views/contact_mailer/volunteer_message.text.erb
@@ -21,4 +21,6 @@ Anything else:
   _("logged in as user {{user_name}}",
     :user_name => user_url(@logged_in_user)) :
   _("not logged in") %>
+
+Case reference: <%= @contact_caseref %>
 ---------------------------------------------------------------------

--- a/lib/volunteer_contact_form.rb
+++ b/lib/volunteer_contact_form.rb
@@ -46,6 +46,8 @@ module VolunteerContactForm
   module MailerMethods
     def volunteer_message(contact, logged_in_user)
       @contact = contact
+      # Setup a case reference so we can find this in the mailbox
+      @contact_caseref = 'VAPP/'+Time.now.strftime('%Y%m%d')+'-'+SecureRandom.base36(4).upcase
       @logged_in_user = logged_in_user
 
       # From is an address we control so that strict DMARC senders don't get
@@ -58,10 +60,14 @@ module VolunteerContactForm
       )
       set_reply_to_headers(nil, 'Reply-To' => reply_to_address)
 
+      # Set a header so we can filter in the mailbox
+      headers['X-WDTK-Contact'] = 'wdtk-volunteer'
+      headers['X-WDTK-CaseRef'] = @contact_caseref
+
       mail(
         from: from,
         to: contact_from_name_and_email,
-        subject: _('Message from WDTK volunteer contact form')
+        subject: _('Message from '+contact.name+' via WDTK volunteer contact form ['+@contact_caseref+']')
       )
     end
   end

--- a/lib/volunteer_contact_form.rb
+++ b/lib/volunteer_contact_form.rb
@@ -67,7 +67,9 @@ module VolunteerContactForm
       mail(
         from: from,
         to: contact_from_name_and_email,
-        subject: _('Message from '+contact.name+' via WDTK volunteer contact form ['+@contact_caseref+']')
+        subject: _('Message from {{name}} via WDTK volunteer contact form [{{reference}}]',
+                   name: contact.name,
+                   reference: @contact_caseref)
       )
     end
   end


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1292 

## What does this do?

This adds a unique reference to the subject line and body of messages received on the Volunteer contact form, and adds a few email headers.

There are no changes to the contact form itself; however, it's worth noting that PR #1289, if implemented, will make minor changes to the form (stylistically).

## Why was this needed?
When submissions of the Volunteer contact form are received in the team@ mailbox they do not have a unique identifier. This is causing issues, as Gmail tries to thread messages into conversation view, which doesn't work so well if they are from different persons (or, as observed by colleagues at the weekend, interspersed with form-spam).

## Implementation notes

Nothing really special here - the reference used is based broadly on our existing format, consisting of a case type ('VAPP'), the date (YYYYMMDD), and a random identifier.

As an example, if 'Humphrey Appleby' submits a form, we'd get something like:

| Name: | Humphrey Appleby |
| :---         | :---  |
| **X-WDTK-Contact:**  |  wdtk-volunteer
|**X-WDTK-CaseRef:** 	|  VAPP/20220718-GA5X	|
|  **Subject:**      	|   Message from Humphrey Appleby via WDTK volunteer contact form [VAPP/20220718-GA5X]           	|

I have tested this in sandbox (running 0.41.1.0) with both logged in / non logged-in and haven't noted any issues.

The method of passing data back to the mailer feels a little 'iffy', but it does work. Do feel free to amend  if there is a more obvious solution that I've missed.

## Screenshots
Example non-logged in:
<img src="https://user-images.githubusercontent.com/249418/179472848-ac96f79d-2d55-44cd-8a33-dbaff6d920be.png" width="500px" alt="Screenshot from WhatDoTheyKnow volunteer contact email">

## Notes to reviewer

The email headers 'X-WDTK-Contact' and 'X-WDTK-CaseRef' are being added for the purposes of future-proofing, as the prototype email handling tool can use these to pre-fill parts of reply emails, saving a bit of time.