### PR TITLE
[#1326] Update help pages

### DIFF
--- a/lib/views/help/_contact_form.cy.html.erb
+++ b/lib/views/help/_contact_form.cy.html.erb
@@ -1,0 +1,83 @@
+<%= form_for :contact,
+             :url => help_contact_path + '#' +  form_id,
+             :html => {:class => 'contact-form'} do |f| %>
+
+    <p class="contact-form__understand">
+        <%= f.check_box :understand, :required => true %>
+        <label for="contact_understand" class="form_label">
+            Rwy'n deall <strong>nad yw WhatDoTheyKnow yn cael ei redeg gan y 
+            llywodraeth, ac ni fydd tîm WhatDoTheyKnow <b>yn gallu helpu</b> 
+            gyda materion personol sy'n gysylltiedig â gwasanaethau'r llywodraeth.
+        </label>
+    </p>
+    <% if not @user %>
+        <p>
+            <label class="form_label" for="contact_name">Eich enw:</label>    
+            <%= f.text_field :name, :size => 20, :required => true %>
+            (Neu  <%= link_to "fewngofnodwch",
+                            signin_url(
+                              :r => request.fullpath + '#' + form_id) %>)
+            <%= f.text_field :name, :size => 20 %>
+        </p>
+
+        <p>
+            <label class="form_label" for="contact_email">Eich e-bost:</label>
+            <%= f.text_field :email, :size => 20 %>
+        </p>
+    <% end %>
+
+    <p>
+        <label class="form_label" for="contact_subject">Pwnc:</label>
+        <%= f.text_field :subject,
+                         :size => 50,
+                         :required => true,
+                         :class => "message-subject" %>
+    </p>
+
+    <p>
+        <label class="form_label" for="contact_message">
+            Fy neges i dîm WhatDoTheyKnow:
+        </label>
+        <%= f.text_area :message, :rows => 10, :cols => 60, :required => true %>
+    </p>
+
+    <p style="display:none;">
+        <%= f.label :comment, 'Peidiwch â llenwi’r yn y maes hwn' %>
+        <%= f.text_field :comment %>
+    </p>
+
+    <% if !@last_request.nil? %>
+        <p>
+            <label class="form_label" for="contact_message">Cynnwys dolen i ofyn am:</label>
+            <%=request_link(@last_request) %>
+            <%= submit_tag "remove", :name => 'remove' %>
+        </p>
+    <% end %>
+    <% if !@last_body.nil? %>
+        <p>
+            <label class="form_label" for="contact_message">Cynnwys dolen i awdurdod:</label>
+            <%=public_body_link(@last_body) %>
+            <%= submit_tag "remove", :name => 'remove' %>
+        </p>
+    <% end %>
+
+    <% if @recaptcha_required %>
+      <%= recaptcha_tags %><br />
+    <% end %>
+
+    <div class="form_button">
+        <script><!--
+            if (!!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/)) {
+                $('#contact_understand').removeAttr('required');
+                $('#contact_name').removeAttr('required');
+                $('#contact_email').removeAttr('required');
+                $('#contact_subject').removeAttr('required');
+                $('#contact_message').removeAttr('required');
+            }
+        //--></script>
+        <%= hidden_field_tag(:current_form, form_id) %>
+        <%= hidden_field_tag(:submitted_contact_form, 1) %>
+        <%= submit_tag "Anfon neges i dîm WhatDoTheyKnow", :data => { :disable_with => "Anfon…" } %>
+    </div>
+
+<% end %>

--- a/lib/views/help/_history.cy.html.erb
+++ b/lib/views/help/_history.cy.html.erb
@@ -1,0 +1,18 @@
+<% if @history %>
+  <div class="changes">
+    <h2 id="changes">
+      Newidiadau <a href="#changes">#</a>
+    </h2>
+
+    <p>
+      Byddwn yn adolygu'r tudalennau hyn yn gyson, a gallwn wneud newidiadau 
+      o bryd i'w gilydd er mwyn sicrhau eu bod yn parhau'n gyfredol ac yn gywir.
+      Gallwch ddod o hyd i grynodeb o'r newidiadau yr ydym wedi'u gwneud yn 
+      ein <%= link_to 'storfa GitHub',
+        @history.commits_url,
+        alt: "Dolen i fersiwn hanes ar gyfer WhatDoTheyKnow #{@title} (cynhaliwyd ar GitHub)" %>
+      ond os oes gennych unrhyw gwestiynau, gwnewch
+      <%= link_to 'cysylltu â ni', help_contact_path %>.
+    </p>
+  </div>
+<% end %>

--- a/lib/views/help/about.cy.html.erb
+++ b/lib/views/help/about.cy.html.erb
@@ -43,5 +43,8 @@
   <p>
     <strong>Nesaf,</strong> darllenwch am <a href="<%= help_requesting_path %>">wneud ceisiadau</a> -&gt;
   </p>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -130,7 +130,7 @@
         WhatDoTheyKnow is run and maintained by
         <a href="http://www.mysociety.org/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a>.
         mySociety is a registered charity in England and Wales (no.
-        <a href="http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityWithPartB.aspx?RegisteredCharityNumber=1076346&SubsidiaryNumber=0">
+        <a href="https://register-of-charities.charitycommission.gov.uk/charity-search/-/charity-details/3078648">
         1076346</a>).
         mySociety is also a limited company registered in England and Wales (no.
         <a href="http://opencorporates.com/companies/gb/03277032">03277032</a>)

--- a/lib/views/help/contact.cy.html.erb
+++ b/lib/views/help/contact.cy.html.erb
@@ -1,91 +1,150 @@
 <% @title = "Cysylltwch â ni" %>
 
-<%= foi_error_messages_for :contact %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+<h1><%= @title %></h1>
+<p>Pwy hoffech gysylltu â nhw?</p>
 
-<div id="contact_preamble">
+<div class="contact-page">
 
-    <% if !flash[:notice] %>
-        <h1>Cysylltu ag awdurdod i gael gwybodaeth swyddogol</h1>
+    <h2 class="contact-page__goal" id="government">
+        <label class="houdini-label" for="goal1">
+            Rwyf am gysylltu ag <strong>adran o'r llywodraeth</strong>
+             – er enghraifft, Fisâu a Mewnfudo, y Swyddfa Gartref, CThEM,
+             neu'r Adran Gwaith a Phensiynau.
+        </label>
+    </h2>
 
-<ul>
-<li><a href="<%= new_request_path %>">Ewch yma</a> i wneud cais, yn gyhoeddus, am wybodaeth gan awdurdodau cyhoeddus yn y DU.</li>
-<li> Yn gofyn am wybodaeth breifat amdanoch chi eich hun? Darllenwch ein tudalen gymorth am <a href="<%= help_requesting_path(:anchor => 'data_protection') %>">ddiogelu data</a> . </li>
-</ul>
-
-<h1>Codi mater gyda’r Llywodraeth</h1>
-
-<ul>
-<li><a href="http://www.writetothem.com">Ysgrifennwch at eich AS, cynghorydd lleol neu gynrychiolydd arall</a></li> .
-<li>Mae <a href="http://www.number10.gov.uk/">Rhif 10</a> yn lle da i ddechrau os hoffech gymryd mater gyda llywodraeth ganolog y DU. </li>
-</ul>
-
-
-    <% end %>
-
-<h1>Cysylltu â thîm WhatDoTheyKnow</h1>
-    <% if !flash[:notice] %>
-<ul>
-<li> Darllenwch y <a href="<%= help_about_path %>">dudalen gymorth</a> yn gyntaf, gan y gallai ateb eich cwestiwn yn gyflymach. </li>
-<li>Byddem wrth ein bodd cael clywed sut brofiad gawsoch wrth ddefnyddio’r wefan hon. Naill ai llenwch y ffurflen hon,
-neu anfonwch e-bost at <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a></li>
-<li>Rydym yn <strong>elusen</strong> ac nid yn rhan o’r Llywodraeth.</li> </ul>
-</ul>
-    <% end %>
-</div>
-
-<%= form_for :contact do |f| %>
-
-    <% if not @user %>
-        <p>
-            <label class="form_label" for="contact_name">Eich enw:</label>
-            <%= f.text_field :name, :size => 20 %>
-            (Neu <%= link_to "fewngofnodwch", signin_url(:r => request.fullpath) %>)
-        </p>
-
-        <p>
-            <label class="form_label" for="contact_email">Eich e-bost:</label>
-            <%= f.text_field :email, :size => 20 %>
-        </p>
-    <% end %>
-
-    <p>
-        <label class="form_label" for="contact_subject">Pwnc:</label>
-        <%= f.text_field :subject, :size => 50 %>
-    </p>
-
-    <p>
-        <label class="form_label" for="contact_message">Neges i’r wefan:</label>
-        <%= f.text_area :message, :rows => 10, :cols => 60 %>
-    </p>
-
-    <p style="display:none;">
-        <%= f.label :comment, "Peidiwch â llenwi’r yn y maes hwn" %>
-        <%= f.text_field :comment %>
-    </p>
-
-    <% if !@last_request.nil? %>
-        <p>
-            <label class="form_label" for="contact_message">Include link to request:</label>
-            <%=request_link(@last_request) %>
-            <%= submit_tag "remove", :name => 'remove' %>
-        </p>
-    <% end %>
-    <% if !@last_body.nil? %>
-        <p>
-            <label class="form_label" for="contact_message">Include link to authority:</label>
-            <%=public_body_link(@last_body) %>
-            <%= submit_tag "remove", :name => 'remove' %>
-        </p>
-    <% end %>
-
-    <p class="form_note">
-    Dim ond gyda <strong>phroblemau technegol</strong> y gallwn eich helpu, neu gyda chwestiynau am Ryddid Gwybodaeth. Gweler ben y dudalen hon os hoffech gysylltu â’r Llywodraeth. </p>
-
-
-    <div class="form_button">
-        <%= hidden_field_tag(:submitted_contact_form, 1) %>
-        <%= submit_tag "Anfonwch neges i’r elusen", :data => { :disable_with => "Anfon..." } %>
-        &lt;- Ni sy’n cynnal y wefan hon, nid y Llywodraeth!
+    <input class="houdini-input" type="radio" name="goals" id="goal1">
+    <div class="houdini-target contact-page__options">
+        <ul>
+            <li>
+                <a href="<%= select_authority_path %>">Ewch yma</a> i wneud 
+                cais, yn gyhoeddus, am wybodaeth gan awdurdodau cyhoeddus 
+                yn y DU.
+            </li>
+            <li>
+                Os oes angen i chi drafod materion personol gyda chyngor y DU, 
+                dylech <a href="https://www.gov.uk/cymraeg/">
+                find wyf nhw ar GOV.UK</a>.
+            </li>
+            <li>
+                Os ydych yn cael trafferth cael y gwasanaeth mae arnoch ei angen
+                o gorff llywodraeth yna gall swyddfa eich AS yn aml
+                helpu. Gallwch <a href="https://www.writetothem.com/">ysgrifen
+                at eich AS ar WriteToThem.com</a>.
+            </li>
+        </ul>
     </div>
 
-<% end %>
+    <h2 class="contact-page__goal" id="authority">
+        <label class="houdini-label" for="goal2">
+            Rwyf am gysylltu ag awdurdod cyhoeddus, fel fy
+            <strong>cyngor lleol, ysbyty, neu ysgol</strong>.
+        </label>
+    </h2>
+
+    <input class="houdini-input" type="radio" name="goals" id="goal2">
+    <div class="houdini-target contact-page__options">
+        <ul>
+            <li>
+                Os ydych eisiau gwneud cais Rhyddid Gwybodaeth i gyngor DU neu 
+                awdurdod cyhoeddus, gallwch 
+                <a href="<%= select_authority_path %>">find nhw yma</a>.
+            </li>
+            <li>
+                Os oes angen i chi drafod materion personol gyda chyngor y DU, 
+                dylech <a href="https://www.gov.uk/cymraeg/">
+                find wyf nhw ar GOV.UK</a>.
+            </li>
+            <li>
+                Os ydych chi eisiau ysgrifennu at eich AS, cynghorydd lleol, 
+                neu gynrychiolydd arall, gallwch 
+                <a href="https://www.writetothem.com/">
+                ysgrifen i'ch AS ar WriteToThem.com</a>.
+            </li>
+        </ul>
+    </div>
+
+
+    <h2 class="contact-page__goal" id="writing-help">
+        <label class="houdini-label" for="goal3">
+            Rydw i angen <strong>help i ysgrifennu cais rhyddid 
+            gwybodaeth</strong>.
+        </label>
+    </h2>
+
+    <input class="houdini-input" type="radio" name="goals" id="goal3"
+        <% if params["contact"] && params[:current_form] == 'writing-help' %>checked<% end %>>
+    <div class="houdini-target contact-page__options">
+        <ul>
+            <li>
+                Cysylltwch yn uniongyrchol â'r tîm sy'n rhedeg WhatDoTheyKnow:
+
+                <%= foi_error_messages_for :contact %>
+
+                <%= render :partial => "help/contact_form",
+                           :locals => { :form_id => 'writing-help' } %>
+            </li>
+        </ul>
+    </div>
+
+    <h2 class="contact-page__goal" id="wdtk-volunteer">
+        <label class="houdini-label" for="goal4">
+            Hoffwn gymryd rhan a dod yn <strong>wirfoddolwr</strong>
+        </label>
+    </h2>
+
+    <input class="houdini-input" type="radio" name="goals" id="goal4"
+        <% if params["contact"] && params[:current_form] == 'wdtk-volunteer' %>checked<% end %>>
+    <div class="houdini-target contact-page__options">
+        <ul>
+            <li>
+                Defnyddiwch y ffurflen hon os oes gennych ddiddordeb mewn gwirfoddoli ar gyfer
+                WhatDoTheyKnow
+            </li>
+            <li>
+                Os hoffech fwy o wybodaeth am ba wirfoddoli, gweld 
+                <%= link_to _("ein tudalen cymryd rhan"), help_volunteers_path %>.
+            </li>
+            <li>
+                <%= foi_error_messages_for :contact %>
+
+                <%= render :partial => "help/contact_volunteer_form",
+                           :locals => { :form_id => 'wdtk-volunteer' } %>
+            </li>
+        </ul>
+    </div>
+    
+
+    <h2 class="contact-page__goal" id="wdtk">
+        <label class="houdini-label" for="goal5">
+            Mae gen i fater arall, neu adborth yn ymwneud â'r
+            WhatDoTheyKnow.com wefan, fy mod am godi gyda'r
+            <strong>tîm sy'n rhedeg WhatDoTheyKnow</strong>.
+        </label>
+    </h2>
+
+   <input class="houdini-input" type="radio" name="goals" id="goal5"
+        <% if params["contact"] && params[:current_form] == 'wdtk' %>checked<% end %>>
+    <div class="houdini-target contact-page__options">
+        <ul>
+            <li>
+                Yn gyntaf, rhowch gynnig ar wirio <a href="<%= help_about_path %>">our
+                tudalennau cymorth helaeth</a>, sy'n cynnwys ateb i'r rhan fwyaf
+                materion a chwestiynau sydd gennych.
+            </li>
+            <li>
+                Os nad yw eich problem yn dod o dan ein tudalennau cymorth, gallwch 
+                gysylltu'n uniongyrchol â'r tîm sy'n rhedeg WhatDoTheyKnow:
+
+                <%= foi_error_messages_for :contact %>
+
+                <%= render :partial => "help/contact_form",
+                           :locals => { :form_id => 'wdtk' } %>
+            </li>
+        </ul>
+    </div>
+
+</div>
+</div>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -66,7 +66,7 @@
       Do not make vexatious requests (requests with no serious purpose, or which
       are intended to disrupt the operation of a public body). The ICO has
       guidance on vexatious requests
-      <a href="https://ico.org.uk/media/for-organisations/documents/1198/dealing-with-vexatious-requests.pdf">
+      <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">
       here</a>.
     </li>
     <li>

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -320,10 +320,11 @@
     certain PDFs.
   </p>
   <p>
-    Because our service automatically redacts email addresses and mobile phone
-    numbers from responses, it isn’t well suited to making requests for contact
-    email contacts — but if you need to know an address that we’ve removed,
-    please  <a href="<%=  help_contact_path %>">get in touch</a> with us.
+    If you need to know an address that we've removed, please 
+    <a href="<%=  help_contact_path %>">get in touch</a> with us. It's worth 
+    noting though, that as our team is small, we've not got the capacity to 
+    deal with a large number of these requests, so our service isn't well 
+    suited to being used to gather email addresses.
     Occasionally, an email address forms an important part of a response and if
     we’re asked to reveal it we may post it in an annotation.
   </p>

--- a/lib/views/help/officers.cy.html.erb
+++ b/lib/views/help/officers.cy.html.erb
@@ -168,5 +168,8 @@
     <strong>Os nad ydych wedi eisoes,</strong> darllenwch <a href="<%= help_about_path %>">y cyflwyniad</a> -&gt;<br>
     <strong>Fel arall,</strong> y <a href="<%= help_credits_path %>">credydau</a> neu’r <a href="<%= help_api_path %>">API rhaglenwyr</a> -&gt;
   </p>
+
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -91,14 +91,35 @@
     <dd>
     <p>Os gwelwch unrhyw wybodaeth bersonol amdanoch chi ar y wefan yr hoffech i ni dtynnu neu guddio, yna rhowch <a href="<%= help_contact_path %>">wybod i ni</a> . Nodwch yn union pa wybodaeth yr ydych yn credu sy’n broblem a pham, a lle y mae’n ymddangos ar y wefan.</p>
     <p>Os yw’n wybodaeth bersonol sensitif sydd wedi cael ei phostio ar ddamwain, yna byddwn fel arfer yn ei dileu. Fel arfer, ni fyddwn ond yn ystyried ceisiadau i gael gwared ar wybodaeth bersonol a ddaw oddi wrth yr unigolyn dan sylw, ond am wybodaeth sensitif byddem yn gwerthfawrogi pe bai unrhyw un yn tynnu ein sylw ati.</p>
-    <p>Mae gennych hawl o dan <a
-    href="http://www.legislation.gov.uk/ukpga/1998/29/section/10">adran 10 y Ddeddf Ddiogelu Data</a>
-    i ofyn i ni ddileu eich gwybodaeth bersonol ar y sail ei bod yn achosi difrod neu ofid sylweddol a
-    diangen i chi. Byddwn ni’n ystyried unrhyw hysbysiad o’r fath, nad oes rhaid iddo’n sôn yn benodol
-    am y Ddeddf, ac yn ei gydbwyso yn erbyn unrhyw fudd a ddeuai i’r cyhoedd o gyhoeddi’r deunydd.
-    Ceir peth arweiniad ar yr hysbysiadau hyn <a
-      href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/damage-or-distress/">
-    ar wefan y ICO</a>.
+      <p>
+        Mae gennych hawl o dan <a href="https://www.legislation.gov.uk/eur/2016/679/article/17">
+        Article 17 o Reoliadau Diogelu Data Cyffredinol y DU</a> (GDPR y DU) i ofyn i ni ddileu eich 
+        gwybodaeth personol.
+      </p>
+      <p>
+        I wneud cais, <%= link_to 'cysylltwch â ni', help_contact_path %>.
+      </p>
+      <p>
+        Byddwn yn ystyried unrhyw gais o'r fath, ac yn ei gydbwyso yn erbyn unrhyw fudd cyhoeddus 
+        mewn cyhoeddi'r deunydd.
+      </p>
+      <p>
+        Gallwch gael rhagor o wybodaeth am eich hawliau drwy ymweld â'r 
+        <a href="https://cy.ico.org.uk/your-data-matters/your-right-to-get-your-data-deleted/">
+        Gwefan y Comisiynydd Gwybodaeth</a>, neu drwy ffonio eu llinell gymorth.
+      </p>
+    </dd>
+    <dt id="right_to_access">
+      Eich hawl mynediad <a href="#right_to_access">#</a>
+    </dt>
+    <dd>
+      <p>
+        Gallwch <%= link_to 'contact us', help_contact_path %>gysylltu â ni</a> 
+        ar unrhyw adeg i ofyn i weld pa ddata personol rydym yn ei ddal amdanoch. 
+        Os ydych wedi defnyddio ein gwasanaeth i wneud cais, yna mae'r rhan helaethaf 
+        o'r wybodaeth sydd gennym amdanoch yn cael ei dangos yn gyhoeddus ar ein 
+        gwefan neu i'w gweld ar eich proffil defnyddiwr.
+      </p>
     </dd>
     <dt id="public_servant_takedown">Rwy&rsquo;n was cyhoeddus - a fedrwch dynnu gwybodaeth bersonol amdanaf i? <a href="#public_servant_takedown">#</a></dt>
     <dd>
@@ -109,6 +130,39 @@
         <li>Os ydych yn dal swydd gradd isel, lle na gymerir penderfyniadau, byddwn yn ystyried ceisiadau i ddileu eich manylion. Mae cael gwared ar y manylion hyn yn anodd i’n gwirfoddolwyr ei wneud, felly rhowch wybod i ni pam mae hyn yn wirioneddol bwysig i chi. Os byddwn yn cytuno i gael gwared ar eich manylion byddwn yn cymryd camau rhesymol i wneud hynny, ond mewn rhai achosion efallai na fyddwn yn gallu am resymau technegol.</li>
       </ul>
     </p>
+    </dd>
+    <dd>
+    <dt id="right_to_complain">
+      Eich hawl i wneud cwyn <a href="#right_to_complain">#</a>
+    </dt>
+    <dd>
+      <p>
+        Mae gennych hawl i gwyno os ydych yn credu ein bod wedi cam-lawio eich 
+        data personol. <%= link_to 'Cysylltwch â ni yn gyntaf', help_contact_path %>, 
+        fel y gallwn geisio helpu 
+        (gweler ein <%= link_to 'trefn gwyno', help_complaints_path %> yma).
+      </p>
+      <p>
+        Yn y DU, y corff goruchwylio perthnasol yw Swyddfa'r Comisiynydd Gwybodaeth (ICO). 
+        Ein rhif cofrestru diogelu data yw 
+        <a href="https://ico.org.uk/ESDWebPages/Entry/Z9602302">ZA9602302</a>.
+      </p>
+      <p>
+        Gallwch gysylltu â'r ICO gan ddefnyddio unrhyw un o'r dulliau canlynol:
+        <ul>
+        <li>
+          Ar-lein:&nbsp;&nbsp; <a href="https://cy.ico.org.uk/make-a-complaint/">
+          https://cy.ico.org.uk/make-a-complaint/</a>
+        </li>
+        <li>
+          Phone:&nbsp;&nbsp; 029 2067 8400 (0303 123 1113, yn Saesneg)
+        </li>
+        <li>
+          Post:&nbsp;&nbsp; Swyddfa'r Comisiynydd Gwybodaeth, 
+          Wycliffe House, Water Lane, WILMSLOW, SK9 5AF
+        </li>
+        </ul>
+      </p>
     </dd>
   </dl>
   <p><strong>Dysgwch fwy</strong> o’r cymorth i <a href="<%= help_officers_path %>">swyddogion Rhyddid Gwybodaeth</a> -&gt;</p>

--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -111,6 +111,9 @@
     </p>
     </dd>
   </dl>
-  <p><strong>Dysgwch fwy</strong> o’r cymorth i <a href="<%= help_officers_path %>">swyddogion Rhyddid Gwybodaeth</a> -&gt;
+  <p><strong>Dysgwch fwy</strong> o’r cymorth i <a href="<%= help_officers_path %>">swyddogion Rhyddid Gwybodaeth</a> -&gt;</p>
+  
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -3,6 +3,43 @@
 <div id="left_column_flip" class="left_column_flip">
   <h1 id="privacy"><%= @title %> <a href="#privacy">#</a> </h1>
   <dl>
+    <div class="changes">
+      <span style="font-size:16px">
+      <p>
+        <strong>Pennau i fyny!</strong> Rydym yn gwybod nad yw'r dudalen hon mor gyfoes ag y dymunwn. 
+        Rydyn ni'n ceisio datrys hyn; ond os na allwch ddod o hyd i'r hyn sydd ei angen arnoch yma, 
+        rhowch gynnig ar ein prif <a href="/help/privacy">Hysbysiad Preifatrwydd</a>, sydd yn Saesneg.
+      </p>
+      <p>
+        Os hoffech chi, gallwch weld cyfieithiad awtomataidd, drwy ddefnyddio
+        <a href="https://www-whatdotheyknow-com.translate.goog/help/privacy?_x_tr_sl=auto&_x_tr_tl=cy&_x_tr_hl=en&_x_tr_pto=wapp">
+        Google Translate</a>.
+      </p>
+      </span>
+    </div>
+    <dd>
+      <p>
+        Mae WhatDoTheyKnow yn cael ei redeg gan yr elusen mySociety.
+      </p>
+      <p>
+        Am fanylion llawn strwythur, llywodraethu, a manylion mySociety, a manylion y
+        cofrestriadau perthnasol gyda'r Comisiynydd Gwybodaeth a'r Elusen
+        Comisiwn gweler: 
+        <%= link_to 'Sef yn gwneud WhatDoTheyKnow?', help_about_path  %>
+      </p>
+      <p>
+        Gweithio ym meysydd tryloywder ac atebolrwydd, mySociety
+        yn meddwl yn galed ac yn gofalu'n fawr am breifatrwydd a diogelwch ein defnyddwyr:
+        mae hyd y polisi preifatrwydd hwn yn un canlyniad o hynny. Ni wyddom nad oes neb
+        yn mynd trwy bolisïau preifatrwydd am hwyl, er hynny, rydym wedi ceisio ei gadw'n
+        darllen clir a gweddol gyflym.
+      </p>
+      <p>
+        Gobeithio ei fod yn cwmpasu popeth sydd angen i chi ei wybod, ond os oes gennych chi unrhyw un o hyd
+        cwestiynau mae croeso i chi <%= link_to 'gysylltu â ni', help_contact_path %>.
+      </p>
+    </dd>
+  
     <dt id="email_address">Pwy sy’n cael gweld fy nghyfeiriad e-bost? <a href="#email_address">#</a> </dt>
     <dd>
     <p>Ni fyddwn yn datgelu eich cyfeiriad e-bost i neb oni bai bod yn rhaid i ni yn ôl y gyfraith, neu i chi ofyn i ni wneud. Mae hyn yn cynnwys yr awdurdod cyhoeddus yr ydych chi’n anfon cais ato. Chân nhw weld dim ond cyfeiriad e-bost @whatdotheyknow.com sy’n benodol i’r cais hwnnw. </p>

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -3,133 +3,170 @@
 <div id="left_column_flip" class="left_column_flip">
   <h1 id="making_requests"><%= @title %> <a href="#making_requests">#</a> </h1>
   <dl>
-    <dt id="which_authority">Dydw i ddim yn siŵr i ba awdurdod i wneud cais, sut y gallaf gael gwybod? <a href="#which_authority">#</a> </dt>
+    <dt id="which_authority">
+      Dydw i ddim yn siŵr i ba awdurdod i wneud cais, sut y gallaf gael gwybod? 
+      <a href="#which_authority">#</a>
+    </dt>
     <dd>
-    <p>Gall fod yn anodd deall strwythur cymhleth y llywodraeth, a gweithio allan pwy sy’n gwybod
-    y wybodaeth yr ydych ei heisiau. Dyma rai awgrymiadau:</p>
-    <ul>
-      <li>Pori neu chwilio WhatDoTheyKnow gan chwilio am geisiadau tebyg i’ch un chi.</li>
-      <li>Pan fyddwch wedi dod o hyd i awdurdod y credwch y gallai fod ganddo’r wybodaeth, defnyddiwch
-      ddolen y "dudalen gartref" ar ochr dde eu dudalen i weld yr hyn y maent yn ei wneud ar eu gwefan.</li>
-      <li>Cysylltwch â’r awdurdod dros y ffôn neu e-bost i ofyn a ydynt yn dal y math o
-      wybodaeth yr hoffech ei chael.</li>
-      <li>Peidiwch â phoeni’n ormodol am gael yr awdurdod cywir. Os ydych yn ei gael yn anghywir, dylent eich
-        cynghori chi i bwy y dylech wneud y cais yn lle.
-      </li>
-      <li>Os oes gennych achos dyrys, cysylltwch <a href="<%= help_contact_path %>">â ni</a> am gymorth.</li>
-    </ul>
+      <p>
+        Gall fod yn anodd deall strwythur cymhleth y llywodraeth, a gweithio allan pwy 
+        sy’n gwybod y wybodaeth yr ydych ei heisiau. Dyma rai awgrymiadau:
+      </p>
+      <ul>
+        <li>Pori neu chwilio WhatDoTheyKnow gan chwilio am geisiadau tebyg i’ch un chi.</li>
+        <li>Pan fyddwch wedi dod o hyd i awdurdod y credwch y gallai fod ganddo’r wybodaeth, defnyddiwch
+        ddolen y "dudalen gartref" ar ochr dde eu dudalen i weld yr hyn y maent yn ei wneud ar eu gwefan.</li>
+        <li>Cysylltwch â’r awdurdod dros y ffôn neu e-bost i ofyn a ydynt yn dal y math o
+        wybodaeth yr hoffech ei chael.</li>
+        <li>Peidiwch â phoeni’n ormodol am gael yr awdurdod cywir. Os ydych yn ei gael yn anghywir, dylent eich
+          cynghori chi i bwy y dylech wneud y cais yn lle.
+        </li>
+        <li>Os oes gennych achos dyrys, cysylltwch <a href="<%= help_contact_path %>">â ni</a> am gymorth.</li>
+      </ul>
     </dd>
-    <dt id="missing_body">Does gennych chi mo’r awdurdod cyhoeddus yr wyf am
-    wneud cais iddo! <a href="#missing_body">#</a> </dt>
+    <dt id="missing_body">
+      Does gennych chi mo’r awdurdod cyhoeddus yr wyf am 
+      wneud cais iddo! <a href="#missing_body">#</a>
+    </dt>
     <dd>
-    <p>
-      Cysylltwch <a href="<%= new_change_request_path %>">â ni</a> gydag enw’r awdurdod cyhoeddus ac,
-      os gallwch ddod o hyd ddo, eu cyswllt cyfeiriad e-bost ar gyfer ceisiadau Rhyddid Gwybodaeth.
-    </p>
-    <p>
-      Os hoffech chi helpu i ychwanegu categori cyfan o awdurdodau cyhoeddus at y
-      wefan, byddem wrth ein bodd cael clywed gennych hefyd.
-    </p>
+      <p>
+        Cysylltwch <a href="<%= new_change_request_path %>">â ni</a> gydag enw’r awdurdod cyhoeddus ac,
+        os gallwch ddod o hyd ddo, eu cyswllt cyfeiriad e-bost ar gyfer ceisiadau Rhyddid Gwybodaeth.
+      </p>
+      <p>
+        Os hoffech chi helpu i ychwanegu categori cyfan o awdurdodau cyhoeddus at y
+        wefan, byddem wrth ein bodd cael clywed gennych hefyd.
+      </p>
     </dd>
-    <dt id="authorities">Pam eich bod yn cynnwys rhai awdurdodau nad ydynt yn ffurfiol
-    yn ddarostyngedig i’r Ddeddf Rhyddid Gwybodaeth?<a href="#authorities">#</a> </dt>
+    <dt id="authorities">
+      Pam eich bod yn cynnwys rhai awdurdodau nad ydynt yn ffurfiol 
+      yn ddarostyngedig i’r Ddeddf Rhyddid Gwybodaeth?<a href="#authorities">#</a>
+    </dt>
     <dd>
-    <p>Mae WhatDoTheyKnow yn gadael i chi wneud ceisiadau am wybodaeth i ystod o
-    sefydliadau:</p>
-    <ul>
-      <li> Rhai sy’n ddarostyngedig yn ffurfiol i’r Ddeddf Rhyddid Gwybodaeth</li>
-      <li> Rhai sy’n ddarostyngedig yn ffurfiol i’r Rheoliadau Amgylcheddol (grŵp
-      nad yw wedi ei ddiffinio cystal)</li>
-      <li> Rhai sy’n cydymffurfio’n wirfoddol â’r Ddeddf Rhyddid Gwybodaeth</li>
-      <li> Rhai nad ydynt yn ddarostyngedig i’r Ddeddf, ond rydym yn meddwl y dylent
-        fod, ar y sail fod ganddynt gyfrifoldebau cyhoeddus sylweddol
-      </li>
-    </ul>
-    <p>Yn yr achos olaf, rydym yn defnyddio’r safle i lobio am ehangu cwmpas y
-      Ddeddf Rhyddid Gwybodaeth. Hyd yn oed os nad yw sefydliad yn rhwym yn gyfreithiol
-      i ymateb i gais Rhyddid Gwybodaeth, gallant wneud hynny’n wirfoddol.
-    </p>
+      <p>
+        Mae WhatDoTheyKnow yn gadael i chi wneud ceisiadau am wybodaeth i ystod o 
+        sefydliadau:
+      </p>
+      <ul>
+        <li> Rhai sy’n ddarostyngedig yn ffurfiol i’r Ddeddf Rhyddid Gwybodaeth</li>
+        <li> Rhai sy’n ddarostyngedig yn ffurfiol i’r Rheoliadau Amgylcheddol (grŵp
+        nad yw wedi ei ddiffinio cystal)</li>
+        <li> Rhai sy’n cydymffurfio’n wirfoddol â’r Ddeddf Rhyddid Gwybodaeth</li>
+        <li> Rhai nad ydynt yn ddarostyngedig i’r Ddeddf, ond rydym yn meddwl y dylent
+          fod, ar y sail fod ganddynt gyfrifoldebau cyhoeddus sylweddol
+        </li>
+      </ul>
+      <p>
+        Yn yr achos olaf, rydym yn defnyddio’r safle i lobio am ehangu cwmpas y 
+        Ddeddf Rhyddid Gwybodaeth. Hyd yn oed os nad yw sefydliad yn rhwym yn gyfreithiol 
+        i ymateb i gais Rhyddid Gwybodaeth, gallant wneud hynny’n wirfoddol.
+      </p>
     </dd>
-    <dt id="focused">Pam mae’n rhaid i mi gadw fy nghais yn gryno? <a href="#focused">#</a> </dt>
+    <dt id="focused">
+      Pam mae’n rhaid i mi gadw fy nghais yn gryno? <a href="#focused">#</a>
+    </dt>
     <dd>
-    <p>
-      Dim ond yr hyn sydd ei angen ddylai fod yn eich cais fel y gall rhywun ddeall
-      yn hawdd pa wybodaeth rydych yn gofyn amdani. <i>Peidiwch</i> â chynnwys unrhyw
-      un o’r canlynol:
-    </p>
-    <ul>
-      <li>dadleuon am eich achos</li>
-      <li>datganiadau a allai fwrw anfri neu sarhau eraill</li>
-    </ul>
-    <p>
-      Os byddwch yn gwneud hyn, efallai y bydd yn rhaid i ni dynnu eich cais er mwyn
-      osgoi problemau gyda chyfraith enllib sydd yn boen i chi ac i ni. Mae negeseuon
-      byr cryno yn ei wneud yn haws i awdurdodau dddeall yn glir pa wybodaeth rydych
-      yn gofyn amdani, sy’n golygu y byddwch yn cael ateb yn gynt.
-    </p>
-    <p>Os ydych am wybodaeth i gefnogi dadl neu ymgyrch, mae Rhyddid Gwybodaeth yn
-      arf pwerus. Er na chewch ddefnyddio’r wefan hon i redeg eich ymgyrch, rydym yn
-      eich annog i’w defnyddio i gael y wybodaeth rydych ei hangen. Rydym hefyd yn
-      eich annog i redeg eich ymgyrch yn rhywle arall - un ffordd effeithiol a hawdd
-      iawn yw i chi <%= link_to 'ddechrau eich blog eich hun', "http://cy.wordpress.com/"%>.
-      Mae croeso i chi greu cysylltiad â’ch ymgyrch o’r wefan hon mewn nodyn i’ch
-      cais (gallwch wneud nodiadau ar ôl cyflwyno’r cais).
-    </p>
+      <p>
+        Dim ond yr hyn sydd ei angen ddylai fod yn eich cais fel y gall rhywun ddeall
+        yn hawdd pa wybodaeth rydych yn gofyn amdani. <i>Peidiwch</i> â chynnwys unrhyw
+        un o’r canlynol:
+      </p>
+      <ul>
+        <li>dadleuon am eich achos</li>
+        <li>datganiadau a allai fwrw anfri neu sarhau eraill</li>
+      </ul>
+      <p>
+        Os byddwch yn gwneud hyn, efallai y bydd yn rhaid i ni dynnu eich cais er mwyn
+        osgoi problemau gyda chyfraith enllib sydd yn boen i chi ac i ni. Mae negeseuon
+        byr cryno yn ei wneud yn haws i awdurdodau dddeall yn glir pa wybodaeth rydych
+        yn gofyn amdani, sy’n golygu y byddwch yn cael ateb yn gynt.
+      </p>
+      <p>
+        Os ydych am wybodaeth i gefnogi dadl neu ymgyrch, mae Rhyddid Gwybodaeth yn 
+        arf pwerus. Er na chewch ddefnyddio’r wefan hon i redeg eich ymgyrch, rydym yn 
+        eich annog i’w defnyddio i gael y wybodaeth rydych ei hangen. Rydym hefyd yn 
+        eich annog i redeg eich ymgyrch yn rhywle arall - un ffordd effeithiol a hawdd 
+        iawn yw i chi <%= link_to 'ddechrau eich blog eich hun', "http://cy.wordpress.com/"%>. 
+        Mae croeso i chi greu cysylltiad â’ch ymgyrch o’r wefan hon mewn nodyn i’ch 
+        cais (gallwch wneud nodiadau ar ôl cyflwyno’r cais).
+      </p>
     </dd>
-    <dt id="fees">Ydy’n costio i mi wneud cais? <a href="#fees">#</a> </dt>
+    <dt id="fees">
+      Ydy’n costio i mi wneud cais? <a href="#fees">#</a>
+    </dt>
     <dd>
-    <p>Mae gwneud cais Rhyddid Gwybodaeth bron bob amser yn rhad ac am ddim.</p>
-    <p>Bydd awdurdodau’n aml yn cynnwys llith ddiangen, frawychus, wrth gydnabod
-      negeseuon yn dweud y "gallent" godi ffi. Anwybyddwch rybuddion o’r fath. Ni
-      fyddant bron byth mewn gwirionedd yn codi ffi. Os byddant yn codi ffi, dim ond
-      os ydych wedi cytuno’n benodol ymlaen llaw i dalu y gallant godi tâl arnoch.
-      <a
-      href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#15">Rhagor o fanylion</a>
-    gan y Comisiynydd Gwybodaeth.</p>
-    <p>Weithiau bydd awdurdod yn gwrthod eich cais, gan ddweud bod y gost o
-      drin yn fwy na £600 (ar gyfer llywodraeth ganolog) neu £450 (ar gyfer pob
-      awdurdod cyhoeddus arall). Yn y fan hon, gallwch fireinio eich cais. e.e.
-      byddai’n llawer rhatach i awdurdod ddweud wrthych y swm a wariwyd ar malws
-    melys y llynedd nag yn y deng mlynedd diwethaf.</p>
+      <p>
+        Mae gwneud cais Rhyddid Gwybodaeth bron bob amser yn rhad ac am ddim.
+      </p>
+      <p>
+        Bydd awdurdodau’n aml yn cynnwys llith ddiangen, frawychus, wrth gydnabod 
+        negeseuon yn dweud y "gallent" godi ffi. Anwybyddwch rybuddion o’r fath. Ni 
+        fyddant bron byth mewn gwirionedd yn codi ffi. Os byddant yn codi ffi, dim ond 
+        os ydych wedi cytuno’n benodol ymlaen llaw i dalu y gallant godi tâl arnoch. 
+        <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#15">
+        Rhagor o fanylion</a>gan y Comisiynydd Gwybodaeth.
+      </p>
+      <p>
+        Weithiau bydd awdurdod yn gwrthod eich cais, gan ddweud bod y gost o 
+        drin yn fwy na £600 (ar gyfer llywodraeth ganolog) neu £450 (ar gyfer pob 
+        awdurdod cyhoeddus arall). Yn y fan hon, gallwch fireinio eich cais, e.e. 
+        byddai'n llawer rhatach i awdurdod ddweud wrthych y swm a wariwyd ar malws 
+        melys y llynedd nag yn ystod y deng mlynedd diwethaf.
+      </p>
     </dd>
-    <dt id="quickly_response">Pa mor gyflym y caf ymateb? <a href="#quickly_response">#</a> </dt>
+    <dt id="quickly_response">
+      Pa mor gyflym y caf ymateb? <a href="#quickly_response">#</a>
+    </dt>
     <dd>
-    <p>Yn ôl y gyfraith, mae’n rhaid i awdurdodau cyhoeddus ymateb yn <strong>brydlon</strong>} i geisiadau.
-    </p>
-    <p>Hyd yn oed os nad ydynt yn brydlon, ym mron pob achos, rhaid iddynt ymateb
-      o fewn 20 diwrnod gwaith. Os oedd rhaid i chi egluro eich cais, neu os oeddech
-      wedi gofyn i ysgol, ac mewn achos neu ddau arall, yna mae’n bosibl y cânt fwy
-      o amser (<a href="<%= help_officers_path(:anchor => 'days') %>">manylion llawn</a>).
-    </p>
-    <p>Bydd WhatDoTheyKnow yn anfon e-bost atoch os nad ydych yn cael ymateb amserol.
-      Yna, gallwch anfon at yr awdurdod cyhoeddus neges i’w hatgoffa, ac yn dweud
-    wrthynt os ydynt yn torri’r gyfraith.</p>
+      <p>
+        Yn ôl y gyfraith, mae’n rhaid i awdurdodau cyhoeddus ymateb yn 
+        <strong>brydlon</strong> i geisiadau.
+      </p>
+      <p>
+        Hyd yn oed os nad ydynt yn brydlon, ym mron pob achos, rhaid iddynt ymateb 
+        o fewn 20 diwrnod gwaith. Os oedd rhaid i chi egluro eich cais, neu os oeddech 
+        wedi gofyn i ysgol, ac mewn achos neu ddau arall, yna mae’n bosibl y cânt fwy 
+        o amser (<a href="<%= help_officers_path(:anchor => 'days') %>">manylion llawn</a>).
+      </p>
+      <p>
+        Bydd WhatDoTheyKnow yn anfon e-bost atoch os nad ydych yn cael ymateb amserol. 
+        Yna, gallwch anfon at yr awdurdod cyhoeddus neges i’w hatgoffa, ac yn dweud 
+        wrthynt os ydynt yn torri’r gyfraith.
+      </p>
     </dd>
-    <dt id="no_response">Beth os na fyddaf byth yn cael ymateb?<a href="#no_response">#</a> </dt>
+    <dt id="no_response">
+      Beth os na fyddaf byth yn cael ymateb?<a href="#no_response">#</a>
+    </dt>
     <dd>
-    <p>Mae nifer o bethau y gallwch eu gwneud os ydych byth yn cael ymateb.</p>
-    <ul>
-      <li>Weithiau, mae problem go iawn wedi digwydd  ac nid yw’r awdurdod erioed
-        wedi derbyn y cais. Mae’n werth ffonio’r awdurdod a gwirio’n gwrtais eu bod
-        wedi derbyn y cais. Cafodd ei anfon atynt drwy e-bost.
-      </li>
-      <li>Os nad ydynt wedi ei dderbyn, mwy na thebyg "hidlyddion sbam" fydd achos
-        y broblem. Cyfeiriwch yr awdurdod at y mesurau yn yr ateb
-        ’<a href="<%= help_officers_path(:anchor => 'spam_problems') %>">gallaf weld cais ar WhatDoTheyKnow, ond
-        chawsom ni mohono erioed drwy e-bost!</a>’ yn yr adran i swyddogion rhyddid
-      gwybodaeth yn yr adran help hon.</li>
-      <li>Os ydych chi’n dal heb unrhyw lwc, yna gallwch ofyn am adolygiad mewnol,
-        ac yna gwyno i’r Comisiynydd Gwybodaeth am yr awdurdod. Darllenwch
-        ’<a href="<%= help_general_path(:template => 'unhappy') %>">ein tudalen Anhapus ynghylch yr ymateb a gawsoch?</a>’.
-      </li>
-    </ul>
+      <p>
+        Mae nifer o bethau y gallwch eu gwneud os ydych byth yn cael ymateb.
+      </p>
+      <ul>
+        <li>Weithiau, mae problem go iawn wedi digwydd  ac nid yw’r awdurdod erioed
+          wedi derbyn y cais. Mae’n werth ffonio’r awdurdod a gwirio’n gwrtais eu bod
+          wedi derbyn y cais. Cafodd ei anfon atynt drwy e-bost.
+        </li>
+        <li>Os nad ydynt wedi ei dderbyn, mwy na thebyg "hidlyddion sbam" fydd achos
+          y broblem. Cyfeiriwch yr awdurdod at y mesurau yn yr ateb
+          ’<a href="<%= help_officers_path(:anchor => 'spam_problems') %>">gallaf weld cais ar WhatDoTheyKnow, ond
+          chawsom ni mohono erioed drwy e-bost!</a>’ yn yr adran i swyddogion rhyddid
+        gwybodaeth yn yr adran help hon.</li>
+        <li>Os ydych chi’n dal heb unrhyw lwc, yna gallwch ofyn am adolygiad mewnol,
+          ac yna gwyno i’r Comisiynydd Gwybodaeth am yr awdurdod. Darllenwch
+          ’<a href="<%= help_general_path(:template => 'unhappy') %>">
+          ein tudalen Anhapus ynghylch yr ymateb a gawsoch?</a>’.
+        </li>
+      </ul>
     </dd>
-    <dt id="not_satifised">Beth os nad wyf yn fodlon ā’r ymateb? <a href="#not_satifised">#</a> </dt>
+    <dt id="not_satifised">
+      Beth os nad wyf yn fodlon ā’r ymateb? <a href="#not_satifised">#</a>
+    </dt>
     <dd>
-    <p>Os na chawsoch y wybodaeth y gofynnoch amdani, neu os na dderbynioch chi
-      hi mewn pryd, yna darllenwch ein tudalen ’<a href="<%= help_general_path(:template => 'unhappy') %>">
-      Anhapus ynghylch yr ymateb a gawsoch?</a>’.
-    </p>
+      <p>
+        Os na chawsoch y wybodaeth y gofynnoch amdani, neu os na dderbynioch chi hi mewn pryd, yna darllenwch ein 
+        tudalen ’<a href="<%= help_general_path(:template => 'unhappy') %>">
+        Anhapus ynghylch yr ymateb a gawsoch?</a>’.
+      </p>
     </dd>
     <dt id="reuse">Mae’n dweud na chaf i ddim ail-ddefnyddio’r wybodaeth a gefais! <a href="#reuse">#</a> </dt>
     <dd>
@@ -137,37 +174,48 @@
       am "<a href="http://www.legislation.gov.uk/uksi/2005/1515/contents/made">Reoliadau
       Ail-Defnyddio Gwybodaeth y Sector Cyhoeddus 2005</a>", sydd ar yr olwg gyntaf
     yn awgrymu efallai na chewch chi wneud dim â’r wybodaeth.</p>
-    <p>Fe gewch chi, wrth gwrs, ysgrifennu erthyglau am yr wybodaeth neu ei
-      chrynhoi, neu dyfynnu rhannau ohoni. Rydym hefyd yn meddwl y dylech chi
-      deimlo’n rhydd i ailgyhoeddi’r wybodaeth yn llawn, yn union fel rydym yn ei
+    <p>
+      Fe gewch chi, wrth gwrs, ysgrifennu erthyglau am yr wybodaeth neu ei chrynhoi, neu dyfynnu rhannau ohoni. 
+      Rydym hefyd yn meddwl y dylech chi deimlo’n rhydd i ailgyhoeddi’r wybodaeth yn llawn, yn union fel rydym yn ei 
       wneud, er mewn damcaniaeth efallai na fydd caniatâd gennych i wneud hynny.
       Gweler <a href="<%= help_officers_path(:anchor => 'copyright') %>">ein polisi ar hawlfraint</a>.
     </p>
     </dd>
-    <dt id="ico_help">Allwch chi ddweud mwy wrthyf am fanion y broses o wneud ceisiadau? <a href="#ico_help">#</a> </dt>
+    <dt id="ico_help">
+      Allwch chi ddweud mwy wrthyf am fanion y broses o wneud ceisiadau? <a href="#ico_help">#</a>
+    </dt>
     <dd>
-    <p>Edrychwch ar dudalennau  <a href="https://ico.org.uk/for-the-public/official-information/">mynediad
-    i wybodaeth swyddogol</a> ar wefan y Comisiynydd Gwybodaeth.</p>
-    <p>Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus yn yr Alban, mae’r broses yn debyg iawn. Mae gwahaniaethau o gwmpas y terfynau amser ar gyfer cydymffurfio. Gweler <a href="https://www.itspublicknowledge.info/your-rights">canllawiau  Comisiynydd Gwybodaeth yr Alban</a> am fanylion.</p>
+      <p>
+        Edrychwch ar dudalennau  <a href="https://cy.ico.org.uk/your-data-matters/official-information/">mynediad
+        i wybodaeth swyddogol</a> ar wefan y Comisiynydd Gwybodaeth.
+      </p>
+      <p>
+        Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus yn yr Alban, mae’r broses yn debyg iawn. 
+        Mae gwahaniaethau o gwmpas y terfynau amser ar gyfer cydymffurfio. 
+        Gweler <a href="https://www.itspublicknowledge.info/your-rights">
+        canllawiau Comisiynydd Gwybodaeth yr Alban</a> am fanylion.
+      </p>
     </dd>
-    <dt id="data_protection">A gaf i wneud cais am wybodaeth amdanaf fi fy hun? <a href="#data_protection">#</a> </dt>
+    <dt id="data_protection">
+      A gaf i wneud cais am wybodaeth amdanaf fi fy hun? <a href="#data_protection">#</a>
+    </dt>
     <dd>
-    <p>
-      <b>Na chewch</b>. Mae ceisiadau sy’n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu 
-      gwneudd o dan y Ddeddf Rhyddid Gwybodaeth, ac ni allant eich helpu i ddod o hyd i wybodaeth am unigolyn preifat.
-    </p>
-    <p>
-      Os hoffech wybod pa wybodaeth y mae awdurdod cyhoeddus yn ei chadw amdanoch eich hun, dylech wneud cais 
-      "Hawl i Fynediad" (a elwir hefyd yn "Gais Gwrthrych am Wybodaeth" gan ddefnyddio cyfraith Diogelu Data. 
-      Mae gan wefan y Comisiynydd Gwybodaeth 
-      <a href="https://cy.ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">
-      ganllaw sy'n esbonio sut i wneud hyn</a>, ond gallwch hefyd ffonio eu llinell gymorth ar 
-      029 2067 8400 (0303 123 1113, yn Saesneg) i gael cyngor.
-    </p>
-    <p>
-      Os byddwch yn gweld fod rhywun wedi cynnwys gwybodaeth bersonol, yn ddiarwybod o bosibl, mewn cais, 
-      <a href="<%= help_contact_path %>">cysylltwch â ni</a> ar unwaith er mwyn i ni ei symud.
-    </p>
+      <p>
+        <b>Na chewch</b>. Mae ceisiadau sy’n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu 
+        gwneudd o dan y Ddeddf Rhyddid Gwybodaeth, ac ni allant eich helpu i ddod o hyd i wybodaeth am unigolyn preifat.
+      </p>
+      <p>
+        Os hoffech wybod pa wybodaeth y mae awdurdod cyhoeddus yn ei chadw amdanoch eich hun, dylech wneud cais 
+        "Hawl i Fynediad" (a elwir hefyd yn "Gais Gwrthrych am Wybodaeth" gan ddefnyddio cyfraith Diogelu Data. 
+        Mae gan wefan y Comisiynydd Gwybodaeth 
+        <a href="https://cy.ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">
+        ganllaw sy'n esbonio sut i wneud hyn</a>, ond gallwch hefyd ffonio eu llinell gymorth ar 
+        029 2067 8400 (0303 123 1113, yn Saesneg) i gael cyngor.
+      </p>
+      <p>
+        Os byddwch yn gweld fod rhywun wedi cynnwys gwybodaeth bersonol, yn ddiarwybod o bosibl, mewn cais, 
+        <a href="<%= help_contact_path %>">cysylltwch â ni</a> ar unwaith er mwyn i ni ei symud.
+      </p>
     </dd>
     <dt id="private_requests">
       Hoffwn gadw fy nghais yn gyfrinachol! (O leiaf nes i mi gyhoeddi fy stori) <a href="#private_requests">#</a>
@@ -184,19 +232,61 @@
         yn breifat, yna <a href="<%= account_request_index_path %>">darganfyddwch fwy a chysylltwch â ni</a>.
       </p>
     </dd>
-    <dt id="eir">Pam dim ond gwybodaeth am yr amgylchedd y gallaf ofyn amdani gan rai awdurdodau? <a href="#eir">#</a> </dt>
+    <dt id="eir">
+      Pam dim ond gwybodaeth am yr amgylchedd y gallaf ofyn amdani gan rai awdurdodau? <a href="#eir">#</a>
+    </dt>
     <dd>
-    <p>Mae rhai awdurdodau cyhoeddus, megis <a href="http://www.whatdotheyknow.com/body/milford_haven_port_authority">Milford Haven Port Authority</a>, nad ydynt yn dod o dan y Ddeddf Rhyddid Gwybodaeth, ond yn dod o dan ddeddf arall, sef y Rheoliadau Gwybodaeth Amgylcheddol (EIR). </p>
-    <p>Mae’n gyfraith debyg iawn, ac fe wnewch gais iddynt gan ddefnyddio WhatDoTheyKnow yn union yr un ffordd â chais Rhyddid Gwybodaeth. Yr unig wahaniaeth yw y cewch eich atgoffa ar y dudalen lle byddwch yn ysgrifennu eich cais mai dim ond am &quot;wybodaeth amgylcheddol&quot; y cewch ofyn ac mae’n dweud wrthych beth mae hynny’n ei olygu. Mae’n eithaf eang. </p>
-    <p>Gallwch, wrth gwrs, wneud cais am wybodaeth amgylcheddol gan awdurdodau eraill. Gwnewch gais Rhyddid Gwybodaeth (FOI) fel arfer. Mae’n ddyletswydd ar yr awdurdod i weithio allan ai’r Rheoliadau Gwybodaeth Amgylcheddol (EIR) yw’r ddeddfwriaeth fwyaf priodol iddynt ymateb o dani. </p> </dd>
-    <dt id="multiple">A gaf i wneud yr un cais i lawer o awdurdodau, ee pob cyngor? <a href="#multiple">#</a> </dt>
-    <dd>Rydym yn gofyn i chi yn gyntaf anfon fersiwn brawf o’ch cais i ychydig o awdurdodau. Bydd eu hymatebion yn eich helpu i wella geiriad eich cais, er mwyn i chi gael y wybodaeth orau pan fyddwch yn anfon y cais i bob un o’r awdurdodau. Ar hyn o bryd nid oes system awtomataidd ar gyfer anfon y cais i’r awdurdodau eraill, rhaid i chi gopïo a gludo â llaw. </dd>
-    <dt id="offsite">Gwnes gais heb ddefnyddio’r wefan: sut y gallaf ei lwytho i’r archif?<a href="#offsite">#</a> </dt>
-    <dd>Mae WhatDoTheyKnow yn archif o geisiadau a wnaethpwyd trwy’r wefan, ac nid yw’n ceisio bod yn archif o bob cais Rhyddid Gwybodaeth. Fyddwn ni byth yn cynnal llwytho ceisiadau eraill i fyny. Yn un peth, ni fyddem yn gallu cadarnhau bod ymatebion eraill mewn gwirionedd yn dod oddi wrth yr awdurdod. Os yw hyn yn wir yn bwysig i chi, gallwch chi bob amser wneud yr un cais eto drwy WhatDoTheyKnow. </dd>
-    <dt id="moderation">Sut ydych chi’n cymedroli anodiadau ar gais? <a href="#moderation">#</a> </dt>
+      <p>
+        Mae rhai awdurdodau cyhoeddus, megis <a href="http://www.whatdotheyknow.com/body/milford_haven_port_authority">
+        Milford Haven Port Authority</a>, nad ydynt yn dod o dan y Ddeddf Rhyddid Gwybodaeth, ond yn dod o dan ddeddf 
+        arall, sef y Rheoliadau Gwybodaeth Amgylcheddol (EIR).
+      </p>
+      <p>
+        Mae’n gyfraith debyg iawn, ac fe wnewch gais iddynt gan ddefnyddio WhatDoTheyKnow yn union yr un ffordd â chais 
+        Rhyddid Gwybodaeth. Yr unig wahaniaeth yw y cewch eich atgoffa ar y dudalen lle byddwch yn ysgrifennu eich cais 
+        mai dim ond am &quot;wybodaeth amgylcheddol&quot; y cewch ofyn ac mae’n dweud wrthych beth mae hynny’n ei 
+        olygu. Mae’n eithaf eang.
+      </p>
+      <p>
+        Gallwch, wrth gwrs, wneud cais am wybodaeth amgylcheddol gan awdurdodau eraill. Gwnewch gais Rhyddid Gwybodaeth 
+        (FOI) fel arfer. Mae’n ddyletswydd ar yr awdurdod i weithio allan ai’r Rheoliadau Gwybodaeth Amgylcheddol (EIR) 
+        yw’r ddeddfwriaeth fwyaf priodol iddynt ymateb o dani.
+      </p>
+    </dd>
+    <dt id="multiple">
+      A gaf i wneud yr un cais i lawer o awdurdodau, ee pob cyngor? <a href="#multiple">#</a>
+    </dt>
     <dd>
-    <p>Mae anodiadau ar WhatDoTheyKnow i helpu pobl i gael y wybodaeth sy arnynt ei eisiau, neu i roi awgrymiadau i lefydd y gallant fynd i’w helpu i weithredu arno. Rydym yn cadw’r hawl i ddileu unrhyw beth arall. </p>
-    <p>Nid yw trafodaethau gwleidyddol diddiwedd yn cael eu caniatáu. Postiwch ddolen i fforwm addas neu wefan ymgyrch mewn man arall.</p>
+      <p>
+        Rydym yn gofyn i chi yn gyntaf anfon fersiwn brawf o’ch cais i ychydig o awdurdodau. Bydd eu hymatebion yn eich 
+        helpu i wella geiriad eich cais, er mwyn i chi gael y wybodaeth orau pan fyddwch yn anfon y cais i bob un 
+        o’r awdurdodau. Ar hyn o bryd nid oes system awtomataidd ar gyfer anfon y cais i’r awdurdodau eraill, rhaid 
+        i chi gopïo a gludo â llaw.
+      </p>
+    </dd>
+    <dt id="offsite">
+      Gwnes gais heb ddefnyddio’r wefan: sut y gallaf ei lwytho i’r archif?<a href="#offsite">#</a>
+    </dt>
+    <dd>
+      <p>
+        Mae WhatDoTheyKnow yn archif o geisiadau a wnaethpwyd trwy’r wefan, ac nid yw’n ceisio bod yn archif o bob cais 
+        Rhyddid Gwybodaeth. Fyddwn ni byth yn cynnal llwytho ceisiadau eraill i fyny. Yn un peth, ni fyddem yn gallu 
+        cadarnhau bod ymatebion eraill mewn gwirionedd yn dod oddi wrth yr awdurdod. Os yw hyn yn wir yn bwysig i chi, 
+        gallwch chi bob amser wneud yr un cais eto drwy WhatDoTheyKnow.
+      </p>
+    </dd>
+    <dt id="moderation">
+      Sut ydych chi’n cymedroli anodiadau ar gais? <a href="#moderation">#</a>
+    </dt>
+    <dd>
+      <p>
+        Mae anodiadau ar WhatDoTheyKnow i helpu pobl i gael y wybodaeth sy arnynt ei eisiau, neu i roi awgrymiadau i 
+        lefydd y gallant fynd i’w helpu i weithredu arno. Rydym yn cadw’r hawl i ddileu unrhyw beth arall.
+      </p>
+      <p>
+        Nid yw trafodaethau gwleidyddol diddiwedd yn cael eu caniatáu. Postiwch ddolen i fforwm addas neu wefan 
+        ymgyrch mewn man arall.
+      </p>
     </dd>
   </dl>
   <p><strong>Nesaf</strong>, darllenwch am <a href="<%= help_privacy_path %>">eich preifatrwydd</a> -&gt;</p>

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -127,7 +127,8 @@
     <dt id="not_satifised">Beth os nad wyf yn fodlon ā’r ymateb? <a href="#not_satifised">#</a> </dt>
     <dd>
     <p>Os na chawsoch y wybodaeth y gofynnoch amdani, neu os na dderbynioch chi
-      hi mewn pryd, yna darllenwch ein tudalen ’<a href="<%= help_general_path(:template => 'unhappy') %>">Anhapus ynghylch yr ymateb a gawsoch?</a>’.
+      hi mewn pryd, yna darllenwch ein tudalen ’<a href="<%= help_general_path(:template => 'unhappy') %>">
+      Anhapus ynghylch yr ymateb a gawsoch?</a>’.
     </p>
     </dd>
     <dt id="reuse">Mae’n dweud na chaf i ddim ail-ddefnyddio’r wybodaeth a gefais! <a href="#reuse">#</a> </dt>
@@ -147,13 +148,27 @@
     <dd>
     <p>Edrychwch ar dudalennau  <a href="https://ico.org.uk/for-the-public/official-information/">mynediad
     i wybodaeth swyddogol</a> ar wefan y Comisiynydd Gwybodaeth.</p>
-    <p>Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus yn yr Alban, mae’r broses yn debyg iawn. Mae gwahaniaethau o gwmpas y terfynau amser ar gyfer cydymffurfio. Gweler <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">canllawiau  Comisiynydd Gwybodaeth yr Alban</a> am fanylion.</p>
+    <p>Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus yn yr Alban, mae’r broses yn debyg iawn. Mae gwahaniaethau o gwmpas y terfynau amser ar gyfer cydymffurfio. Gweler <a href="https://www.itspublicknowledge.info/your-rights">canllawiau  Comisiynydd Gwybodaeth yr Alban</a> am fanylion.</p>
     </dd>
     <dt id="data_protection">A gaf i wneud cais am wybodaeth amdanaf fi fy hun? <a href="#data_protection">#</a> </dt>
     <dd>
-    <p>Na chewch. Mae ceisiadau sy’n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu gwneudd o dan y Ddeddf Rhyddid Gwybodaeth, ac ni allant eich helpu i ddod o hyd i wybodaeth am unigolyn preifat.</p>
-    <p>Os hoffech wybod pa wybodaeth y mae awdurdod cyhoeddus yn ei chadw amdanoch chi eich hun, dylech wneud &quot;Cais Gwrthrych am Wybodaeth&quot; yn breifat gan ddefnyddio gyfraith Diogelu Data. Mae’r daflen &quot; <a href="http://www.ico.org.uk/upload/documents/library/data_protection/introductory/subject_access_rights.pdf">Sut i gael mynediad at eich gwybodaeth</a> &quot;(ar wefan y Comisiynydd Gwybodaeth) yn esbonio sut i wneud hyn.</p>
-    <p>Os byddwch yn gweld fod rhywun wedi cynnwys gwybodaeth bersonol, yn ddiarwybod o bosibl, mewn cais, <a href="<%= help_contact_path %>">cysylltwch â ni</a> ar unwaith er mwyn i ni ei symud.</p> </dd>
+    <p>
+      Na chewch. Mae ceisiadau sy’n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu 
+      gwneudd o dan y Ddeddf Rhyddid Gwybodaeth, ac ni allant eich helpu i ddod o hyd i wybodaeth am unigolyn preifat.
+    </p>
+    <p>
+      Os hoffech wybod pa wybodaeth y mae awdurdod cyhoeddus yn ei chadw amdanoch eich hun, dylech wneud cais 
+      "Hawl i Fynediad" (a elwir hefyd yn "Gais Gwrthrych am Wybodaeth" gan ddefnyddio cyfraith Diogelu Data. 
+      Mae gan wefan y Comisiynydd Gwybodaeth 
+      <a href="https://cy.ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">
+      ganllaw sy'n esbonio sut i wneud hyn</a>, ond gallwch hefyd ffonio eu llinell gymorth ar 
+      029 2067 8400 (0303 123 1113, yn Saesneg) i gael cyngor.
+    </p>
+    <p>
+      Os byddwch yn gweld fod rhywun wedi cynnwys gwybodaeth bersonol, yn ddiarwybod o bosibl, mewn cais, 
+      <a href="<%= help_contact_path %>">cysylltwch â ni</a> ar unwaith er mwyn i ni ei symud.
+    </p>
+    </dd>
     <dt id="private_requests">Hoffwn gadw fy nghais yn gyfrinachol! (O leiaf nes i mi gyhoeddi fy stori) <a href="#private_requests">#</a> </dt>
     <dd>
     <p>Mae WhatDoTheyKnow wedi ei chynllunio ar hyn o bryd yn unig ar gyfer ceisiadau cyhoeddus. Cyhoeddir yr holl ymatebion a dderbyniwn yn awtomatig ar y wefan i unrhyw un eu darllen. </p>

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -173,6 +173,9 @@
     <p>Nid yw trafodaethau gwleidyddol diddiwedd yn cael eu caniatáu. Postiwch ddolen i fforwm addas neu wefan ymgyrch mewn man arall.</p>
     </dd>
   </dl>
-  <p><strong>Nesaf</strong>, darllenwch am <a href="<%= help_privacy_path %>">eich preifatrwydd</a> -&gt;
+  <p><strong>Nesaf</strong>, darllenwch am <a href="<%= help_privacy_path %>">eich preifatrwydd</a> -&gt;</p>
+  
+  <%= render partial: 'history' %>
+
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -153,7 +153,7 @@
     <dt id="data_protection">A gaf i wneud cais am wybodaeth amdanaf fi fy hun? <a href="#data_protection">#</a> </dt>
     <dd>
     <p>
-      Na chewch. Mae ceisiadau sy’n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu 
+      <b>Na chewch</b>. Mae ceisiadau sy’n cael eu gwneud gan ddefnyddio WhatDoTheyKnow yn gyhoeddus, ac yn cael eu 
       gwneudd o dan y Ddeddf Rhyddid Gwybodaeth, ac ni allant eich helpu i ddod o hyd i wybodaeth am unigolyn preifat.
     </p>
     <p>
@@ -169,10 +169,21 @@
       <a href="<%= help_contact_path %>">cysylltwch â ni</a> ar unwaith er mwyn i ni ei symud.
     </p>
     </dd>
-    <dt id="private_requests">Hoffwn gadw fy nghais yn gyfrinachol! (O leiaf nes i mi gyhoeddi fy stori) <a href="#private_requests">#</a> </dt>
+    <dt id="private_requests">
+      Hoffwn gadw fy nghais yn gyfrinachol! (O leiaf nes i mi gyhoeddi fy stori) <a href="#private_requests">#</a>
+    </dt>
     <dd>
-    <p>Mae WhatDoTheyKnow wedi ei chynllunio ar hyn o bryd yn unig ar gyfer ceisiadau cyhoeddus. Cyhoeddir yr holl ymatebion a dderbyniwn yn awtomatig ar y wefan i unrhyw un eu darllen. </p>
-    <p>Dylech gysylltu â’r awdurdod cyhoeddus yn uniongyrchol os hoffech wneud cais yn breifat. Os oes gennych ddiddordeb mewn prynu system sy’n eich helpu i reoli ceisiadau Rhyddid Gwybodaeth yn y dirgel, ac yna <a href="<%= help_contact_path %>">cysylltwch â ni</a> . </p> </dd>
+      <p>
+        Ar hyn o bryd dim ond ar gyfer ceisiadau cyhoeddus y mae WhatDoTheyKnow wedi'i gynllunio. Mae'r holl ymatebion 
+        a gawn yn cael eu cyhoeddi'n awtomatig ar y wefan i unrhyw un eu darllen.
+      </p>
+      <p>
+        Fodd bynnag, mae WhatDoTheyKnow<sup>Pro</sup> yn wasanaeth ar gyfer newyddiadurwyr ac ymgyrchwyr sy'n cynnwys 
+        y gallu i ohirio cyhoeddi eich ceisiadau ac ymatebion. Os ydych chi'n newyddiadurwr, yn ymgyrchydd, 
+        yn actifydd, neu'n rhywun arall sydd ag angen i wneud ceisiadau am wybodaeth sydd, i ddechrau o leiaf, 
+        yn breifat, yna <a href="<%= account_request_index_path %>">darganfyddwch fwy a chysylltwch â ni</a>.
+      </p>
+    </dd>
     <dt id="eir">Pam dim ond gwybodaeth am yr amgylchedd y gallaf ofyn amdani gan rai awdurdodau? <a href="#eir">#</a> </dt>
     <dd>
     <p>Mae rhai awdurdodau cyhoeddus, megis <a href="http://www.whatdotheyknow.com/body/milford_haven_port_authority">Milford Haven Port Authority</a>, nad ydynt yn dod o dan y Ddeddf Rhyddid Gwybodaeth, ond yn dod o dan ddeddf arall, sef y Rheoliadau Gwybodaeth Amgylcheddol (EIR). </p>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -111,11 +111,11 @@
 
   <p>
     To make a referral,
-    start by reading <a href="https://ico.org.uk/make-a-complaint/official-information-concerns-report/">the
+    start by reading <a href="https://ico.org.uk/make-a-complaint/foi-and-eir-complaints/">the
     Information Commissioner's advice for those with concerns about accessing
     information</a> which links to their form. If you requested information
     from a Scottish authority, then it is
-    <a href="http://www.itspublicknowledge.info/YourRights/YourRights.asp">the
+    <a href="https://www.itspublicknowledge.info/yourRights/">the
     Scottish Information Commissioner</a> who you will need to contact.
   </p>
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1326 
_#650_

## What does this do?
This is a chunky PR, but in essence it:

- Removes the contact form from `lib/views/help/contact.cy.html.erb` and sets up a partial
- Adds partial `lib/views/help/_history.cy.html.erb`, so that we no longer present the English version on /cy
- Replaces reference to DPA 1998 and briefly covers RtE / RoA (SAR)
- Roughly translates aforementioned
- Fixes a couple of broken links

## Why was this needed?
We had a couple of broken links. At the same time, our Welsh help pages are quite a bit out of sync, so this makes a first attempt at trying to rectify this.

## Implementation notes
Nothing of particular note; however, I would note that although `lib/views/help/contact.cy.html.erb` references the new Volunteer contact form, the partial hasn't been translated, as I believe it would need the specs to be updated. We could remove Houdini goal 4 if necessary.

## Screenshots
n/a

## Notes to reviewer
Apologies - the translations here are machine generated, but wherever possible they have been verified against two different translation engines, and terminology cross-referenced against [BydTermCymru](https://gov.wales/bydtermcymru).

This intentionally only covers the basic parts - we owe it to our Welsh speaking users to ensure that the more complicated parts have had their translations verified (e.g. Helo Blod, or a suitable volunteer).