### PR TITLE
Add paragraph about abuse to the 'house rules'

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -1,4 +1,4 @@
-<% @title = "House rules" %>
+<% @title = "Conditions of use" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
   <h1><%=@title %></h1>
@@ -79,6 +79,16 @@
       Do not seek to evade the actions of site administrators by, for example,
       creating new accounts to evade a ban, or a rate-limiting cap, or by
       republishing material which you know has been removed by moderators.
+    </li>
+    <li>
+      As with all mySociety services and activities, users of WhatDoTheyKnow 
+      must abide by the organisation's <a href="https://www.mysociety.org/code-of-conduct/">Code of Conduct</a>. 
+      This code applies to all activity related to the site, including correspondence with our 
+      staff and volunteers. Where a user sends a message to a member of our team 
+      that is intended to harass, threaten, abuse or distress, we will, at our discretion, 
+      cease communication. We may also ban the correspondent from future use of WhatDoTheyKnow.
+      Where a message  of particular concern, we will forward details 
+      of the correspondence to the police.
     </li>
   </ul>
   <p>


### PR DESCRIPTION
Adds a final paragraph about how we treat abusive correspondence to site volunteers and staff. 

I've also changed 'House Rules' to 'Conditions of Use', as per recent discussions. Not sure if this also changes it in the navigation links to the left of the page though?
