### PR TITLE
Set theme-color meta tag

### DIFF
--- a/lib/views/general/_before_head_end.html.erb
+++ b/lib/views/general/_before_head_end.html.erb
@@ -14,6 +14,11 @@
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="msapplication-TileImage" content="<%= image_path('mstile-144x144.png') %>">
 <meta name="msapplication-config" content="<%= asset_path('browserconfig.xml') %>">
-<meta name="theme-color" content="#ffffff">
+
+<% if @user&.is_pro? %>
+  <meta name="theme-color" content="#365B74">
+<% else %>
+  <meta name="theme-color" content="#3394e6">
+<% end %>
 
 <meta name="google-site-verification" content="DbAHEzh0igI0rZziSexQh5fTrbRfNPSw8BdmrmNY_70" />


### PR DESCRIPTION
Makes the browser URL bar a nice colour [1]. Uses a pro/non-pro
appropriate colour by checking the user. Ideally we'd interpolate the
SCSS setting but don't think we have an easy way of doing that right
now.

In the case of the Pro theme, the darker colour looked better than the
lighter part of the gradient.

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color

**BEFORE**

![IMG_3515](https://user-images.githubusercontent.com/282788/187868841-abb2cf25-6e8a-41f6-a5ff-c5e03e986c5c.PNG)

**AFTER**

![IMG_3514](https://user-images.githubusercontent.com/282788/187868844-1ba38e74-89a1-48ed-8dff-01a602bf11e6.PNG)

![IMG_3516](https://user-images.githubusercontent.com/282788/187868836-90612789-e7bd-4ac7-977d-be1cf384696c.PNG)

