### PR TITLE
1706 add a help page on exemptions

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -44,4 +44,7 @@ Rails.application.routes.draw do
   
   get '/help/environmental_information' => 'help#environmental_information',
       as: :help_environmental_information
+  
+  get '/help/exemptions' => 'help#exemptions',
+      as: :help_exemptions
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -14,6 +14,7 @@ Rails.configuration.to_prepare do
     def ico_officers; end
     def glossary; end
     def environmental_information; end
+    def exemptions; end
     
     private
 

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -54,6 +54,9 @@
       <li>
         <%= link_to_unless_current "Environmental Information", help_environmental_information_path %>
       </li>
+      <li>
+        <%= link_to_unless_current "Exemptions", help_exemptions_path %>
+      </li>
       <% if feature_enabled?(:alaveteli_pro) %>
         <li><%= link_to_unless_current "Pro", help_pro_path %></li>
       <% end %>

--- a/lib/views/help/exemptions.html.erb
+++ b/lib/views/help/exemptions.html.erb
@@ -3,7 +3,9 @@
 <div id="left_column_flip" class="left_column_flip">
   <h1 id="Exemptions"><%= @title %></h1>
   <p>This is a short guide to the reasons that authorities can refuse requests for information under the Freedom of Information Act 
-  (FOI) and the Freedom of Information (Scotland) Act (FOISA).</p>
+  (FOI) and the Freedom of Information (Scotland) Act (FOISA). You can find information about what to do if your request has been 
+  refused, including advice on how to challenge some of the exemptions listed below on our &lsquo;
+  <a href="<%= help_general_path(:template => 'unhappy') %>">Unhappy about the response you got?</a>&rsquo; help page.</p>
   <h2 id="public">
     📖 Information that’s already public
     <a href="#public">#</a>

--- a/lib/views/help/exemptions.html.erb
+++ b/lib/views/help/exemptions.html.erb
@@ -1,0 +1,291 @@
+<% @title = "Exemptions" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+  <h1 id="Exemptions"><%= @title %></h1>
+  <p>This is a short guide to the reasons that authorities can refuse requests for information under the Freedom of Information Act 
+  (FOI) and the Freedom of Information (Scotland) Act (FOISA).</p>
+  <h2 id="public">
+    📖 Information that’s already public
+    <a href="#public">#</a>
+  </h2>
+  <p>Things that are already published somewhere else e.g information that’s available to everyone online or that is in a book 
+    or newspaper. This includes information referred to in a public authority’s publication scheme. The publication scheme sets 
+    out a public authority’s commitment to make some types of information routinely available on request.
+  </p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/21">Section 21</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/25">Section 25</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection25InformationOtherwiseAccessible.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: No</li>
+  </ul>
+  <h2 id=security_services>
+    🕵️‍♀️ Information about the work of the Security Services
+    <a href="#security_services">#</a>
+  </h2>
+  <p>Information relating to MI5, MI6, GCHQ and certain other bodies. The public interest test only needs to be carried out when 
+  someone has asked for very old records.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/23">Section 23</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-23-security-bodies/">ICO guidance</a></li>
+    <li>FOISA: No exact equivalent</li>
+    <li>Public Interest Test: Sometimes</li>
+  </ul>
+  <h2 id="court">
+    📄 Court records
+    <a href="#court">#</a>
+  </h2>
+  <p>Any court records, for example records of what was said in court, or documents that have been submitted by parties involved in 
+  a court case. There are separate access regimes for getting access to these. Information relating to court building and facilities will 
+  not normally be covered by this exemption.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/32">Section 32</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619028/s32-court-inquiry-and-arbitration-records.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/37">Section 37</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection37CourtRecords.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: No</li>
+  </ul>
+  <h2 id="parliamentary_privilege">
+    🗳️ Information covered by Parliamentary privilege
+    <a href="#parliamentary_privilege">#</a>
+  </h2>
+  <p>Information relating to the proceedings of both Houses of Parliament. Parliamentary privilege helps to protect members of the 
+  House of Commons and the House of Lords, so they can do their jobs without any external interference. Ultimately, the Speaker of 
+    the House of Commons and the Lord Speaker decide what information is or isn’t privileged.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/34">Section 34</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1161/section_34_parliamentary_privilege.pdf">ICO guidance</a></li>
+    <li>FOISA: No equivalent</li>
+    <li>Public Interest Test: No</li>
+  </ul>
+  <h2 id="confidence">
+    🤫 Information provided in confidence
+    <a href="#confidence">#</a>
+  </h2>
+  <p>Information given to a public authority by another person or organisation in confidence. The information is only exempt if the 
+  provider of the information could bring a legal case against the public authority for breach of confidence and the case would be 
+  likely to succeed. There is a public interest defence to breach of confidence claims, so you can ask the authority to assess the 
+  public interest on that basis.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/41">Section 41</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(2)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: No</li>
+  </ul>
+  <h2 id="legal">
+    👮 Information that can’t legally be disclosed
+    <a href="#legal">#</a>
+  </h2>
+  <p>Information where disclosure is prohibited by law or would result in contempt of court. Contempt of court refers to a situation 
+  where someone’s actions risk unfairly influencing a court case. This could include disobeying a court order.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/44">Section 44</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619033/s44-prohibitions-on-disclosure.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/26">Section 26</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection26ProhibitionsOnDisclosure.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: No</li>
+  </ul>
+  <h2 id="future_publication">
+    🗓️ Information that they say they are going to publish
+    <a href="#future_publication">#</a>
+  </h2>
+  <p>Information that an authority “plans” to publish in the future. The information that they are intending to publish has to be 
+  the same as the information that has been asked for. An authority that uses this exemption is not under any legal obligation to 
+  publish the information at a later date. For Scottish public authorities, the planned publication must be within 12 weeks of the 
+  request date. For all other public authorities in the UK, this exemption applies even if no publication date has been set.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22">Section 22</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1172/information-intended-for-future-publication-and-research-information-sections-22-and-22a-foi.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/27">Section 27</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection27InformationIntendedforFuturePublication.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="research">
+    🔬 Ongoing research
+    <a href="#research">#</a>
+  </h2>
+  <p>Information which has been collected or prepared as part of a programme of research where disclosure would have a negative 
+  impact on institutions or people who are involved in the research. The exemption only applies if the research programme is still 
+  continuing and if there is an intention to publish the research.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22A">Section 22A</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1172/information-intended-for-future-publication-and-research-information-sections-22-and-22a-foi.pdf">ICO guidance</a></li>
+    <li>FOISA: No equivalent</li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="national_security">
+    💣 Information about national security
+    <a href="#national_security">#</a>
+  </h2>
+  <p>Information relating to the security of the United Kingdom. This can include information relating to the security of 
+  Government buildings and the prevention of terrorism.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/24">Section 24</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-24-safeguarding-national-security/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="defence">
+    🪖 Information about defence
+    <a href="#defence">#</a>
+  </h2>
+  <p>Information relating to the defence of the UK and the Channel Islands and the effectiveness of the UK armed forces. 
+  This can also include information about the armed forces of the UK’s allies.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/26">Section 26</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-26-defence/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(4)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="international_relations">
+    🌍 Information about international relations
+    <a href="#international_relations">#</a>
+  </h2>
+  <p>Communications with other countries, such as correspondence between diplomats, and other information that an authority thinks 
+  would harm relations between the UK and other countries if it was released.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/27">Section 27</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-27-international-relations/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/32">Section 32</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection32InternationalRelations.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="uk_relations">
+    🤝 Relations between the different governments within the UK
+    <a href="#uk_relations">#</a>
+  </h2>
+  <p>Communications between the UK Government and the devolved administrations in Wales, Scotland, and Northern Ireland.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/28">Section 28</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-28-relations-within-the-uk/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/28">Section 28</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection28RelationswithintheUnitedKingdom.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="economy">
+    💰 Information that could harm the economy
+    <a href="#economy">#</a>
+  </h2>
+  <p>Information that an authority thinks would have a negative impact on the economic interests of the UK or any part of the UK 
+  if released. This covers information that would have a negative impact on the finances of the UK Government or any of the devolved 
+    administrations. This exemption can be used in cases where information could result in volatility in foreign exchange rates.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/29">Section 29</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619027/s29-the-economy.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(2)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="law_enforcement">
+    🚓 Information that could harm law enforcement activity
+    <a href="#law_enforcement">#</a>
+  </h2>
+  <p>Information that if released would have a negative impact on the work of the police and other public authorities whose job it 
+  is to enforce the law. This includes information about the detection and prevention of crime and also information about catching 
+  and prosecuting people who are suspected to have committed crimes. In addition, this also covers immigration controls, the 
+  collection of taxes, the prison system, and certain types of civil proceedings.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/31">Section 31</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/35">Section 35</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection35LawEnforcement.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="investigations">
+    🔎 Criminal investigations
+    <a href="#investigations">#</a>
+  </h2>
+  <p>Information about formal investigations carried out by a public authority to find out whether or not a person should be charged 
+  with a crime or whether or not a person is guilty of a crime. This can apply to information about investigations that have already 
+  finished as well as current investigations.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/30">Section 30</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/34">Section 34</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection34InvestigationsbyScottishPublicAuthoritiesandProceedings.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="audit">
+    ✅ Audit information
+    <a href="#audit">#</a>
+  </h2>
+  <p>Any information that could harm a public authority’s ability to carry out an effective audit of another public authority. 
+  This covers formal ‘value for money’ reviews as well as the auditing of accounts.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/33">Section 33</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1210/public-audit-functions-s33-foi-guidance.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/40">Section 40</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/Briefing_Section40AuditFunctions.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="policy_formation">
+    🗄️ Information about the inner workings of Government
+    <a href="#policy_formation">#</a>
+  </h2>
+  <p>This covers information about the creation of government policies and correspondence sent to and from ministers. It applies 
+  to the UK Government and to the devolved administrations. The exemptions also cover information about the operation of private 
+  ministerial offices and advice from the government’s senior legal advisers who are known as the Law Officers.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/35">Section 35</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/29">Section 29</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection29FormulationofScottishAdministrationPolicy.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="health_and_safety">
+    👩‍⚕️ Health and safety information
+    <a href="#health_and_safety">#</a>
+  </h2>
+  <p>Information that, if released, could put someone’s health or safety at risk. This includes risks to both physical and mental health.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/38">Section 38</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="environmental">
+    🐻 Environmental information
+    <a href="#environmental">#</a>
+  </h2>
+  <p>You can have environmental information, but it needs to be handled under the Environmental Information Regulations (EIR) or the 
+  Environmental Information (Scotland) Regulations (EISR). This means it is exempt under FOI. This is good news for requesters 
+  because your rights under EIR and EISR are much stronger.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/39">Section 39</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1043419/exemption-for-environmental-information-section-39.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(2)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="legal_privilege">
+    ⚖️ Legally privileged information
+    <a href="#legal_privilege">#</a>
+  </h2>
+  <p>Information that is covered by legal privilege, such as legal advice and communications between an organization and its 
+  lawyers. This also covers certain types of internal discussion that are closely linked to legal proceedings. This exemption 
+  exists so that people are able to talk openly with their lawyers and receive appropriate legal advice.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/42">Section 42</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1208/legal_professional_privilege_exemption_s42.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="commercial">
+    🏭 Information that could harm commercial interests
+    <a href="#commercial">#</a>
+  </h2>
+  <p>Information on trade secrets (such as secret recipes) or information that could harm the commercial interests of any company or other business. The authority must show that the release of the information would directly cause the harm being claimed.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/43">Section 43</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Yes</li>
+  </ul>
+  <h2 id="royal">
+    👑 Communications with the Royal Family and awarding of honours
+    <a href="#royal">#</a>
+  </h2>
+  <p>Communications to and from the King, the Royal Family, and the Royal Household. This also covers information relating to the 
+  awarding of honours such as knighthoods and seats in the House of Lords (peerages).</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/37">Section 37</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/communications-with-her-majesty-and-the-awarding-of-honours-section-37/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/41">Section 41</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection41CommunicationsWithHerMajestyetcandHonours.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Sometimes</li>
+  </ul>
+  <h2 id="personal_information">
+    🙋 Personal information
+    <a href="#personal_information">#</a>
+  </h2>
+  <p>Your own or someone else's personal information. The exemption only applies if the person can be identified, e.g., because the 
+  data includes the person’s name or an identifier such as National Insurance number or email address. This is only relevant for 
+  people who are still alive at the time the request is made. This exemption exists to protect people’s right to privacy. The law 
+  on how personal data can be used and stored in the UK is set out in a law called UK GDPR.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/40">Section 40</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2619056/s40-personal-information-section-40-regulation-13.pdf">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/38">Section 38</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection38PersonalInformationGDPR.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Sometimes</li>
+  </ul>
+  <h2 id="public_affairs">
+    🙃 Information that could be prejudicial to the effective conduct of public affairs
+    <a href="#public_affairs">#</a>
+  </h2>
+  <p>Information that the authority claims could undermine the principle of collective responsibility, discourage public officials 
+  from saying what they really think, or make it more difficult for the public authority to operate effectively. Outside of 
+  Scotland, an authority can’t use this exemption unless the qualified person says it is OK to do so. The qualified person 
+    is usually a minister or chief executive. If this is used against you, it’s quite hard to overturn.</p>
+  <ul>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/36">Section 36</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/section-36-prejudice-to-the-effective-conduct-of-public-affairs/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/30">Section 30</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection30PrejudicetotheEffectiveConductofPublicAffairs.pdf">OSIC guidance</a></li>
+    <li>Public Interest Test: Sometimes</li>
+  </ul>
+  <%= render partial: 'history' %>
+
+  <div id="hash_link_padding"></div>
+</div>


### PR DESCRIPTION
## Relevant issue(s)
#1706
## What does this do?
Adds a help page about the various FOI and FOISA exemptions, with links to guidance
## Why was this needed?
We had no way of linking users to guidance on specific issues. Help people to understand what they can and can't get released under FOI
## Implementation notes

## Screenshots
<img width="1225" alt="Screenshot 2023-06-14 at 14 37 44" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/87f45791-f474-4588-8933-5bf79b05bab0">
<img width="841" alt="Screenshot 2023-06-14 at 14 38 01" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/7d927e01-51a0-4ed0-9bc8-412f6a0f3372">
<img width="678" alt="Screenshot 2023-06-14 at 14 38 13" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/490ef58a-a77e-4243-9447-73c2a2bc2b37">
## Notes to reviewer
