### PR TITLE
Add Sandwell MBC to `model_patches.rb`

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -160,6 +160,7 @@ Rails.configuration.to_prepare do
     Information-rights@nhsbsa.nhs.uk
     noreply-horsham@axlr8.com
     donotreply@plymouth.gov.uk
+    do_not_reply@sandwell.gov.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1700

## What does this do?

Adds the no-reply mailbox used by Sandwell MBC in recent responses, to the `invalid_reply_addresses` list used by `ReplyToAddressValidator`.

## Why was this needed?

Sandwell are issuing responses (via Granicus / Firmstep), sent from a mailbox that does not accept replies.

## Implementation notes

Nothing of note.

## Screenshots

N/A

## Notes to reviewer

N/A
