### PR TITLE
[#1678] Maiden names language improvement

### DIFF
--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -22,7 +22,7 @@
                     <li role="presentation"><%= link_to 'Help', help_path %></li>
                     <li role="presentation"><%= link_to 'Contact us', help_contact_path %></li>
                     <li role="presentation"><%= link_to 'Become a volunteer', help_volunteers_path %></li>
-                    <li role="presentation"><%= link_to 'House rules', help_house_rules_path %></li>
+                    <li role="presentation"><%= link_to 'Conditions of use', help_house_rules_path %></li>
                     <li role="presentation"><%= link_to 'Privacy and cookies', help_privacy_path %></li>
                     <li role="presentation"><%= link_to 'API', help_api_path %></li>
                     <% if feature_enabled?(:pro_pricing) %>

--- a/lib/views/help/_sidebar.cy.html.erb
+++ b/lib/views/help/_sidebar.cy.html.erb
@@ -5,6 +5,7 @@
       <li><%= link_to_unless_current "Cyflwyniad", help_about_path %></li>
       <li><%= link_to_unless_current "Gwneud ceisiadau", help_requesting_path %></li>
       <li><%= link_to_unless_current "Eich preifatrwydd", help_privacy_path %></li>
+      <li><%= link_to_unless_current "Amodau defnydd", help_house_rules_path %></li>
       <li><%= link_to_unless_current "Swyddogion Rhyddid Gwybodaeth", help_officers_path %></li>
       <li><%= link_to_unless_current "Credydau", help_credits_path %></li>
       <li><%= link_to_unless_current "API Rhaglenwyr", help_api_path %></li>

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -37,7 +37,7 @@
         <%= link_to_unless_current "How we run the site", help_how_path %>
       </li>
       <li>
-        <%= link_to_unless_current "House Rules", help_house_rules_path %>
+        <%= link_to_unless_current "Conditions of use", help_house_rules_path %>
       </li>
       <li>
         <%= link_to_unless_current "Making a complaint", help_complaints_path %>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -1,4 +1,4 @@
-<% @title = "House rules" %>
+<% @title = "Conditions of use" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
   <h1><%=@title %></h1>
@@ -79,6 +79,16 @@
       Do not seek to evade the actions of site administrators by, for example,
       creating new accounts to evade a ban, or a rate-limiting cap, or by
       republishing material which you know has been removed by moderators.
+    </li>
+    <li>
+      As with all mySociety services and activities, users of WhatDoTheyKnow 
+      must abide by the organisation's <a href="https://www.mysociety.org/code-of-conduct/">Code of Conduct</a>. 
+      This code applies to all activity related to the site, including correspondence with our 
+      staff and volunteers. Where a user sends a message to a member of our team 
+      that is intended to harass, threaten, abuse or distress, we will, at our discretion, 
+      cease communication. We may also ban the correspondent from future use of WhatDoTheyKnow.
+      Where a message  of particular concern, we will forward details 
+      of the correspondence to the police.
     </li>
   </ul>
   <p>

--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -469,7 +469,7 @@
       "Bob", “Bobby”, "Robert" or "R.J.".
     </li>
     <li>
-      Women may use their <a href="https://www.whatdotheyknow.com/help/glossary#maiden_name">maiden name</a>.
+      If you have one, you may use your <%= link_to 'maiden name', help_glossary_path(anchor: 'maiden_name') %>.
     </li>
     <li>
       In most cases, you may use any name by which you are “widely known and/or


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1678

## What does this do?

This makes a reasonably simple change to the language surrounding maiden names in the [real name](https://www.whatdotheyknow.com/help/privacy#real_name) section of the privacy notice.

## Why was this needed?

The existing language, which is believed to relate to very old guidance, is gendered - whereas, maiden names are not, in themselves, gender specific.

Making this change helps make our guidance more inclusive. 🏳️‍🌈🏳️‍⚧️

## Implementation notes

Just a standard change of a couple of words.

I did notice that the hyperlink here was in a different format to the others, so I've tidied that up.

From:

```html
<a href="https://www.whatdotheyknow.com/help/glossary#maiden_name">maiden name</a>
```

To: 

```ruby
<%= link_to 'maiden name', help_glossary_path(anchor: 'maiden_name') %>
```

## Screenshots

N/A

## Notes to reviewer

N/A