### PR TITLE
Add NHSBSA no-reply email to `model_patches.rb`

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -157,6 +157,7 @@ Rails.configuration.to_prepare do
     MPSdataoffice-IRU-DONOTREPLY@met.police.uk
     noreply@rugby.gov.uk
     no-reply@cheshire.pnn.police.uk
+    Information-rights@nhsbsa.nhs.uk
   )
 
   User.class_eval do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1666

## What does this do?

Adds an email address for the NHS Business Services Authority (NHSBSA) to `ReplyToAddressValidator.invalid_reply_addresses` in `model_patches.rb`.

## Why was this needed?

NHSBSA issue messages from an email address that does not accept mail.

## Implementation notes

Nothing to note

## Screenshots

N/A

## Notes to reviewer

N/A