### PR TITLE
[#1622] Add no-reply address for Rugby BC to `model_patches.rb`

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -155,6 +155,7 @@ Rails.configuration.to_prepare do
     noreply@m.onetrust.com
     no-reply@notify.microsoft.com
     MPSdataoffice-IRU-DONOTREPLY@met.police.uk
+    noreply@rugby.gov.uk
   )
 
   User.class_eval do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1622

## What does this do?

This adds a new address to the `invalid_reply_addresses` list used by `ReplyToAddressValidator`.

## Why was this needed?

Rugby BC are issuing some messages from a no-reply address, so Alaveteli needs to be able to distinguish this so that users can chase up requests.

## Implementation notes
Nothing of note

## Screenshots
N/A

## Notes to reviewer

N/A