### PR TITLE
[#1486] Add no-reply email for St Helens MBC

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -127,6 +127,7 @@ Rails.configuration.to_prepare do
     donotreply.foi@publicagroup.uk
     do_not_reply@icasework.com
     mailer@donotreply.icasework.com
+    website@digital.sthelens.gov.uk
   )
 
   User::EmailAlerts.instance_eval do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1486

## What does this do?

Adds the no-reply email address used by St Helens MBC to `ReplyToAddressValidator.invalid_reply_addresses` in `model_patches.rb`.

## Why was this needed?

Public body is sending substantive replies from an email address that does not accept responses.

## Implementation notes

Nothing of note

## Screenshots
N/A

## Notes to reviewer
N/A