### PR TITLE
[#1467] Fix missing tag in `lib/views/help/_contact_form.cy.html.erb`

### DIFF
--- a/lib/views/help/_contact_form.cy.html.erb
+++ b/lib/views/help/_contact_form.cy.html.erb
@@ -6,8 +6,9 @@
         <%= f.check_box :understand, :required => true %>
         <label for="contact_understand" class="form_label">
             Rwy'n deall <strong>nad yw WhatDoTheyKnow yn cael ei redeg gan y 
-            llywodraeth, ac ni fydd tîm WhatDoTheyKnow <b>yn gallu helpu</b> 
-            gyda materion personol sy'n gysylltiedig â gwasanaethau'r llywodraeth.
+            llywodraeth</strong>, ac ni fydd tîm WhatDoTheyKnow 
+            <strong>yn gallu helpu</strong> gyda materion personol sy'n 
+            gysylltiedig â gwasanaethau'r llywodraeth.
         </label>
     </p>
     <% if not @user %>


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1467 

## What does this do?

Resolves missing `</strong>` tag in `lib/views/help/_contact_form.cy.html.erb` and swaps another tag from `<b>` to `<strong>` for consistency.

## Why was this needed?

Tag was missing in commit 82041ed1cf, meaning that the footer on the help page was being erroneously rendered in bold / heavier weight than intended. This only affected the Welsh 🏴󠁧󠁢󠁷󠁬󠁳󠁿  endpoint for [/help/contact](https://www.whatdotheyknow.com/cy/help/contact).

## Implementation notes
Nothing of note

## Screenshots
### Before
<img src="https://user-images.githubusercontent.com/249418/197377734-ed8b02cf-81da-468d-b1d3-b61d91a94554.png" width="500px" alt="Closeup screenshot of the WhatDoTheyKnow website's footer, which gives links to various help pages, and to other mySociety services. Due to a formatting glitch, everything is bold!">

### After
<img src="https://user-images.githubusercontent.com/249418/197379574-6cbe1778-ed77-478d-a213-37c7d6b5dcbf.png" width="500px" alt="Closeup screenshot of the WhatDoTheyKnow sandbox website's footer, which gives links to various help pages, and to other mySociety services. The text now renders correctly and doesn't look silly.">
(ignore the reference to Sandbox)

## Notes to reviewer
Mea culpa - sorry for the hassle.