### PR TITLE
Update requesting.html.erb - no brackets for year of an Act of Parliament

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -557,7 +557,7 @@
         such as the
         <a href="https://www.nhs.uk/common-health-questions/nhs-services-and-treatments/can-i-access-the-medical-records-health-records-of-someone-who-has-died/"
         title="NHS England guidance on the Access to Health Records Act 1990">
-        Access to Health Records Act (1990)</a> and the
+        Access to Health Records Act 1990</a> and the
         <a href="https://www.gov.uk/guidance/request-records-of-deceased-service-personnel"
         title="MoD Guidance: Request records of deceased service personnel">
         Ministry of Defence procedure for accessing records of deceased service


### PR DESCRIPTION
We don't need to put the year in brackets in the name of an Act of Parliament. I know that the NHS page we link to does but I don't think that's right. See also: https://www.legislation.gov.uk/ukpga/1990/23/contents

## Relevant issue(s)

## What does this do?

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer
