### PR TITLE
[#1624, #1631] Fix link for CCNI database, add exempt charities

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -22,7 +22,7 @@
                     "https://www.charitycommissionni.org.uk/charity-details/?regId=#{ tag_value.gsub(/^NIC/, '') }" %><br>
     <% elsif tag_value.match(/^exempt/) %>
       <%= link_to _("Exempt charity - <i>what's that?</i>"),
-                    "https://www.gov.uk/government/publications/exempt-charities-cc23/exempt-charities#list-of-exempt-charities" %><br>
+                    "https://www.gov.uk/government/publications/exempt-charities-cc23/exempt-charities" %><br>
     <% else %>
       <%= link_to _('Charity registration'),
                     "https://register-of-charities.charitycommission.gov.uk/charity-search/-/results/page/1/delta/20/keywords/#{ tag_value }" %><br>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -19,7 +19,7 @@
                     "https://www.oscr.org.uk/about-charities/search-the-register/charity-details?number=#{ tag_value }" %><br>
     <% elsif tag_value.match(/^NIC/) %>
       <%= link_to _('Charity registration'),
-                    "https://www.charitycommissionni.org.uk/charity-search/?regId=#{ tag_value.gsub(/^NIC/, '') }" %><br>
+                    "https://www.charitycommissionni.org.uk/charity-details/?regId=#{ tag_value.gsub(/^NIC/, '') }" %><br>
     <% else %>
       <%= link_to _('Charity registration'),
                     "https://register-of-charities.charitycommission.gov.uk/charity-search/-/results/page/1/delta/20/keywords/#{ tag_value }" %><br>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -20,6 +20,9 @@
     <% elsif tag_value.match(/^NIC/) %>
       <%= link_to _('Charity registration'),
                     "https://www.charitycommissionni.org.uk/charity-details/?regId=#{ tag_value.gsub(/^NIC/, '') }" %><br>
+    <% elsif tag_value.match(/^exempt/) %>
+      <%= link_to _("Exempt charity - <i>what's that?</i>"),
+                    "https://www.gov.uk/government/publications/exempt-charities-cc23/exempt-charities#list-of-exempt-charities" %><br>
     <% else %>
       <%= link_to _('Charity registration'),
                     "https://register-of-charities.charitycommission.gov.uk/charity-search/-/results/page/1/delta/20/keywords/#{ tag_value }" %><br>


### PR DESCRIPTION
## Relevant issue(s)
- Fixes #1631
- relates to #1624

## What does this do?

This amends the link we use for the Charity Commission of Northern Ireland (charities tagged `charity:NIC00000`) [^1].

It also adds a link for `charity:exempt`, which points to the [guidance on gov.uk](https://www.gov.uk/government/publications/exempt-charities-cc23/exempt-charities#list-of-exempt-charities)

## Why was this needed?

The CCNI link we use is broken and directs users to a page that isn't very helpful to them.

Secondly, at the moment we don't have a way to display an indicator for _exempt charities_. This reuses existing code to do it cheaply.

## Implementation notes

Nothing of note - however, I do ponder the regex for exempt. Theoretically, we should match `charity:exempt` and `charity:exempt00000` [^1]. I think this does the trick _as is_.

## Screenshots

N/A

## Notes to reviewer

Nothing of note.

[^1]: where `00000` is the charity registration number.