### PR TITLE
Don't make assumptions re users identity

### DIFF
--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -128,9 +128,9 @@
         </li>
       </ul>
     </dd>
-      <dt id="identity_checks">
-      Do you check the identity of your users?
-      <a href="#identity_checks">#</a>
+      <dt id="identity_of_requester">
+      How can we be sure the requester is the same person we have dealt with previously?
+      <a href="#identity_of_requester">#</a>
     </dt>
     <dd>
       <p>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -128,6 +128,20 @@
         </li>
       </ul>
     </dd>
+      <dt id="identity_checks">
+      Do you check the identity of your users?
+      <a href="#identity_checks">#</a>
+    </dt>
+    <dd>
+      <p>
+        WhatDoTheyKnow does not check the identity of its users so it is possible for any person to set up an account under any name. 
+        We would advise public authorities not to assume that a person writing to them via our site is the same as a person they have 
+        dealt with previously under the same name even if the subject matter of the correspondence is the same or on similar lines.
+      </p> 
+      <p>
+        UK Freedom of Information law is <a href="https://www.whatdotheyknow.com/help/glossary">applicant blind</a> and so there is no
+        requirement for identity checks.
+      </p>
     <dt id="vexatious">
       Aren’t you making lots of vexatious requests?
       <a href="#vexatious">#</a>

--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -134,9 +134,8 @@
     </dt>
     <dd>
       <p>
-        WhatDoTheyKnow does not check the identity of its users so it is possible for any person to set up an account under any name. 
-        We would advise public authorities not to assume that a person writing to them via our site is the same as a person they have 
-        dealt with previously under the same name even if the subject matter of the correspondence is the same or on similar lines.
+      We would advise public authorities not to assume that a person writing to them via our site is the same as a person they have 
+       dealt with previously under the same name. 
       </p> 
       <p>
         UK Freedom of Information law is <a href="https://www.whatdotheyknow.com/help/glossary">applicant blind</a> and so there is no


### PR DESCRIPTION
We do not check users identity. FOI officers should not assume the requester is the same person as someone they have dealt with previously even if both have the same name.

## Relevant issue(s)
Ensure public authorities don't wrong infer users identity and then respond in the wrong way e.g. by copying in another email address, adding in someones middle name, qualifications etc.

## What does this do?
See above.

## Why was this needed?
See above.

## Implementation notes
N/A.

## Screenshots
N/A.

## Notes to reviewer
N/A.