### PR TITLE
Add custom `User.content_limits` configuration

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -159,6 +159,12 @@ Rails.configuration.to_prepare do
     no-reply@cheshire.pnn.police.uk
   )
 
+  User.content_limits = {
+    info_requests: AlaveteliConfiguration.max_requests_per_user_per_day,
+    comments: AlaveteliConfiguration.max_requests_per_user_per_day,
+    user_messages: 2
+  }
+
   User.class_eval do
     private
 


### PR DESCRIPTION
Reduce the daily cap on `UserMessages` to combat abuse. It's unlikely that genuine usage exceeds this level.

Requires https://github.com/mysociety/alaveteli/pull/7677