### PR TITLE
Patch User#can_make_comments?

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -160,6 +160,12 @@ Rails.configuration.to_prepare do
   )
 
   User.class_eval do
+    alias_method :orig_can_make_comments?, :can_make_comments?
+    def can_make_comments?
+      return true if no_limit?
+      orig_can_make_comments?
+    end
+
     private
 
     def exceeded_user_message_limit?


### PR DESCRIPTION
Ensure users with no limit set can make comments.

At the moment, we are limiting users ability to make comments when `Comment.exceeded_creation_rate?` returns false. This happens if too many comments are created in a short period of time.

This is a quick fix for a Pro user. Eventually we will migrate this fix to core.

See: https://groups.google.com/a/mysociety.org/g/alaveteli-pro/c/N0oifwP09bg