### PR TITLE
Make it clearer that people can use the site for free

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -31,6 +31,15 @@
       received, are automatically published on the website for you and anyone
       else to find and read.
     </dd>
+     <dt id="does_it_cost_money">Does it cost money to get an account on the site? <a href="#does_it_cost_money">#</a> </dt>
+    <dd>
+      <p>No. You can create an account on the site for free. Once you have an account, 
+      you can make up to ten freedom of information requests free of charge each day. 
+        The ten a day limit is more than enough for almost all of our users.</p>
+      <p>We do offer a paid service for journalists and others who may need to make
+      a higher number of requests or have other special requirements. 
+      The paid services is called <a href="https://www.whatdotheyknow.com/pro">WhatDoTheyKnow Pro</a>.</p>
+    </dd>
     <dt id="whybother_me">
       Why would I bother to do this?
       <a href="#whybother_me">#</a>

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -40,6 +40,8 @@
                      old_unclassified: @old_unclassified } %>
 
 <div id="left_column" class="left_column">
+  <%= render_notes(@info_request.all_notes) %>
+
   <% @info_request.info_request_events.each do |info_request_event| %>
     <% if info_request_event.visible %>
       <%= render partial: 'request/correspondence',


### PR DESCRIPTION
## Relevant issue(s)
Make it clearer that people can use the site for free.

## What does this do?
Amends help pages to make it clearer that people can use the site for free.

## Why was this needed?
(1) At a time when the cost of living is increasing in the UK and major national newspapers are talking about a cost of living crisis, it might be helpful to make it even clearer that people can use the site for free.

(2) We are all about transparency so making it really clear at the outset that you can make FOI requests for free is in line with our principles.

(3) In behavioural economics, there is something called 'the Power of Free'. My limited understanding of this concept is that people have a very high preference for things that are free which is higher than you might otherwise expect even by comparisons to things that cost almost nothing e.g. one penny (GBP). If I have got this right then even of the people who think the cost of using the site is likely be very low and easily affordable the knowledge that it is free will encourage a higher proportion to sign up.

https://www.forbes.com/sites/piyankajain/2018/03/01/5-behavioral-economics-principles-for-marketeers/?sh=51c10c8e28eb

## Implementation notes
N/A.

## Screenshots
N/A.

## Notes to reviewer
I am not an experienced coder.