### PR TITLE
[#1663] Add additional routes for `/help/house_rules`

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -24,6 +24,10 @@ Rails.application.routes.draw do
   get '/help/house_rules' => 'help#house_rules',
       as: :help_house_rules
 
+  get '/help/:house_rules_resolve' => redirect("/help/house_rules", status: 302),
+        as: :help_house_rules_resolve,
+        constraints: { house_rules_resolve: /conditions_of_use|site_rules|terms_and_conditions|terms_of_service|terms_of_use|the_legal_stuff|the_rules/ }
+      
   get '/help/how' => 'help#how',
       as: :help_how
 


### PR DESCRIPTION
## Relevant issue(s)

#1663

## What does this do?

This adds a new route which allows for the `/help/house_rules` page to be accessed using different paths.

## Why was this needed?

Chat on #1663, and predecessors, has raised the issue of language.

Allowing more possibilities allows us to ensure that messages to users are easy to understand, as _"house rules"_ may not mean something to many.

## Implementation notes

The basic implementation isn't anything especially complex - it is a redirect to `/help/house_rules`.

We match `:help_house_rules_resolve` against a constraint. The following are accepted values:

- `conditions_of_use`
- `site_rules`
- `terms_and_conditions`
- `terms_of_service`
- `terms_of_use`
- `the_legal_stuff`
- `the_rules`

This doesn't change the _existing_ route for `/help/house_rules`, as whilst it is trivial to include _that_ here, it is a bit less _elegant_ [^1].

## Screenshots

N/A

## Notes to reviewer

I've tested this on a sandbox install (running `0.43.0.0` / rails `7.0.4.3` / ruby `3.2.1`) and didn't encounter any problems.

[^1]: not that this is elegant… but, it prevents a slight nuisance  in regard to how we render the sidebar (e.g. not rendering a clickable 'house rules' link when we don't have to).