### PR TITLE
Fixes mySoc styleguide conflict

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -493,7 +493,7 @@
     </p>
     </dd>
     <dt id="ico_help">
-      Can you tell me more of the nitty gritty about the process of making requests?
+      Can you get into the details about the process of making requests?
       <a href="#ico_help">#</a>
     </dt>
     <dd>


### PR DESCRIPTION
Fixes #1311 

The mySociety style guide identified the old wording as being a phrase that shouldn't be used due to the racial connotations. This fixes the issue using the suggested alternative.