### PR TITLE
Adding link to role specific pro pages

### DIFF
--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -16,7 +16,9 @@
                     <li role="presentation"><%= link_to 'Make a request', select_authority_path %></li>
                     <li role="presentation"><%= link_to 'Browse requests', request_list_successful_path %></li>
                     <li role="presentation"><%= link_to 'View authorities', list_public_bodies_default_path %></li>
-                    <li role="presentation"><%= link_to 'Journalist?', account_request_index_path %></li>
+                    <li role="presentation"><%= link_to 'Campaigners', pro_page_path('campaigners') %></li>
+                    <li role="presentation"><%= link_to 'Journalists', pro_page_path('journalists') %></li>
+                    <li role="presentation"><%= link_to 'Researchers', pro_page_path('researchers') %></li>
                 </ul>
                 <ul>
                     <li role="presentation"><%= link_to 'Help', help_path %></li>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #654 
## What does this do?
Adds link to the other landing pages
## Why was this needed?
To better market Pro
## Implementation notes

## Screenshots
<img width="1145" alt="Screenshot 2023-06-22 at 10 53 12" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/71aba7d1-2cc9-4538-a64c-8d8980eb9ab0">
## Notes to reviewer
The question marks looked ugly, so I switched to the plural instead. Could add "for" in front of these.