### PR TITLE
1112 broken links to ico guidance in the help pages following ico website changes

### DIFF
--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -100,7 +100,7 @@
         </li>
         <li>
           The Information Commissioner’s
-          <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#1">
+          <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/guide-to-freedom-of-information/receiving-a-request/">
           guidance for organisations</a> says <i>“A
           request must ... include an address for correspondence. This need not
           be the person’s residential or work address - it can be <strong>any
@@ -108,16 +108,14 @@
           address or <strong>email address;</strong>”</i>
         </li>
         <li>
-          Paragraph 107 of the <a href="https://ico.org.uk/media/for-organisations/documents/1164/recognising-a-request-made-under-the-foia.pdf#page=22"
+         The <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/recognising-a-request-made-under-the-freedom-of-information-act-section-8/#dowehave"
               title="Recognising a request made under the FOIA">Information
           Commissioner’s Guidance on recognising a request</a> under the Freedom
           of Information Act now contains a section specifically on
           <%= link_to 'WhatDoTheyKnow', frontpage_path %> which states:
           <blockquote>
-            With respect to the address for correspondence, we consider the
-            <code>@whatdotheyknow.com</code> email address provided to
-            authorities when requests are made through the site to be a valid
-            contact address for the purposes of Section 8(1)(b).
+          We consider the <code>@whatdotheyknow.com</code> email address provided when requests are made through the site to be a 
+          valid contact address for the purposes of section 8(1)(b).
           </blockquote>
         </li>
         <li>

--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -53,7 +53,7 @@
     <p>Yn ôl y gyfraith, rhaid i chi ddefnyddio eich enw go iawn ar gyfer y cais iddo fod cais Rhyddid Gwybodaeth dilys. Gweler y cwestiwn nesaf ar gyfer dewisiadau eraill os nad ydych am i’ch enw llawn gael ei gyhoeddi. </p> </dd>
     <dt id="real_name">A allaf wneud cais Rhyddid Gwybodaeth gan ddefnyddio ffugenw? <a href="#real_name">#</a> </dt>
     <dd>
-    <p>Yn dechnegol, rhaid i chi ddefnyddio eich enw iawn ar gyfer eich cais iddo fod yn gais Rhyddid Gwybodaeth dilys yn ôl y gyfraith. Gweler y <a href="http://www.ico.org.uk/upload/documents/library/freedom_of_information/detailed_specialist_guides/name_of_applicant_fop083_v1.pdf">canllawiau hyn gan y Comisiynydd Gwybodaeth</a> (Ionawr 2009). </p>
+    <p>Yn dechnegol, rhaid i chi ddefnyddio eich enw iawn ar gyfer eich cais iddo fod yn gais Rhyddid Gwybodaeth dilys yn ôl y gyfraith. Gweler y <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/recognising-a-request-made-under-the-freedom-of-information-act-section-8/#whatismeant">canllawiau hyn gan y Comisiynydd Gwybodaeth</a> (Ionawr 2009). </p>
     <p>Fodd bynnag, mae’r un canllawiau hefyd yn dweud ei fod yn arfer da i’r awdurdod cyhoeddus ystyried cais a wnaed gan ddefnyddio ffugenw amlwg. Dylech gyfeirio at hyn os bydd awdurdod cyhoeddus yn gwrthod cais am eich bod yn defnyddio ffugenw.</p>
     <p>Byddwch yn ofalus, serch hynny, hyd yn oed os yw’r awdurdod yn dilyn yr arfer da hwn, bydd y ffugenw yn ôl pob tebyg yn ei gwneud yn amhosibl i chi gwyno wrth y Comisiynydd Gwybodaeth yn ddiweddarach am y ffordd y cafodd eich cais ei drin. </p>
     <p>Mae yna nifer o ddewisiadau da eraill yn hytrach na defnyddio ffugenw.</p> <ul>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1112 
## What does this do?
Fixes the broken ICO links found by @garethrees, tweaks the wording slightly to include the current quote.
## Why was this needed?
The links don't work!
## Implementation notes

## Screenshots

## Notes to reviewer
