### PR TITLE
Links from students' union pages to parent institutions

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -72,6 +72,13 @@
   <% end %>
 <% end %>
 
+<% if public_body.has_tag?('su_parent') %>
+  <% public_body.get_tag_values('su_parent').each do |tag_value| %>
+      <%= link_to _('Parent institution'),
+                    "https://www.whatdotheyknow.com/body/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <% if public_body.has_tag?('lei') %>
   <% public_body.get_tag_values('lei').each do |tag_value| %>
       <%= link_to _('Legal Entity Identifier'),


### PR DESCRIPTION
Links from students' unions pages to the parent institution e.g. from University of Lincoln to University of Lincoln Students' Union.

## Relevant issue(s)
See above.

## What does this do?
See above.

## Why was this needed?
See above.

## Implementation notes
None.

## Screenshots
None.

## Notes to reviewer
None.