### PR TITLE
[#541] Fix donation link

### DIFF
--- a/lib/helpers/donation_helper.rb
+++ b/lib/helpers/donation_helper.rb
@@ -16,7 +16,6 @@ module DonationHelper
   def donation_url(options = {})
     AlaveteliConfiguration::donation_url + "?" << options.reverse_merge(
       :utm_source => 'whatdotheyknow.com',
-      :utm_campaign => 'donation_drive_2016',
       :utm_medium => 'link'
     ).to_query
   end

--- a/lib/views/request/describe_notices/_successful.html.erb
+++ b/lib/views/request/describe_notices/_successful.html.erb
@@ -52,7 +52,13 @@
       <p class="what-next__para"><%= _("Your donations help us make " \
                                        "Freedom of Information more " \
                                        "accessible, for everyone.") %></p>
-      <%= donate_now_link 'successful request donate now', :class => 'button what-next__button' %>
+
+      <%= donate_now_link 'successful request donate now',
+                          utm_params: {
+                            utm_content: 'successful request donate now',
+                            utm_campaign: 'successful_request'
+                          },
+                          class: 'button what-next__button' %>
     </div>
     <% end %>
   </div>

--- a/spec/donation_helper_spec.rb
+++ b/spec/donation_helper_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe DonationHelper, type: :helper do
     it 'outputs anchor tag with escaped utm_content param' do
       expect(donate_now_link('foo bar')).to have_xpath(
         '//a[@href="http://example.com/foo?' \
-          'utm_campaign=donation_drive_2016&' \
           'utm_content=foo%2Bbar&' \
           'utm_medium=link&' \
           'utm_source=whatdotheyknow.com"]'


### PR DESCRIPTION
Improve tracking of successful request donations 

Fixes #541

<img width="1025" alt="Screenshot 2023-03-31 at 17 44 40" src="https://user-images.githubusercontent.com/282788/229180707-3ffe8b61-2a9e-418d-8c7f-5c7d7a4cc0f5.png">

Generates:

```
https://www.mysociety.org/donate?
  utm_campaign=successful_request&
  utm_content=successful+request+donate+now&
  utm_medium=link&
  utm_source=whatdotheyknow.com
```