### PR TITLE
fixes alignment of warning text

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -2173,3 +2173,8 @@ $color_asktheeu_dark_green: #C4DDB9;
   background-color: $color_light_grey;
   text-align: left;
 }
+
+.message-text-length {
+  margin: 0.4em 0 0 0;
+}
+


### PR DESCRIPTION
## Relevant issue(s)
Fixes #546 
## What does this do?
Fixes the alignment using the fix suggested by @zarino 
## Why was this needed?
The text was out of alignment
## Implementation notes

## Screenshots
<img width="730" alt="Screenshot 2023-06-22 at 13 37 46" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/7ab8b2d3-a72e-43d0-b159-ca9b03aa1fb3">
<img width="527" alt="Screenshot 2023-06-22 at 13 40 00" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/7a92e2c3-7d6a-4e90-bca7-431d65d166c6">

## Notes to reviewer
Seems to look fine on mobile as tested using dev tools, because it just jumps above the button.