### PR TITLE
[#1180] Update admin team section in `/help/how.html.erb`

### DIFF
--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -367,30 +367,45 @@
     <a href="#admin_team">#</a>
   </h2>
   <p>
-    The majority of WhatDoTheyKnow’s admin team are volunteers, who are active
-    users of the site.
+    WhatDoTheyKnow is a project of mySociety run by a small team of staff 
+    and dedicated volunteers.    
   </p>
   <p>
-    Volunteers are supervised and mentored by their peer volunteers, and by
-    mySociety staff on the management and FOI team. As mySociety is a
-    distributed organisation, this happens via the monthly WhatDoTheyKnow
-    volunteer catchup calls, and by email or individual calls as required.
-    Volunteers’ activity running the site, or on email lists, are visible to
-    other members of the volunteer team, as well as mySociety staff, and anyone
-    can speak up with suggestions for doing things differently.
+    Volunteers are supervised and mentored by the other members of the 
+    admin team. As mySociety is a distributed organisation,  we keep in touch 
+    with you by email or individual calls as required. Volunteers’ activity 
+    running the site, or on email lists, is visible to other members of the  
+    admin team, as well as other mySociety staff, and anyone can speak up with 
+    suggestions for doing things differently.
   </p>
   <p>
-    When a new volunteer starts, they are asked to agree to the terms of a
-    volunteer agreement, and the WhatDoTheyKnow password and data retention
-    policies. Depending on the nature of their volunteering, they may have an
-    introductory call or meeting with a current volunteer or with a member of
-    mySociety staff.
+    We also have regular online team meetings that all volunteers are invited 
+    to join, although attendance at these is optional.
   </p>
   <p>
-    Volunteers who will actively administer the site will be asked to join a
-    call in which a current volunteer demonstrates the use of the WhatDoTheyKnow
-    admin interface. If everyone concerned is comfortable, they may then be
-    given access to the administration interface.
+    When a new volunteer starts, they are asked to agree to the terms of a 
+    volunteer agreement.  This includes mySociety’s 
+    <a href="https://www.mysociety.org/code-of-conduct/" 
+    title="Link to the mySociety Code of Conduct (opens in a new window)"
+    target="_blank">Code of Conduct</a>, password policy, data retention policy 
+    and personal data policy.
+  </p>
+  <p>
+    Depending on the nature of their volunteering, they may have an 
+    introductory call with a current member of the WhatDoTheyKnow admin team, 
+    generally with one existing volunteer and one member of staff.
+  </p>
+  <p>
+    Volunteers who will actively administer the site are asked to join a 
+    training call in which a member of the admin team will demonstrate the use 
+    of the WhatDoTheyKnow admin interface. If everyone concerned is 
+    comfortable, they may then be given access to the administration interface.
+  </p>
+  <p>
+    Joining the admin team is not the only way to help run the site. Read more 
+    on how to 
+    <a href="https://www.whatdotheyknow.com/help/volunteers"
+    title="Find out more about volunteering at WhatDoTheyKnow">get involved</a>
   </p>
   <h2 id="user_accounts">
     User accounts

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -381,11 +381,11 @@
   </p>
   <p>
     Volunteers are supervised and mentored by the other members of the 
-    admin team. As mySociety is a distributed organisation,  we keep in touch 
-    with you by email or individual calls as required. Volunteers’ activity 
-    running the site, or on email lists, is visible to other members of the  
-    admin team, as well as other mySociety staff, and anyone can speak up with 
-    suggestions for doing things differently.
+    admin team. As mySociety is a distributed organisation, we keep in touch 
+    by email or individual calls as required. Volunteers’ activity running the 
+    site, or on email lists, is visible to other members of the admin team, as 
+    well as other mySociety staff, and anyone can speak up with suggestions for 
+    doing things differently.
   </p>
   <p>
     We also have regular online team meetings that all volunteers are invited 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1180

## What does this do?
This updates the content of section "Membership of the admin team" based on the agreed text.

## Why was this needed?
Improvements being made as part of the implementation of the volunteer plan and have been ratified by the Service Manager and team.

## Implementation notes
`/lib/views/help/how.html.erb` has mixed use of ' and ’ (U+2019) - the latter being the predominant. As this is what's already there, I haven't sought to revise any existing content. We can do that at another point.

## Screenshots
N/A

## Notes to reviewer
N/A