### PR TITLE
1140 add anchor links to help pages where they are missing

### DIFF
--- a/lib/views/help/api.html.erb
+++ b/lib/views/help/api.html.erb
@@ -2,7 +2,10 @@
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
   <h1><%=@title %></h1>
-  <h2> Introduction </h2>
+  <h2 id="introduction"> 
+    Introduction 
+    <a href="#introduction">#</a>
+  </h2>
   <p>
     This page explains how developers can access data from WhatDoTheyKnow, or
     allow other websites and software to interact with the site via an “API”.
@@ -14,7 +17,10 @@
     help us give it a higher development priority.
   </p>
   <hr>
-  <h2> 1. Linking to new requests </h2>
+  <h2 id="new_requests">
+    1. Linking to new requests 
+    <a href="#new_requests">#</a>
+  </h2>
   <p>
     To encourage your users to make requests to a particular public authority,
     use URLs of the form: <%= link_to new_request_to_body_url(:url_name =>
@@ -47,7 +53,10 @@
     </li>
   </ul>
   <hr>
-  <h2> 2. RSS (actually, Atom) feeds </h2>
+  <h2 id="rss_feeds"> 
+    2. RSS (actually, Atom) feeds 
+    <a href="#rss_feeds">#</a>
+  </h2>
   <p>There are Atom feeds on most pages which list FOI requests, which you can
     use to get updates and links in XML format. Find the URL of the Atom feed in
     one of these ways:
@@ -72,7 +81,10 @@
     tips</a> for details.
   </p>
   <hr>
-  <h2> 3. JSON structured data </h2>
+  <h2 id="json"> 
+    3. JSON structured data 
+    <a href="#json">#</a>
+  </h2>
   <p>
     Quite a few pages have JSON versions, which let you download information
     about objects in a structured form. Find them by:
@@ -91,12 +103,18 @@
     information about the list of events in the feed.
   </p>
   <hr>
-  <h2> 4. Spreadsheet of all authorities </h2>
+  <h2 id="all_authorities"> 
+    4. Spreadsheet of all authorities 
+    <a href="#all_authorities">#</a>
+  </h2>
   <p>
     A spreadsheet file listing every body in WhatDoTheyKnow is available:
     <%= link_to "all-authorities.csv", all_public_bodies_csv_url() %>
   </p>
-  <h2> 5. Write API </h2>
+  <h2 id="write_api"> 
+    5. Write API 
+    <a href="#write_api">#</a>
+  </h2>
   <p>
     The write API is designed to be used by authorities to create their own
     requests in the system. The API was used by mySociety’s FOI Register

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -135,8 +135,9 @@
     We will not disclose your email address to anyone else unless we are obliged
     to by law, or you ask us to.
   </p>
-  <h4>
+  <h4 id="email_other">
     Will your email address be used for any other purposes?
+    <a href="#email_other">#</a>
   </h4>
   <p>
     No. After you sign up to WhatDoTheyKnow we will only send you emails
@@ -704,8 +705,9 @@
   <p>
     See also <a href="#right_to_object">your right to object</a>.
   </p>
-  <h4>
+  <h4 id="own_requests">
     Your own requests, annotations and user profile
+    <a href="#own_requests">#</a>
   </h4>
 
   <p>
@@ -760,8 +762,9 @@
     As a user you can view and edit much of this material yourself, but if you
     feel the need to ask us to delete material do get in touch.
   </p>
-  <h4>
+  <h4 id="removal_of_personal_information">
     Removal of personal information from requests and responses
+    <a href="#removal_of_personal_information">#</a>
   </h4>
   <p>
     If you see any personal information about you on the site which you’d like
@@ -907,7 +910,10 @@
     your browsing activities on mySociety’s sites with other companies, you
     can adjust your usage or install opt-out browser plugins.
   </p>
-  <h4>Cookies</h4>
+  <h4 id="cookie_list">
+    Cookies
+    <a href="#cookie_list">#</a>
+  </h4>
   <p>
     To make our service easier or more useful, we sometimes place small data
     files on your computer or mobile phone, known as cookies; this is very
@@ -959,7 +965,10 @@
       </td>
     </tr>
   </table>
-  <h4>Measuring website usage (Google Analytics)</h4>
+  <h4 id="analytics">
+    Measuring website usage (Google Analytics)
+    <a href="#analytics">#</a>
+  </h4>
   <p>
     We use Google Analytics to collect information about how people use this
     site. We do this to make sure it’s meeting its users’ needs and to
@@ -999,7 +1008,10 @@
       machine or device.
     </dd>
   </dl>
-  <h4>Google’s Official Statement about Analytics Data</h4>
+  <h4 id="google_statement">
+    Google’s Official Statement about Analytics Data
+    <a href="#google_statement">#</a>
+  </h4>
   <p>
     “This website uses Google Analytics, a web analytics service provided by
     Google, Inc. (“Google”).  Google Analytics uses “cookies”, which are


### PR DESCRIPTION
## Relevant issue(s)
#1140
## What does this do?
Adds anchor links to the API page, and to the remaining headings on the privacy page
## Why was this needed?
The anchor links were not there before, and this makes it easier to link to sections of the pages.
## Implementation notes
n/a
## Screenshots
<img width="867" alt="Screenshot 2023-04-17 at 14 30 29" src="https://user-images.githubusercontent.com/120410992/232499088-5c3258e5-ce3b-438e-a714-5f1d875aa8e3.png">

## Notes to reviewer
