### PR TITLE
[#818] Add special link for MapIt areas

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -62,6 +62,18 @@
   <% end %>
 <% end %>
 
+<% if public_body.has_tag?('mapit') %>
+  <% public_body.get_tag_values('mapit').each do |tag_value| %>
+    <%= link_to _('Area covered'), "https://mapit.mysociety.org/area/#{tag_value}.html" %>
+
+    <small>
+      [<%= link_to _('others in this area'), list_public_bodies_by_tag_path("mapit:#{tag_value}") %>]
+    </small>
+
+    <br>
+  <% end %>
+<% end %>
+
 <%= link_to _('View FOI email address'), view_public_body_email_path(public_body.url_name) %><br>
 
 <%= link_to _("Ask us to update FOI email"), new_change_request_body_path(:body => public_body.url_name) %><br>


### PR DESCRIPTION
## Relevant issue(s)

Simple version of https://github.com/mysociety/whatdotheyknow-theme/issues/818.

## What does this do?

Link to MapIt area if a body is tagged with `mapit:AREA_ID`, and/or the
"parent" area if tagged with `parent_mapit:AREA_ID`.

Also links to an on-site search to find other bodies in the same area.

## Why was this needed?

Helps users figure out if a body is relevant to their interests.

## Implementation notes

Not sure about the "Parent area" phrasing – could we improve that?

## Screenshots

![Screenshot 2022-08-03 at 10 57 41](https://user-images.githubusercontent.com/282788/182580918-936867f4-5fc8-408e-99c5-972b0a620d5c.png)

## Notes to reviewer
