### PR TITLE
865 add link to privacy notice on contact forms

### DIFF
--- a/lib/views/help/_contact_form.cy.html.erb
+++ b/lib/views/help/_contact_form.cy.html.erb
@@ -80,5 +80,6 @@
         <%= hidden_field_tag(:submitted_contact_form, 1) %>
         <%= submit_tag "Anfon neges i dîm WhatDoTheyKnow", :data => { :disable_with => "Anfon…" } %>
     </div>
+    <%= render :partial => "contact_form_privacy_notice" %>
 
 <% end %>

--- a/lib/views/help/_contact_form.html.erb
+++ b/lib/views/help/_contact_form.html.erb
@@ -79,5 +79,6 @@
         <%= hidden_field_tag(:submitted_contact_form, 1) %>
         <%= submit_tag "Send message to WhatDoTheyKnow team", :data => { :disable_with => "Sending..." } %>
     </div>
+    <%= render :partial => "contact_form_privacy_notice" %>
 
 <% end %>

--- a/lib/views/help/_contact_form_privacy_notice.cy.html.erb
+++ b/lib/views/help/_contact_form_privacy_notice.cy.html.erb
@@ -1,0 +1,9 @@
+   <div class="changes">
+    <h2>
+      Sut ydym yn defnyddio eich gwybodaeth bersonol.
+    </h2>
+    <p>
+      Darllenwch ein <%= link_to 'hysbysiad preifatrwydd', help_privacy_path %> 
+      arlein i gael rhagor o wybodaeth ynghylch sut rydym ni’n trin eich gwybodaeth bersonol.
+    </p>
+  </div>

--- a/lib/views/help/_contact_form_privacy_notice.html.erb
+++ b/lib/views/help/_contact_form_privacy_notice.html.erb
@@ -1,0 +1,8 @@
+  <div class="changes">
+    <h2>
+      What will we do with your data? 
+    </h2>
+    <p>
+      We care about your data and will handle it in line with our <%= link_to 'Privacy Notice', help_privacy_path %>.
+    </p>
+  </div>

--- a/lib/views/help/_contact_volunteer_form.html.erb
+++ b/lib/views/help/_contact_volunteer_form.html.erb
@@ -89,4 +89,5 @@
     <%= hidden_field_tag(:submitted_contact_form, 1) %>
     <%= submit_tag "Send message to WhatDoTheyKnow team", data: { disable_with: "Sending..." } %>
   </div>
+  <%= render :partial => "contact_form_privacy_notice" %>
 <% end %>


### PR DESCRIPTION
## Relevant issue(s)
#865 
## What does this do?
Adds link to Privacy notice to contact forms
## Why was this needed?
There was no link to the privacy notice on the contact form
## Implementation notes

## Screenshots
<img width="770" alt="Screenshot 2023-06-23 at 11 23 36" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/ef598229-94b5-4fdd-b31e-d06f4b9fbee5">
<img width="796" alt="Screenshot 2023-06-23 at 11 23 44" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/d10bc696-0034-4126-b757-d8039856f7bb">
## Notes to reviewer
