### PR TITLE
New ways to link to external sites from authority pages and minor changes to help text 

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -40,9 +40,12 @@
                     "https://ico.org.uk/ESDWebPages/Entry/#{ tag_value }" %><br>
   <% end %>
 <% end %>
+# A UKPRN is a UK Provider Reference Number.
+# The Office for Students (OfS) is a regulator that maintains a register listing all the higher education providers officially recognised by the OfS.
+# This part of the code adds a link to the OfS register for all bodies with a 'UKPRN:' tag.
 
-<% if public_body.has_tag?('ofs') %>
-  <% public_body.get_tag_values('ofs').each do |tag_value| %>
+<% if public_body.has_tag?('UKPRN') %>
+  <% public_body.get_tag_values('UKPRN').each do |tag_value| %>
       <%= link_to _('Provider register'),
                     "https://www.officeforstudents.org.uk/advice-and-guidance/the-register/the-ofs-register/#/provider/#{ tag_value }" %><br>
   <% end %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -84,6 +84,17 @@
   <% end %>
 <% end %>
 
+#On Wikidata, items which are also called Q-items are given unique codes.
+#For example, the Cabinet Office code is Q5995(see https://www.wikidata.org/wiki/Q5995)
+#Each Wikidata item code begins with a "Q" which is followed by a numerical code
+#This part of the code adds a link to https://www.wikidata.org/wiki/ for authorities tagged with 'wikidata:'.
+<% if public_body.has_tag?('wikidata') %>
+  <% public_body.get_tag_values('wikidata').each do |tag_value| %>
+      <%= link_to _('Wikidata page'),
+                    "https://www.wikidata.org/wiki/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <% if public_body.has_tag?('mapit') %>
   <% public_body.get_tag_values('mapit').each do |tag_value| %>
     <%= link_to _('Area covered'), "https://mapit.mysociety.org/area/#{tag_value}.html" %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -72,6 +72,16 @@
   <% end %>
 <% end %>
 
+# A Legal Entity Identifier or LEI is a unique global identifier used for legal entities entering into financial transactions.
+# Each LEI is a 20-character alpha-numeric code.
+# This part of the code adds a link to openleis.com for authorities tagged with 'lei:'.
+<% if public_body.has_tag?('lei') %>
+  <% public_body.get_tag_values('lei').each do |tag_value| %>
+      <%= link_to _('Legal Entity Identifier'),
+                    "http://openleis.com/legal_entities/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <% if public_body.has_tag?('mapit') %>
   <% public_body.get_tag_values('mapit').each do |tag_value| %>
     <%= link_to _('Area covered'), "https://mapit.mysociety.org/area/#{tag_value}.html" %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -40,12 +40,14 @@
                     "https://ico.org.uk/ESDWebPages/Entry/#{ tag_value }" %><br>
   <% end %>
 <% end %>
+
 # A UKPRN is a UK Provider Reference Number.
 # The Office for Students (OfS) is a regulator that maintains a register listing all the higher education providers officially recognised by the OfS.
-# This part of the code adds a link to the OfS register for all bodies with a 'ukprn:' tag.
+# This part of the code adds a link to the OfS register for all bodies with a 'ofs:' tag.
+# The ofs tag should not be used for bodies with a UKPRN that are not on the OfS register (e.g. some academies).
 
-<% if public_body.has_tag?('ukprn') %>
-  <% public_body.get_tag_values('ukprn').each do |tag_value| %>
+<% if public_body.has_tag?('ofs') %>
+  <% public_body.get_tag_values('ofs').each do |tag_value| %>
       <%= link_to _('Provider register'),
                     "https://www.officeforstudents.org.uk/advice-and-guidance/the-register/the-ofs-register/#/provider/#{ tag_value }" %><br>
   <% end %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -41,11 +41,6 @@
   <% end %>
 <% end %>
 
-# A UKPRN is a UK Provider Reference Number.
-# The Office for Students (OfS) is a regulator that maintains a register listing all the higher education providers officially recognised by the OfS.
-# This part of the code adds a link to the OfS register for all bodies with a 'ofs:' tag.
-# The ofs tag should not be used for bodies with a UKPRN that are not on the OfS register (e.g. some academies).
-
 <% if public_body.has_tag?('ofs') %>
   <% public_body.get_tag_values('ofs').each do |tag_value| %>
       <%= link_to _('Provider register'),
@@ -74,24 +69,10 @@
   <% end %>
 <% end %>
 
-# A Legal Entity Identifier or LEI is a unique global identifier used for legal entities entering into financial transactions.
-# Each LEI is a 20-character alpha-numeric code.
-# This part of the code adds a link to openleis.com for authorities tagged with 'lei:'.
 <% if public_body.has_tag?('lei') %>
   <% public_body.get_tag_values('lei').each do |tag_value| %>
       <%= link_to _('Legal Entity Identifier'),
                     "http://openleis.com/legal_entities/#{ tag_value }" %><br>
-  <% end %>
-<% end %>
-
-#On Wikidata, items which are also called Q-items are given unique codes.
-#For example, the Cabinet Office code is Q5995(see https://www.wikidata.org/wiki/Q5995)
-#Each Wikidata item code begins with a "Q" which is followed by a numerical code
-#This part of the code adds a link to https://www.wikidata.org/wiki/ for authorities tagged with 'wikidata:'.
-<% if public_body.has_tag?('wikidata') %>
-  <% public_body.get_tag_values('wikidata').each do |tag_value| %>
-      <%= link_to _('Wikidata page'),
-                    "https://www.wikidata.org/wiki/#{ tag_value }" %><br>
   <% end %>
 <% end %>
 

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -42,7 +42,7 @@
 <% end %>
 # A UKPRN is a UK Provider Reference Number.
 # The Office for Students (OfS) is a regulator that maintains a register listing all the higher education providers officially recognised by the OfS.
-# This part of the code adds a link to the OfS register for all bodies with a 'UKPRN:' tag.
+# This part of the code adds a link to the OfS register for all bodies with a 'ukprn:' tag.
 
 <% if public_body.has_tag?('ukprn') %>
   <% public_body.get_tag_values('ukprn').each do |tag_value| %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -44,8 +44,8 @@
 # The Office for Students (OfS) is a regulator that maintains a register listing all the higher education providers officially recognised by the OfS.
 # This part of the code adds a link to the OfS register for all bodies with a 'UKPRN:' tag.
 
-<% if public_body.has_tag?('UKPRN') %>
-  <% public_body.get_tag_values('UKPRN').each do |tag_value| %>
+<% if public_body.has_tag?('ukprn') %>
+  <% public_body.get_tag_values('ukprn').each do |tag_value| %>
       <%= link_to _('Provider register'),
                     "https://www.officeforstudents.org.uk/advice-and-guidance/the-register/the-ofs-register/#/provider/#{ tag_value }" %><br>
   <% end %>


### PR DESCRIPTION
## Relevant issue(s)
New ways to link to external sites from authority pages and minor changes to help text.

## What does this do?
New ways to link to external sites from authority pages and minor changes to help text. 

## Why was this needed?
See above.

## Implementation notes
N/A.

## Screenshots
N/A

## Notes to reviewer
I am trying to squash my commits but this may not work.
