### PR TITLE
More links on public authority pages

### DIFF
--- a/lib/views/help/glossary.html.erb
+++ b/lib/views/help/glossary.html.erb
@@ -145,7 +145,7 @@ Environmental Information Regulations 2004 (
 <dt id="github">GitHub</dt>
 <dd>GitHub is an online tool for software development and version control.
  Issues can be raised in GitHub where there are bugs in the site software or to suggest improvements or new features.
-  The code behind the WhatDoTheyKnow website is worked on using GitHub. See also <a fre="#alaveteli>Alaveteli</a>.
+  The code behind the WhatDoTheyKnow website is worked on using GitHub. See also <a href="#alaveteli">Alaveteli</a>.
   </dd>
 </dl>
 <a href="#top">[Top]</a>


### PR DESCRIPTION
## Relevant issue(s)
More links on public authority pages.

## What does this do?
Add links to Office for Students (a regulator) pages, WikiData and also for Legal Entity Identifiers.

## Why was this needed?
Not needed but useful.

## Implementation notes
N/A.

## Screenshots
N/A.

## Notes to reviewer
I tried to combine a number of commits into one request. I had a few false starts. I hope this works.