### PR TITLE
Remove custom autoloaded path

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -31,15 +31,6 @@ Rails.application.config.assets.precompile.unshift(LOOSE_THEME_ASSETS)
 
 Rails.application.config.assets.precompile << ["tests.js"]
 
-# In order to have the theme lib/ folder ahead of the main app one,
-# inspired in Ruby Guides explanation: http://guides.rubyonrails.org/plugins.html
-%w{ . }.each do |dir|
-  path = File.join(File.dirname(__FILE__), dir)
-  $LOAD_PATH.insert(0, path)
-  ActiveSupport::Dependencies.autoload_paths << path
-  ActiveSupport::Dependencies.autoload_once_paths.delete(path)
-end
-
 def prepend_theme_assets
   # Prepend the asset directories in this theme to the asset path:
   ['stylesheets', 'images', 'javascripts'].each do |asset_type|
@@ -63,7 +54,9 @@ for patch in ['patch_mailer_paths.rb',
               'helper_patches.rb',
               'mailer_patches.rb',
               'analytics_event.rb',
+              'help_page_history.rb',
               'public_body_questions.rb',
+              'school_late_calculator.rb',
               'volunteer_contact_form.rb']
     require File.expand_path "../#{patch}", __FILE__
 end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/6341

## What does this do?

Remove custom autoloaded path

## Why was this needed?

Fixes issues when using theme on Rails 7 as this was causing the post install script to error with:
```
Zeitwerk::NameError: expected file ./lib/censor_rules.rb to define constant CensorRules, but didn't
```

Needed to explicitly require some files as Rails convention is to not autoload files under `lib/`.

See: https://github.com/rails/rails/issues/38671#issuecomment-947449850

## Implementation notes

## Screenshots

## Notes to reviewer
