### PR TITLE
[#1678] Make maiden name language more inclusive. 🏳️‍🌈🏳️‍⚧️

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -470,7 +470,7 @@
       "Bob", “Bobby”, "Robert" or "R.J.".
     </li>
     <li>
-      Women may use their <a href="https://www.whatdotheyknow.com/help/glossary#maiden_name">maiden name</a>.
+      If you have one, you may use your <%= link_to 'maiden name', help_glossary_path(anchor: 'maiden_name') %>.
     </li>
     <li>
       In most cases, you may use any name by which you are “widely known and/or


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1678

## What does this do?

This makes a reasonably simple change to the language surrounding maiden names in the [real name](https://www.whatdotheyknow.com/help/privacy#real_name) section of the privacy notice.

## Why was this needed?

The existing language, which is believed to relate to very old guidance, is gendered - whereas, maiden names are not, in themselves, gender specific.

Making this change helps make our guidance more inclusive. 🏳️‍🌈🏳️‍⚧️

## Implementation notes

Just a standard change of a couple of words.

I did notice that the hyperlink here was in a different format to the others, so I've tidied that up.

From:

```html
<a href="https://www.whatdotheyknow.com/help/glossary#maiden_name">maiden name</a>
```

To: 

```ruby
<%= link_to 'maiden name', help_glossary_path(anchor: 'maiden_name') %>
```

## Screenshots

N/A

## Notes to reviewer

This replaces #1683 - apologies.