### PR TITLE
Add page for reporting data breaches

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -57,7 +57,8 @@ for patch in ['patch_mailer_paths.rb',
               'help_page_history.rb',
               'public_body_questions.rb',
               'school_late_calculator.rb',
-              'volunteer_contact_form.rb']
+              'volunteer_contact_form.rb',
+              'data_breach.rb']
     require File.expand_path "../#{patch}", __FILE__
 end
 

--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -9,6 +9,13 @@ Rails.application.routes.draw do
   get '/ni' => redirect('/body?tag=ni', status: 302)
   get '/northern-ireland' => redirect('/body?tag=ni', status: 302)
 
+  get '/help/report-a-data-breach' => 'help#report_a_data_breach',
+      as: :help_report_a_data_breach
+  post '/help/report-a-data-breach' => 'help#report_a_data_breach_handle_form_submission',
+      as: :help_report_a_data_breach_handle_form_submission
+  get '/help/report-a-data-breach/thank-you' => 'help#report_a_data_breach_thank_you',
+      as: :help_report_a_data_breach_thank_you
+
   get "/help/ico-guidance-for-authorities" => redirect("https://ico.org.uk/media/for-organisations/documents/how-to-disclose-information-safely-removing-personal-data-from-information-requests-and-datasets/2013958/how-to-disclose-information-safely.pdf"),
       as: :ico_guidance
 

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -2,8 +2,9 @@
 Rails.configuration.to_prepare do
   HelpController.class_eval do
     prepend VolunteerContactForm::ControllerMethods
+    prepend DataBreach::ControllerMethods
 
-    before_action :set_history, except: :index
+    before_action :set_history, except: [:index, :report_a_data_breach_handle_form_submission]
 
     def principles; end
     def house_rules; end

--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -1,0 +1,67 @@
+module DataBreach
+  class Report
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :url, :string
+    attribute :special_category_or_criminal_offence_data, :boolean
+    attribute :message, :string
+    attribute :contact_email, :string
+    attribute :is_public_body, :boolean
+
+    validates_presence_of :url, :message => N_("Please enter the URL of the page where the data breach occurred")
+    validates_presence_of :message, :message => N_("Please describe the data breach")
+
+    validates :is_public_body, inclusion: { in: [true, false], message: N_("Please confirm whether you are reporting on behalf of the public body responsible for the data breach") }
+  end
+
+  module ControllerMethods
+    def report_a_data_breach
+      @report = Report.new
+    end
+
+    def report_a_data_breach_handle_form_submission
+      @report = Report.new(report_params)
+      if @report.valid?
+        # TODO: Handle a successful submission
+        ContactMailer.data_breach(@report, current_user).deliver_now
+
+        # Redirect to a thank you page
+        flash[:notice] = _('Thank you for reporting a data breach. We will review your report and get back to you if we need any more information.')
+        redirect_to help_report_a_data_breach_thank_you_path
+      else
+        render :report_a_data_breach
+      end
+    end
+
+    def report_a_data_breach_thank_you; end
+
+    private
+
+    def report_params
+      params.require(:data_breach_report).permit(:url, :special_category_or_criminal_offence_data, :message, :contact_email, :is_public_body)
+    end
+  end
+
+  module MailerMethods
+    def data_breach(report, logged_in_user)
+      @report = report
+      @logged_in_user = logged_in_user
+
+      # From is an address we control so that strict DMARC senders don't get
+      # refused
+      from = MailHandler.address_from_name_and_email(
+        'WhatDoTheyKnow.com data breach report', blackhole_email
+      )
+
+      # Set a header so we can filter in the mailbox
+      headers['X-WDTK-Contact'] = 'wdtk-data-breach-report'
+
+      mail(
+        from: from,
+        to: contact_from_name_and_email,
+        subject: _('New data breach report'),
+      )
+    end
+  end
+end

--- a/lib/mailer_patches.rb
+++ b/lib/mailer_patches.rb
@@ -2,5 +2,6 @@
 Rails.configuration.to_prepare do
   ContactMailer.class_eval do
     prepend VolunteerContactForm::MailerMethods
+    prepend DataBreach::MailerMethods
   end
 end

--- a/lib/views/contact_mailer/data_breach.text.erb
+++ b/lib/views/contact_mailer/data_breach.text.erb
@@ -1,0 +1,18 @@
+Someone has submitted a data breach report.
+
+URL: <%= @report.url %>
+Special category or criminal offence data: <%= @report.special_category_or_criminal_offence_data ? 'Yes' : 'No' %>
+DPO email: <%= @report.contact_email %>
+Reporting on behalf of public body: <%= @report.is_public_body ? 'Yes' : 'No' %>
+
+Message:
+<%= @report.message %>
+
+---------------------------------------------------------------------
+<%= _('Message sent using {{site_name}} data breach form, ',
+      :site_name => site_name.html_safe) -%>
+<%= @logged_in_user ?
+  _("logged in as user {{user_name}}",
+    :user_name => user_url(@logged_in_user)) :
+  _("not logged in") %>
+---------------------------------------------------------------------

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -110,7 +110,12 @@
       </li>
 
       <li>
-      <%= link_to_unless_current 'ICO officers', help_ico_officers_path %>
+        <%= link_to_unless_current 'ICO officers', help_ico_officers_path %>
+      </li>
+
+      <li>
+        <%= link_to_unless_current 'Report a data breach',
+                                   help_report_a_data_breach_path %>
       </li>
     </ul>
 

--- a/lib/views/help/report_a_data_breach.html.erb
+++ b/lib/views/help/report_a_data_breach.html.erb
@@ -1,0 +1,91 @@
+<h1>Report a data breach</h1>
+
+<% @title = "Report a data breach" %>
+
+<%= render partial: 'sidebar' %>
+
+<div id="left_column_flip" class="left_column_flip">
+  <h2>Use this form to report a data breach</h2>
+
+  <p>If you believe that you have identified a data breach in a response that has been provided to a request made via WhatDoTheyKnow, please use this form to report the incident.</p>
+
+  <%= form_with model: @report, url: help_report_a_data_breach_handle_form_submission_path, html: { class: 'contact-form' } do |f| %>
+
+    <%= foi_error_messages_for :report %>
+
+    <p>
+      <%= f.label :url, "Please provide a link to the request or attachment containing the data breach." %>
+      <span class="form_item_note">
+        Alternatively you can provide the request's email address, if known.
+        <br>
+        <br>
+      </span>
+      <%= f.text_field :url %>
+    </p>
+
+    <p>
+      <%= f.label :message, "Please provide details about this data breach" %>
+      <%= f.text_area :message, rows: 3 %>
+    </p>
+
+    <p>
+        <%= f.check_box :special_category_or_criminal_offence_data, id: 'special_category_or_criminal_offence_data' %>
+        <label for="special_category_or_criminal_offence_data" class="form_label">
+          This data breach involves special category or criminal offence data
+        </label>
+    </p>
+
+    <p>
+      <%= f.label :contact_email, "Please provide the email address for the Data Protection Officer (if known):" %>
+      <%= f.text_field :contact_email %>
+    </p>
+
+    <p>
+        <label>Are you reporting on behalf of the public body responsible for the data breach?</label>
+        <%= f.label :is_public_body_yes, class: 'form_inline' do %>
+          <%= f.radio_button :is_public_body, true %>
+          Yes
+        <% end %>
+        <%= f.label :is_public_body, class: 'form_inline' do %>
+          <%= f.radio_button :is_public_body, false %>
+          No
+        <% end %>
+    </p>
+
+    <div class="actions">
+      <%= f.submit "Send" %>
+    </div>
+
+    <%= render partial: 'contact_form_privacy_notice' %>
+  <% end %>
+
+  <h2 id="report_breach_further_information">
+    Further information
+    <a href="#report_breach_further_information">#</a>
+  </h2>
+
+  <p>
+    We take all incidents reported via this form extremely seriously, and aim to acknowledge and investigate all reports promptly.
+  </p>
+  <p>
+    Special Category data and Criminal Offence data are defined by Section 10 of the Data Protection Act 2018.
+  </p>
+  <p>
+    Special Category information includes personal data revealing racial or ethnic origin, political opinions, religious or philosophical beliefs, trade union membership, health, information about a person’s sex life or sexual orientation.
+  </p>
+  <p>
+    Criminal Offence data includes the personal information of offenders or suspected offenders, relating to criminal convictions and offences, including the investigation of, or proceedings for, any offence or alleged offence.
+  </p>
+  <p>
+    Please see the relevant ICO Guidance for more information:
+    <ul>
+      <li><a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/lawful-basis-for-processing/special-category-data/">Special Category data</a></li>
+      <li><a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/lawful-basis-for-processing/criminal-offence-data/">Criminal Offence data</a></li>
+    </ul>
+  </p>
+
+
+  <%= render partial: 'history' %>
+
+  <div id="hash_link_padding"></div>
+</div>

--- a/lib/views/help/report_a_data_breach_thank_you.html.erb
+++ b/lib/views/help/report_a_data_breach_thank_you.html.erb
@@ -1,0 +1,10 @@
+
+<% @title = "Thank you for reporting a data breach" %>
+
+<%= render partial: 'sidebar' %>
+
+<div id="left_column_flip" class="left_column_flip">
+  <h1>Thank you for reporting a data breach</h1>
+
+  <p>We will review your report and take appropriate action.</p>
+</div>

--- a/spec/integration/report_a_data_breach_spec.rb
+++ b/spec/integration/report_a_data_breach_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../spec_helper'
+require 'integration/alaveteli_dsl'
+
+RSpec.describe 'report a data breach page' do
+  it 'displays a form to the visitor' do
+    visit help_report_a_data_breach_path
+
+    expect(page).to have_css('input[name="data_breach_report[url]"]')
+    expect(page).to have_css('textarea[name="data_breach_report[message]"]')
+    expect(page).to have_css('input[name="data_breach_report[contact_email]"]')
+    expect(page).to have_css('input[name="data_breach_report[url]"]')
+  end
+
+  it 'validates the form' do
+    visit help_report_a_data_breach_path
+
+    click_button 'Send'
+
+    expect(ActionMailer::Base.deliveries).to be_empty
+    expect(page).to have_content('Please enter the URL of the page where the data breach occurred')
+    expect(page).to have_content('Please describe the data breach')
+    expect(page).to have_content('Please confirm whether you are reporting on behalf of the public body responsible for the data breach')
+  end
+
+  it 'user can submit the form and the result is emailed' do
+    visit help_report_a_data_breach_path
+    fill_in 'data_breach_report[url]', with: 'https://example.com'
+    fill_in 'data_breach_report[message]', with: 'A data breach occurred'
+    fill_in 'data_breach_report[contact_email]', with: 'test@example.com'
+    choose 'data_breach_report[is_public_body]', option: 'true'
+    check 'data_breach_report[special_category_or_criminal_offence_data]'
+    click_button 'Send'
+
+    expect(page).to have_content('Thank you for reporting a data breach')
+
+    last_email = ActionMailer::Base.deliveries.last
+    expect(last_email.from).to eq(['do-not-reply-to-this-address@localhost'])
+    expect(last_email.to).to eq(['postmaster@localhost'])
+    expect(last_email.subject).to eq('New data breach report')
+    expect(last_email.body).to include('URL: https://example.com')
+    expect(last_email.body).to include('Special category or criminal offence data: Yes')
+    expect(last_email.body).to include('DPO email: test@example.com')
+    expect(last_email.body).to include('Reporting on behalf of public body: Yes')
+    expect(last_email.body).to include("Message:\nA data breach occurred")
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/1602

## What does this do?

This adds a new help page containing a form for reporting data breaches. When submitted the form is emailed to the site admins.

## Implementation notes

It follows a similar pattern to the volunteer contact form, that was added in #1208, but uses a new POST endpoint for handling the form submission.

## Screenshots

<img width="1115" alt="image" src="https://github.com/mysociety/whatdotheyknow-theme/assets/22996/ef8b1b43-e852-44a1-ad77-50f3a74ee497">


## Notes to reviewer

Opening this pull request for feedback and to check that this is heading in the right direction.

There's still a bit more to do on this, namely:

- [x] Write some copy for the high-level description/introduction that will go above the form
- [x] Write some copy for the **Further information** section below the form
- [x] Add some tests (wanted to check I was heading in the right direction before adding these)
- [x] Design? Think what's there is good enough to start with, but happy to hear any feedback on how it could be improved