### PR TITLE
[#1328] Update ICO links for s14 and s43 in refusal advice

### DIFF
--- a/config/refusal_advice/section_14_actions.yml.erb
+++ b/config/refusal_advice/section_14_actions.yml.erb
@@ -23,14 +23,14 @@ foi:
         html: >
           A <a href="http://www.bailii.org/ew/cases/EWCA/Civ/2015/454.html">Court of Appeal case</a> stated that a request may not be vexatious if "the information sought would be of value to the requester or to the public or any section of the public".
 
-          Consider requesting an internal review, citing the <a href="https://ico.org.uk/media/for-organisations/documents/1198/dealing-with-vexatious-requests.pdf">ICO guidance</a> and stating the value this information would have if released.
+          Consider requesting an internal review, citing the <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a> and stating the value this information would have if released.
 
     - id: s14-a13
       show_if:
       - { id: s14-q6, operator: is, value: 'yes' }
       advice:
         html: >
-          Consider requesting an internal review. The <a href="https://ico.org.uk/media/for-organisations/documents/1198/dealing-with-vexatious-requests.pdf">ICO guidance</a> states that an FOI service must be 'applicant blind'. Exemption 14(1) can only be applied to the request itself, and not the individual who submits it.
+          Consider requesting an internal review. The <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a> states that an FOI service must be 'applicant blind'. Exemption 14(1) can only be applied to the request itself, and not the individual who submits it.
 
     - id: s14-a15
       show_if:
@@ -44,7 +44,7 @@ foi:
       - { id: s14-q8, operator: is, value: 'yes' }
       advice:
         html: >
-          Request an internal review, citing the <a href="https://ico.org.uk/media/for-organisations/documents/1198/dealing-with-vexatious-requests.pdf">ICO guidance</a>. Round robin requests can be a legitimate way to get a wider picture or consistent data from a range of authorities. Also, authorities may only consider the burden on themselves, not that which your other requests may place on other authorities.
+          Request an internal review, citing the <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a>. Round robin requests can be a legitimate way to get a wider picture or consistent data from a range of authorities. Also, authorities may only consider the burden on themselves, not that which your other requests may place on other authorities.
 
     - id: s14-a18
       show_if:
@@ -95,7 +95,7 @@ foi:
       - { id: s14-q4y1y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Reply, citing <a href="https://ico.org.uk/media/for-organisations/documents/1198/dealing-with-vexatious-requests.pdf">ICO guidance</a> and asking for such suggestions.
+          Reply, citing <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a> and asking for such suggestions.
 
     - id: s14-a17
       show_if:

--- a/config/refusal_advice/section_43.yml.erb
+++ b/config/refusal_advice/section_43.yml.erb
@@ -11,7 +11,7 @@ foi:
         Has the authority demonstrated that the disclosure of the information you have requested would prejudice commercial interests?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a> states that an authority "must show that because [the information] is commercially sensitive, disclosure would be, or would be likely to be, prejudicial to the commercial activities of a person (an individual, a company, the public authority itself or any other legal entity)".
+        <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> states that an authority "must show that because [the information] is commercially sensitive, disclosure would be, or would be likely to be, prejudicial to the commercial activities of a person (an individual, a company, the public authority itself or any other legal entity)".
 
   - id: s43-q1y1
     show_if:
@@ -30,7 +30,7 @@ foi:
         Has the authority conducted a prejudice test?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a> says: "In order to apply section 43(2), the public authority must satisfy itself that disclosure of the information would, or would be likely to, prejudice or harm the commercial interests of any person (this can include the public authority holding it)."
+        <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says: "In order to apply section 43(2), the public authority must satisfy itself that disclosure of the information would, or would be likely to, prejudice or harm the commercial interests of any person (this can include the public authority holding it)."
 
   - id: s43-q1y1y1y1
     show_if:

--- a/config/refusal_advice/section_43_actions.yml.erb
+++ b/config/refusal_advice/section_43_actions.yml.erb
@@ -49,7 +49,7 @@ foi:
       - { id: s43-q2y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a> says that this argument can only be applied if future transactions are likely to have a 'degree of similarity' with the one you are asking about.
+          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says that this argument can only be applied if future transactions are likely to have a 'degree of similarity' with the one you are asking about.
 
           Consider whether this is the case - you may have grounds to request an internal review if it is not.
 
@@ -58,7 +58,7 @@ foi:
       - { id: s43-q2y2, operator: is, value: 'no' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a> states that: "It is [...] important for a public authority to consider each clause within a contract, rather than view the contract as a whole. Arguments about the burden this may create are not relevant under section 43".
+          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> states that: "It is [...] important for a public authority to consider each clause within a contract, rather than view the contract as a whole. Arguments about the burden this may create are not relevant under section 43".
 
           You may have grounds for requesting an internal review. Cite the ICO guidance and ask for the other parts of the contract to be released.
 
@@ -67,21 +67,21 @@ foi:
       - { id: s43-q3, operator: is, value: 'no' }
       advice:
         html: >
-          Ask for an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a> and asking the authority to provide evidence that the public interest test was conducted in this case.
+          Ask for an internal review, citing <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> and asking the authority to provide evidence that the public interest test was conducted in this case.
 
     - id: s43-a11
       show_if:
       - { id: s43-q3y1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider asking for an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a>.
+          Consider asking for an internal review, citing <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>.
 
     - id: s43-a12
       show_if:
       - { id: s43-q3y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
+          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
 
           These would, however, be set against the commercial interests of, for example, competition, reputation, ability to generate income and impact on other negotiations.
 
@@ -106,7 +106,7 @@ foi:
       - { id: s43-q4n1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
+          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
 
           These would, however, be set against the commercial interests of, for example, competition, reputation, ability to generate income and impact on other negotiations.
 
@@ -126,7 +126,7 @@ foi:
       - { id: s43-q1y1y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">The ICO says</a>: "The public authority must decide the likelihood of prejudice arising on the facts of each case".
+          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">The ICO says</a>: "The public authority must decide the likelihood of prejudice arising on the facts of each case".
 
           Consider asking for clarification, citing this guidance and requesting that the authority provide more details about their calculations in applying the prejudice test.
 
@@ -137,7 +137,7 @@ foi:
       - { id: s43-q6, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a> says, "The public authority must apply an exemption based on the circumstances that exist at the time the request is made. However information submitted during a tendering process is more likely to be commercially sensitive while the tendering process is ongoing, compared to once the contract has been awarded", although it does also note that some information will remain sensitive, for example if it reveals an approach to business which if known to the public could be commercially damaging.
+          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says, "The public authority must apply an exemption based on the circumstances that exist at the time the request is made. However information submitted during a tendering process is more likely to be commercially sensitive while the tendering process is ongoing, compared to once the contract has been awarded", although it does also note that some information will remain sensitive, for example if it reveals an approach to business which if known to the public could be commercially damaging.
 
           You may wish to consider resubmitting your request once some time has passed.
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1328 

## What does this do?
This fixes links to the Information Commissioner's guidance in the refusal advice for s14 (Vexatious) and s43 (Commercial Interests).

## Why was this needed?
The ICO are _slowly_ moving away from the PDF based guidance docs, and their website doesn't degrade the links gracefully, meaning we're dispensing out of date information.

## Implementation notes
I think I've clobbered all of the links in the s14 and s43 set. I've made a brief check of s12 and s35 and they still appear to be okay.

## Screenshots
n/a

## Notes to reviewer

The format here is a carbon copy of how things were already setup. I did ponder if it would be practical to specify the URLs in one place and have a call back - but decided not to meddle with the existing format.