### PR TITLE
[#1653] Add route for usage survey

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   get "/help/ico-anonymisation-code" => redirect("https://ico.org.uk/media/1061/anonymisation-code.pdf"),
      as: :ico_anonymisation_code
 
+  get "/how-have-you-used-wdtk" => redirect("https://survey.alchemer.com/s3/7276877/How-have-you-used-WTDK"),
+     as: :how_have_you_used_wdtk
+
   get '/help/principles' => 'help#principles',
       as: :help_principles
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1653

## What does this do?

This provides a route to the "How have you used" survey, off the WDTK domain.

## Why was this needed?

The existing URI is not 'easy to remember', and doesn't look great when it is laid out in plain text [^1].

Having a redirect off our domain allows for a more 'user friendly' approach.

## Implementation notes

Nothing to note, this isn't new (or especially novel) code - we use the same approach for ICO guidance.

It's worth noting that there _is_ a typo in the Alchemer URL (`WTDK` instead of `WDTK`) - but, that's what is currently live.

## Screenshots

N/A

## Notes to reviewer

Nothing to note here. Once this survey has been closed it's possible we'll want to reuse the route - but, for now, directing straight to Alchemer, rather than an interstitial, seems more user friendly (less clicks).

[^1]: and it avoids the _"isn't there a typo"_ conversation! 🙂