### PR TITLE
[#1387] Add iCasework DNR email to `model_patches.rb`

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -125,6 +125,8 @@ Rails.configuration.to_prepare do
     dvla.donotreply@dvla.gov.uk
     noreply@my.tewkesbury.gov.uk
     donotreply.foi@publicagroup.uk
+    do_not_reply@icasework.com
+    mailer@donotreply.icasework.com
   )
 
   User::EmailAlerts.instance_eval do


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1387

## What does this do?
This patch adds two generic generic email addresses (used by Civica iCasework) to `model_patches.rb`

## Why was this needed?
Per #1387, some authorities using iCasework are issuing automated reminders, prompting for a user's response. Unlike most iCasework messages, these are being sent from a `no-reply` email address.

As these are being added to the request thread, and as they take the same form as the 'original' message, it is likely a user will respond to them and get a frustrating outcome. This then becomes a nuisance to deal with, as we cannot easily re-direct correspondence so have to give advice as to how this can be done.

## Implementation notes
Nothing of note, this is long established code.

## Screenshots
N/A

## Notes to reviewer
N/A