### PR TITLE
help text - info may be out of date

### DIFF
--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -21,8 +21,8 @@
     Some public bodies will release information that is many years out of date on the site. 
     This can happen if the requester asks for information relating to events that happened a number of years ago. 
     This can also happen if a document has not been updated for some time, and the requester asks for the latest version. 
-    This means that some of the information that is published on the site will already be out of date on the day it is published.
-     We never remove material from the site just because it is old or because a newer version of the material exists. 
+   This means that some of the information that is published on the site will already be out of date on the day it is published.
+   We never remove material from the site just because it is old or because a newer version of the material exists. 
     This is because we are trying to create a permanent archive.
   </p>
   <h2 id="reactive_moderation">

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -13,6 +13,18 @@
     this administration team, with support from mySociety’s Chief Executive and
     <a href="<%= help_about_path(:anchor => 'who') %>">Trustees</a>.
   </p>
+   <h2 id="information_may_be_out_of_date">
+    Information you find on the site may be out of date
+    <a href="#information_may_be_out_of_date">#</a>
+  </h2>
+  <p>
+    Some public bodies will release information that is many years out of date on the site. 
+    This can happen if the requester asks for information relating to events that happened a number of years ago. 
+    This can also happen if a document has not been updated for some time, and the requester asks for the latest version. 
+    This means that some of the information that is published on the site will already be out of date on the day it is published.
+     We never remove material from the site just because it is old or because a newer version of the material exists. 
+    This is because we are trying to create a permanent archive.
+  </p>
   <h2 id="reactive_moderation">
     Reactive moderation principle
     <a href="#reactive_moderation">#</a>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -82,10 +82,10 @@
   <p>
     There's a good chance an internal review will prompt a change in the public
     body's stance. Based on Scottish data, 
-    <a href="https://research.mysociety.org/html/reforming-foi/l/7.62.cqnd7.zdv8i.6njs-.y6jyl.html">
-    40% of internal reviews</a> result in some form of new information being
-    released, and based on UK central government data roughly 
-    <a href="https://research.mysociety.org/html/reforming-foi/l/7.62.cqnd7.zdv8i.6njs-.y6jyl.html">
+    <a href="https://research.mysociety.org/html/reforming-foi/l/7.62.67c3q.zdv8i.j1tkf.dejgi.html">
+    16% of internal reviews</a> result in an entirely substituted decision (and more a partially substituted decision)
+    , and based on UK central government data roughly 
+    <a href="https://research.mysociety.org/html/reforming-foi/l/7.62.67c3q.zdv8i.j1tkf.dejgi.html">
     25% of internal reviews</a> lead to more information being released.
   </p>
 


### PR DESCRIPTION
Information may be out of date on the day it is published

## Relevant issue(s)
Information may be out of date on the day it is published. This is because FOI is  aright to information held by public authorities that may or may not be up to date.

## What does this do?
Improves help text. Provides clarity to users.

## Why was this needed?
See above.

## Implementation notes
See above.

## Screenshots
N/A

## Notes to reviewer
See also: https://wdtkwiki.mysociety.org/wiki/Draft_legal_notice_for_the_site
