### PR TITLE
Update glossary.html.erb

### DIFF
--- a/lib/views/help/glossary.html.erb
+++ b/lib/views/help/glossary.html.erb
@@ -296,7 +296,7 @@ Most organisations providing NHS services are subject to <a href="#foi">FOI</a>.
 <dt id="withheld">Withheld</dt>
 <dd>Withheld information is information that was asked for and is held by the <a href="#public_authority">public authority</a> that is not made available to the <a href="#requester">requester</a>. For example, where documents have not been provided at all or where documents have been provided but with some text removed or covered with a black box. Means the opposite of <a href="#disclosed">disclosed</a> and <a href="#released">released</a>. See also <a href="#redacted">redacted</a> </dd>
 <dt id="working_day">Working day</dt>
-<dd>Normally, FOI requests have to be answered within twenty working days. A working day for the purposes of the Freedom of Information Act 2000 is a day other than a Saturday or Sunday that is not a public authority in any part of the United Kingdom. Under <a href="#foisa">FOISA</a>, a working day is a day that is not a Saturday or Sunday that is not a public holiday in Scotland. In the UK, public holidays are often called bank holidays.</dd>
+<dd>Normally, FOI requests have to be answered within twenty working days. A working day for the purposes of the Freedom of Information Act 2000 is a day other than a Saturday or Sunday that is not a public holiday in any part of the United Kingdom. Under <a href="#foisa">FOISA</a>, a working day is a day that is not a Saturday or Sunday that is not a public holiday in Scotland. In the UK, public holidays are often called bank holidays.</dd>
 </dl>
 <a href="#top">[Top]</a>
 <hr/>


### PR DESCRIPTION
Fixing typo

## Relevant issue(s)
N/A
## What does this do?
Fixes a typo in the Glossary
## Why was this needed?
A wrong word was used
## Implementation notes
N/A
## Screenshots

## Notes to reviewer
It said authority when it should have said holiday.