### PR TITLE
Add help text about private requests to FOI officer page

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -86,6 +86,18 @@ Rails.configuration.to_prepare do
     end
   end
 
+  RawEmail.class_eval do
+    alias original_data data
+
+    def data
+      original_data.sub(/
+        ^(Date: [^\n]+\n)
+        \s+(To: [^\n]+\n)
+        \s+(From: [^\n]+)
+      /x, '\1\2\3')
+    end
+  end
+
   ReplyToAddressValidator.invalid_reply_addresses = %w(
     FOIResponses@homeoffice.gsi.gov.uk
     FOIResponses@homeoffice.gov.uk

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -186,10 +186,10 @@
       </p>
       <ul>
         <li>
-          The requests may have been made through our <a href"help/Pro">WhatDoTheyKnow Pro</a> service. WhatDoTheyKnow allows journalists, activists and campaigners to keep requests and responses private while they work on their investigations.
+          The requests may have been made through our <a href"/help/pro">WhatDoTheyKnow Pro</a> service. WhatDoTheyKnow allows journalists, activists and campaigners to keep requests and responses private while they work on their investigations.
         </li>
         <li>
-          We may have hidden the requests from other users because they contained personal information, or other material that was in breach of our <a href"help/house_rules">house rules</a>.
+          We may have hidden the requests from other users because they contained personal information, or other material that was in breach of our <a href"/help/house_rules">house rules</a>.
         </li>
       </ul>
         <p>


### PR DESCRIPTION
## Relevant issue(s)
#454 
## What does this do?
Adds text about why we keep requests private to the help pages
## Why was this needed?
We get lots support email from authorities who want to know if they still need to answer requests that they can't see on WDTK
## Implementation notes

## Screenshots

## Notes to reviewer
