### PR TITLE
Update requesting.html.erb

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -713,11 +713,15 @@
       </p>
       <p>
         You may wish to consider setting up a new account for your
-        whistleblowing request as your history of requests may help people identify you.
+        whistleblowing request as your history of requests may help people to identify you.
+        
+        The UK charity <a href="https://protect-advice.org.uk/">Protect</a> aims to make whistleblowing work for individuals, organisations and society and offers a free, confidential whistleblowing advice line.
+        For EU citizens and residents <a
+        href="https://hrdrelocation.eu/">the EU Human Rights Defenders Relocation
+        Platform</a> may be able to offer assistance.
+        
         See also: <a
-        href="https://p10.secure.hostingprod.com/@spyblog.org.uk/ssl/ht4w/2011/06/table-of-contents.html">Hints and Tips for Whistleblowing from Spy Blog</a> and <a
-        href="https://hrdrelocation.eu/"> The EU Human Rights Defenders Relocation
-        Platform</a>.
+        href="https://p10.secure.hostingprod.com/@spyblog.org.uk/ssl/ht4w/2011/06/table-of-contents.html">Hints and Tips for Whistleblowing from Spy Blog</a> and 
       </p>
     <dd>
     <dt id="moderation">


### PR DESCRIPTION


## Relevant issue(s)
There is a UK charity that helps with whistle blowing. The UK is no longer in the EU so I have reworded the part re the EU Human Rights Defenders Relocation Platform. I didn't remove it because lots of EU citizens live in the UK and it is quite easy to travel between Northern Ireland and the Republic of Ireland.

## What does this do?
Improves the help text.

## Why was this needed?
See above.

## Implementation notes
See above.

## Screenshots
Not needed.

## Notes to reviewer
See above.