### PR TITLE
Create glossary.html.erb

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -35,4 +35,7 @@ Rails.application.routes.draw do
 
   get '/help/ico_officers' => 'help#ico_officers',
       as: :help_ico_officers
+
+  get '/help/glossary' => 'help#glossary',
+      as: :help_glossary
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -12,6 +12,7 @@ Rails.configuration.to_prepare do
     def volunteers; end
     def beginners; end
     def ico_officers; end
+    def glossary; end
 
     private
 

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -48,6 +48,9 @@
       <li>
         <%= link_to_unless_current "Beginner’s Guide", help_beginners_path %>
       </li>
+      <li>
+        <%= link_to_unless_current "Glossary", help_glossary_path %>
+      </li>
       <% if feature_enabled?(:alaveteli_pro) %>
         <li><%= link_to_unless_current "Pro", help_pro_path %></li>
       <% end %>

--- a/lib/views/help/glossary.html.erb
+++ b/lib/views/help/glossary.html.erb
@@ -1,0 +1,302 @@
+<% @title = "Freedom of information glossary" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+ <h1 id="top">Freedom of information glossary</h1>
+ <p>This glossary provides guidance on some of the abbreviations and special terms used by <a href="#foi_officer">FOI officers</a> and transparency campaigners. This glossary also explains some of the terms used in our help pages. </p>
+<br/>
+ <p>
+<a href="#letter_A">A</a>
+<a href="#letter_B">B</a>
+<a href="#letter_C">C</a>
+<a href="#letter_D">D</a>
+<a href="#letter_E">E</a>
+<a href="#letter_F">F</a>
+<a href="#letter_H">H</a>
+<a href="#letter_I">I</a>
+<a href="#letter_M">M</a>
+ <a href="#letter_N">N</a>
+<a href="#letter_P">P</a>
+<a href="#letter_Q">Q</a>
+<a href="#letter_R">R</a>
+<a href="#letter_S"> S</a>
+<a href="#letter_T"> T</a>
+<a href="#letter_V">V</a>
+ <a href="#letter_W">W</a>
+<a href="#letter_Z">Z</a> </p>
+<hr/>
+<br/>
+<h2 id="letter_A">A</h2>
+<dl>
+<dt id="aarhus_convention">Aarhus Convention</dt>
+<dd>The Aarhus Convention provides a right of access to <a href="#environmental_information">environmental information</a>. The Convention was signed in June 1998 in the Danish city of Aarhus. The full name of the Aarhus Convention is the <a href="https://unece.org/environment-policy/public-participation/aarhus-convention/text">UNECE Convention on Access to Information, Public Participation in Decision-making and Access to Justice in Environmental Matters</a>. In the UK, the legislation that gives effect to the Aarhus Convention is called <a href="#environmental_information_regulations">the Environmental Information Regulations</a>.</dd>
+<dt id="absolute_exemption">Absolute exemption</dt>
+<dd>An absolute exemption is an <a href="#exemption">exemption</a> that is not subject to a <a href="#public_interest_test">public interest test</a>.</dd>
+<dt id="alaveteli">Alaveteli</dt>
+<dd>An open-source platform for making public <a href="#freedom_of_information">freedom of information</a> requests to <a href="#public_authorities">public authorities</a>. <a href="#whatdotheyknow">WhatDoTheyKnow</a> is powered by Alaveteli.</dd>
+<dt id="">Anonymisation</dt>
+<dd>The process of removing names, National Insurance numbers and other identifiers from a dataset prior to release so that none of the information can be linked to a specific person. Anonymised data may be useful to researchers.</dd>
+<dt id="api">API</dt>
+<dd>API stands for Application Programming Interface. An API is a piece of software that allows two computer programmes to exchange information. See also: <a href="https://www.whatdotheyknow.com/help/api">https://www.whatdotheyknow.com/help/api</a> </dd>
+<dt id="">Applicant blind</dt>
+<dd>The principle that the information released in response to an <a href="#eir">EIR</a> or <a href="#foi">FOI</a> request should be the same no matter who the <a href="#requester">requester</a> is. In practice, <a href="#public_authorities">public authorities</a> can take the identity of the requester into account in certain situations e.g. when applying the <a href="#cost_limit">cost limit</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_B">B</h2>
+<dl>
+<dt id="bulk_request">Bulk request</dt>
+<dd>The term bulk request is normally use to refer to a <a href="#request">request</a> that is sent to a large number of <a href="#public_authority">public authorities</a>, typically 20 or more.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_C">C</h2>
+<dl>
+<dt id="categorisation_game">Categorisation game</dt>
+<dd>WhatDoTheyKnow encourages users to classify their requests to indicate whether they were successful or not. Any requests that are not classified by the user will, after a period of time has passed, become available for any other user to classify. Classifying requests earns points in the categorisation game. See also: <a href="https://www.whatdotheyknow.com/categorise/play">the categorisation game page</a> </dd>
+<dt id="cost_limit">Cost limit</dt>
+<dd> <p>A <a href="#public_authority">public authority</a> can refuse to answer an <a href="#foi">FOI</a> request where the estimated cost of compliance exceeds the appropriate limit which is known as the cost limit. The cost limit is currently £600 for central government and £450 for all other public authorities. See also the ICO guidance document
+ <a href="https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf">Requests where the cost of
+ compliance exceeds the appropriate limit</a>.</p>
+<p>In Scotland, most authorities will be responding under the Freedom of Information (Scotland) Act 2002, which sets a cost limit of £600. This is set out in the Freedom of Information (Fees for Required Disclosure) (Scotland) Regulations 2004
+ (<a href="https://www.legislation.gov.uk/ssi/2004/467/contents/made“>SSI 2004 no. 467</a>).
+ There is more information in the Scottish Information Commissioner's guidance document - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/FeesandExcessiveCostofComplianceBriefing.pdf">Charging a fee or refusing to comply with a request on excessive cost grounds</a> - which also explains the circumstances in which a public authority might occasionally issue a "fees notice".</p>
+</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_D">D</h2>
+<dl>
+<dt id="data_set">Data set</dt>
+<dd>The term data set is normally used to refer to a large volume of information that is held in a structured form for example, a table or directory.</dd>
+<dt id="decision_letter">Decision letter</dt>
+<dd>A document issued by the ICO or Scottish Information Commissioner that sets out a formal decision that the organisation or individual a request was made to was not in fact a public authority and therefore not subject to <a href="#eir">EIR</a>/<a href="#foi">FOI</a>. See also <a href="#decision_notice">decision notice</a>.</dd>
+<dt id="decision_notice">Decision notice</dt>
+<dd>A document issued by the ICO or Scottish Information Commissioner that sets out a formal decision on what information should and should
+ not be released to the requester by a <a href="#public_authority">public authority</a>. Often abbreviated to DN.</dd>
+<dt id="disclose">Disclose</dt>
+<dd>To make information available to the requester or to the general public. See also <a href="#disclosed">disclosed</a>.</dd>
+<dt id="disclosed">Disclosed</dt>
+<dd>Disclosed information is the information provided to the requester. The opposite of <a href="#redacted">redacted</a> and <a href="#withheld">withheld</a>. See also <a href="#disclosure_log">disclosure log</a>.</dd>
+<dt id="disclosure">Disclosure</dt>
+<dd>Making information available or the information that has been made available. See also <a href="#disclose">disclosed</a>.</dd>
+<dt id="disclosure_log">Disclosure log</dt>
+<dd> <p>A list or table published by <a href="#public_authority">public authorities</a> showing the information they have released in response to requests for information. A disclosure log helps to show what kinds of information the public authority holds and should reduce the chances that the same information is requested twice. See also <a href="#publication_scheme">publication scheme</a>.</p>
+<p>Many FOI systems, such as
+ <a href="https://www.societyworks.org/services/foi/">FOIWorks</a> from <a href="#societyworks">SocietyWorks</a>, uses disclosure logs as an integral part of
+ the request journey. <a href="#whatdotheyknow">WhatDoTheyKnow</a>, while not currently able to search disclosure logs, contains a wealth of information, so you might find the information you are looking for is already on the site. See also <a href="#proactive_disclosure">proactive disclosure</a> </p>
+</dd>
+<dt id="dn">DN</dt>
+<dd>DN stands for <a href="#decision_notice">decision notice</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_E">E</h2>
+<dl>
+<dt id="eir">EIR</dt>
+<dd>EIR stands for <a href="#environmental_information_regulations" > Environmental Information Regulations</a> and usually refers to the
+Environmental Information Regulations 2004 (
+<a href="https://www.legislation.gov.uk/uksi/2004/3391/contents/made">2004 No. 3391</a>), the Environmental Information (Scotland) Regulations 2004 (<a href="https://www.legislation.gov.uk/uksi/2004/3391/contents" > SI 2004 No. 520</a>) or both.</dd>
+<dt id="environmental_information">Environmental information</dt>
+<dd>Information about the physical environment, including rural, urban and marine environments. The definition of environmental information contained in the
+ <a href="#environmental_information_regulations" >Environmental Information Regulations</a> is wide and covers matters such as biodiversity, energy, land use, planning, pollution and waste as well as the impact of the environment on human health.</dd>
+<dt id="environmental_information_regulations">Environmental Information Regulations</dt>
+<dd>Environmental Information Regulations usually refers to the Environmental Information Regulations 2004 (<a href="https://www.legislation.gov.uk/uksi/2004/3391/contents/made">2004 No. 3391</a>), the Environmental Information (Scotland) Regulations 2004 (
+<a href="https://www.legislation.gov.uk/uksi/2004/3391/contents"> SI 2004 No. 520</a>) or both. These laws give requesters a powerful right to access environmental information subject to certain <a href="#exceptions">exceptions</a>.</dd>
+<dt id="exemption">Exemption</dt>
+<dd>A reason that a <a href="#public_authority">public authority</a> can use to withhold information from an <a href="#foi">FOI</a> requester. For example, information can be withheld under
+ the law enforcement exemption or the commercial interests exemption.</dd>
+<dt id="exception">Exception</dt>
+<dd> <a href="#eir">EIR</a> provides requesters with a powerful right to access <a href="#environmentalal_information">environmental information</a> but this right is subject to certain exceptions.
+ For example, there is an exception for information where disclosure would have an adverse impact on international relations, defence,
+ national security or public safety. Exceptions under EIR are similar to <a href="#exemptions">exemptions</a> under <a href="#foi">FOI</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_F">F</h2>
+<dl>
+<dt id="foi">FOI</dt>
+<dd>FOI stands for <a href="#freedom_of_information">freedom of information</a>. See also <a href="#foia">FOIA</a> and <a href="#foisa">FOISA</a>.</dd>
+<dt id="foi_officer">FOI Officer</dt>
+<dd>Freedom of Information Officer - an employee or agent of a public authority whose job includes responding to <a href="#foi">FOI</a> requests.</dd>
+<dt id="foia">FOIA</dt>
+<dd>FOIA stands for Freedom of Information Act. In the UK, FOIA refers to the Freedom of Information Act 2000. See also <a href="#foi">FOI</a> and <a href="#foisa">FOISA</a>.</dd>
+<dt id="foisa">FOISA</dt>
+<dd>Freedom of Information (Scotland) Act 2002 - the act that applies to most public authorities in Scotland except for those which are not devolved (e.g. the
+ Office of the Secretary of State for Scotland, which is part of UK Central Government). See also <a href="#foi">FOI</a> and <a href="#foia">FOIA</a>.</dd>
+<dt id="freedom_of_information">Freedom of information</dt>
+<dd>The principle that governments and other public sector organisations should operate transparently and make information available to the press, citizens etc. In the UK, legislation has been passed in support of this principle including the Freedom of Information Act 2000 and Freedom of Information (Scotland) Act 2002.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_G">G</h2>
+<dl>
+<dt id="gdpr">GDPR</dt>
+<dd>General Data Protection Regulation - a law about data protection and privacy. Following Brexit, the UK has its own version of GDPR. See also <a href="https://www.legislation.gov.uk/eur/2016/679/contents">the text of the General Data Protection Regulation</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_H">H</h2>
+<dl>
+<dt id="house_rules">House rules</dt>
+<dd>The WhatDoTheyKnow House rules set out how we expect people to use and behave on the <a href="#whatdotheyknow">WhatDoTheyKnow</a> site.The rules are published on <a href="https://www.whatdotheyknow.com/help/house_rules"> the House rules page</a>.</dd>
+<dt id="html">HTML</dt>
+<dd>HTML is the standard language used to code webpages. HTML stands for HyperText Markup Language. On <a href="#whatdotheyknow">WhatDoTheyKnow</a>, there is an option to view documents released by <a href="#public_authority">public authorities</a> in HTML.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_I">I</h2>
+<dl>
+<dt id="ico">ICO</dt>
+<dd>ICO stands for <a href="#information_commissioners_office">Information Commissioner’s Office</a>.</dd>
+<dt id="">Information Commissioner</dt>
+<dd>The Information Commissioners is the privacy and data protection regulator for the UK as a whole and the EIR/FOI regulator for UK Central Government,
+ England, Northern Ireland and Wales. See also Scottish Information Commissioner.</dd>
+<dt id="information_commissioners_office">Information Commissioner’s Office</dt>
+<dd>The staff that supports the <a href="#information_commissioner">Information Commissioner</a>. In practice, the terms Information Commissioner and the Information Commissioner's Office are used interchangeably.</dd>
+ <dt id="">Internal review</dt>
+<dd>If you complain about how your request was handled, almost all <a href="#public_authority">public authorities</a> will have a process for reviewing the decisions made and this is know as an internal review.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_M">M</h2>
+<dl>
+<dt id="maiden_name">Maiden name</dt>
+<dd>If a person changes their last name when they get married in order to have the same last name as their spouse, the person's previous name is called their maiden name. The <a href="https://ico.org.uk/media/for-organisations/documents/1164/recognising-a-request-made-under-the-foia.pdf">ICO guidance on recognising FOI requests</a> states that a married woman who uses her maiden name for professional reasons but is known by her married name outside work can make a valid <a href="’#foi">FOI</a> request using either name.</dd>
+<dt id="mysociety">mySociety</dt>
+<dd>mySociety is a registered charity in England and Wales (1076346) and a limited company (03277032). The charity runs a number of websites including WhatDoTheyKnow. <a href="#societyworks">SocietyWorks</a> is a business owned by mySociety.
+See also <a href="https://www.mysociety.org/">mysociety.org</a> </dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_N">N</h2>
+<dl>
+ <dt id="ncnd">NCND</dt>
+<dd>Neither confirm nor deny. This refers to a situation where the <a href="#public_authority">public authority</a> refuses to say whether or not it holds the information that has been requested.
+ Sometimes admitting a document or record exists can 'give the game away'.
+ For example, if an authority admits to holding a copy of a complaint that A made about a new policy but refuses to release the complaint, the requester will still know that A complained.</dd>
+<dt id="nhs">NHS</dt>
+<dd>NHS stands for National Health Service. The NHS is funded by the UK Government and provides mecical and
+dental care that is free at the point of use in most cases.
+The NHS is not a single organisation.
+NHS services are delivered by a large number of NHS trusts and other service providers.
+Most organisations providing NHS services are subject to <a href="#foi">FOI</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_P">P</h2>
+<dl>
+<dt id="personal_data">Personal data</dt>
+<dd>Information about a living person who can be identified from the information for example because it contains their name or an identifier such as a National Insurance number or an email address. See also <a href="#gdpr">GDPR</a>.</dd>
+<dt id="pit">PIT</dt>
+<dd>PIT stands for <a href="#public_interest_test">public interest test</a>.</dd>
+<dt id="proactive_disclosure">Proactive disclosure</dt>
+<dd>The practice adopted by some public authorities of making information available even in the absence of an <a href="#eir">EIR</a> or <a href="#foi">FOI</a> request. Often this is done by publishing documents on the public authority's website. See also disclosure log and publication scheme.</dd>
+<dt id="pseudonym">Pseudonym</dt>
+<dd>A name used for a specific purpose that is not the person's real name. For example, some authors write novels under a pseudonym. Sometimes people make <a href="#foi">FOI</a> requests using a pseudonym.</dd>
+<dt id="public_authority">Public authority</dt>
+<dd>A body such as a Government Department or local council that is subject to <a href="#foi">FOI</a> law or to the <a href="#eir">EIR</a> or similar legislation. On <a href="#whatdotheyknow">WhatDoTheyKnow</a>, we also use the term public authorities for bodies we have added to the site even though they are not subject to EIR or FOI because of their public responsibilities.</dd>
+<dt id="public_interest">Public interest</dt>
+<dd>Something that will benefit the public. Not necessarily something the public will find interesting. The term is difficult to define but anything that would be likely to protect or improve the wellbeing, the rights, health, or finances of the public would normally be viewed as being in the public interest. In <a href="#foi">FOI</a> law, certain exemptions cannot be used to withhold information unless the public interest favours the information being withheld. There is always a public interest in transparency around decisions made by public bodies and in understanding how public money is spent which requesters can often use as arguments in favour of information being released. See also <a href="#public_interest_test">public interest test</a>.</dd>
+<dt id="public_interest_test">Public interest test</dt>
+<dd>The assessment as to whether the release of specific information would be in the <a href="#public_interest">public interest</a>.</dd>
+<dt id="publication_scheme">Publication scheme</dt>
+<dd>Freedom of information law requires every <a href="#public_authority">public authority</a> to have a publication scheme. The publication scheme must be approved by the ICO or the Scottish Information Commissioner. The publication scheme sets out a public authority’s commitment to make some types of information routinely available on request.The public authority is required to publish information in line with the publication scheme.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_Q">Q</h2>
+<dl>
+<dt id="qualified_exemption">Qualified exemption</dt>
+<dd>An <a href="#exemption">exemption</a> that is subject to a <a href="#public_interest_test">public interest test</a>.</dd>
+<dt id="qualified_person">Qualified person</dt>
+<dd>A public authority that wishes to withhold information under section 36 (Prejudice to effective conduct of public affairs) of the Freedom of Information Act 2000 will need to get the qualified person to sign an opinion. There is no equivalent to the qualified opinion under <a href="#foisa">FOISA</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_R">R</h2>
+<dl>
+<dt id="redacted">Redacted</dt>
+<dd>Information contained in a document that has not been made available to the requester. For example, text may have been removed or covered with a black box. Opposite of <a href="#disclosed">disclosed</a>. See also <a href="#withheld">withheld</a>.</dd>
+<dt id="redaction">Redaction</dt>
+<dd>The act of removing or masking information contained in a document such that it cannot be seen by the requester for example by covering up the text with a black box. See also <a href="#redacted">redacted</a>, <a href="#withheld">withheld</a>.</dd>
+<dt id="released">Released</dt>
+<dd>Means the same as <a href="#disclosed">disclosed</a>. Opposite of <a href="#redacted">redacted</a> and <a href="#withheld">withheld</a> </dd>
+<dt id="response">Response</dt>
+<dd>The public authorities reply to an <a href="#eir">EIR</a> or an <a href="’’foi">FOI</a> request. The term is not normally used for emails acknowledging receipt.</dd>
+<dt id="request">Request</dt>
+<dd>An email, letter or other communication requesting recorded information from a <a href="#public_authority">public authority</a>. See also <a href="#bulk_request">bulk request</a>, <a href="#requester">requester</a>.</dd>
+<dt id="requester">Requester</dt>
+<dd>The person or organisation that sent the <a href="#request">request</a> to the <a href="#public_authority">public authority</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_S">S</h2>
+<dl>
+<dt id="s">S</dt>
+<dd>The word section is sometimes abbreviated to “s" or “S". For example, “s40 of the FOIA" can be used in place of “section 40 of the Freedom of Information Act 2000".</dd>
+<dt id="sar">SAR</dt>
+<dd>Subject access request, also known as a "Right of Access" request. </dd>
+<dt id="societyworks">SocietyWorks</dt>
+<dd>SocietyWorks is the commercial arm of <a href="#mysociety">mySociety</a>. See also: <a href="https://www.societyworks.org/">societyworks.org</a>.</dd>
+<dt id="subject_access_request">Subject access request</dt>
+<dd>A request someone has made for their own personal data also known as a "Right of Access" request. Subject access requests should not be made using <a href="#whatdotheyknow">WhatDoTheyKnow</a>. See also <a href="#gdpr">GDPR</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_T">T</h2>
+<dl>
+<dt id="tribunal">Tribunal</dt>
+<dd>A tribunal is a panel chaired by a judge. A tribunal is similar to a court but usually deals with less serious matters. If the <a href="#requester">requester</a> or a <a href="#public_authority">public authority</a> disagrees with a decision made by the <a href="#ico">ICO</a> then they can appear to the First-tier Tribunal.
+</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_V">V</h2>
+<dl>
+<dt id="vexatious">Vexatious</dt>
+<dd>Likely to cause irritation or annoyance or place a disproportionate burden on <a href="#public_authority">public authorities</a>.
+ Public authorities can withhold information under section 14 of the Freedom of Information Act 2000 if the request is vexatious. The equivalent rules for Scotland are contained in section 14 of <a href="#foisa">FOISA</a>.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_W">W</h2>
+<dl>
+<dt id="whatdotheyknow">WhatDoTheyKnow</dt>
+<dd>A website that can be used to make <a href="#foi">FOI</a> and <a href="#eir">EIR</a> requests in public.</dd>
+<dt id="whatdotheyknowpro">WhatDoTheyKnowPro</dt>
+<dd>WhatDoTheyKnow Professional - a version of <a href="#whatdotheyknow">WhatDoTheyKnow</a> made available to journalists and campaigners on payment of a subscription fee.</dd>
+<dt id="whistleblower">Whistleblower</dt>
+<dd>A whistleblower is a someone who reveals information about activity within a company or other organisation that they considered to be illegal, unethical or seriously  concerning. Often whistleblowers are employees of the company or organisation in question. UK law provides some protection for whistleblowers in certain circumstances.</dd>
+<dt id="withheld">Withheld</dt>
+<dd>Withheld information is information that was asked for and is held by the <a href="#public_authority">public authority</a> that is not made available to the <a href="#requester">requester</a>. For example, where documents have not been provided at all or where documents have been provided but with some text removed or covered with a black box. Means the opposite of <a href="#disclosed">disclosed</a> and <a href="#released">released</a>. See also <a href="#redacted">redacted</a> </dd>
+<dt id="working_day">Working day</dt>
+<dd>Normally, FOI requests have to be answered within twenty working days. A working day for the purposes of the Freedom of Information Act 2000 is a day other than a Saturday or Sunday that is not a public authority in any part of the United Kingdom. Under <a href="#foisa">FOISA</a>, a working day is a day that is not a Saturday or Sunday that is not a public holiday in Scotland. In the UK, public holidays are often called bank holidays.</dd>
+</dl>
+<a href="#top">[Top]</a>
+<hr/>
+<br/>
+<h2 id="letter_Z">Z</h2>
+<dl>
+<dt id="zip_file">ZIP file</dt>
+<dd>ZIP is an archive file format used for data compression. <a href="#public_authorities">Public authorities</a> sometimes send very large datasets to requester using a ZIP file because there is a limit to the file size that they can send by email.</dd>
+</dl>
+<%= render partial: 'history' %>
+<div id="hash_link_padding"></div>
+</div>


### PR DESCRIPTION
## Relevant issue(s)
Create a glossary to help demystify some of the abbreviations and special terms used by FOI officers and transparency campaigners. Explains terms used in our help pages and elsewhere on the site.

## What does this do?
See above.

## Why was this needed?
See above.

## Implementation notes
Once this goes live, certain terms on the help pages can be linked to these definitions.

## Screenshots
N/A
## Notes to reviewer
