### PR TITLE
[#11] Add FOISA help page

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -56,4 +56,7 @@ Rails.application.routes.draw do
 
   get '/help/search_engines' => 'help#search_engines',
       as: :help_search_engines
+
+  get '/help/about_foisa' => 'help#about_foisa',
+      as: :help_about_foisa
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -18,6 +18,7 @@ Rails.configuration.to_prepare do
     def exemptions; end
     def authority_performance_tracking; end
     def search_engines; end
+    def about_foisa; end
 
     private
 

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -60,6 +60,9 @@
       <li>
         <%= link_to_unless_current "Exemptions", help_exemptions_path %>
       </li>
+      <li>
+        <%= link_to_unless_current "About FOI in Scotland", help_about_foisa_path %>
+      </li>
       <% if feature_enabled?(:alaveteli_pro) %>
         <li><%= link_to_unless_current "Pro", help_pro_path %></li>
       <% end %>

--- a/lib/views/help/about_foisa.html.erb
+++ b/lib/views/help/about_foisa.html.erb
@@ -1,0 +1,165 @@
+<% @title = "Freedom of Information (Scotland) Act" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+  <h1 id="freedom_of_information_scotland_act"><%= @title %></h1>
+
+  <h2 id="what_is_FOISA">
+    What&nbsp;is&nbsp;the&nbsp;Freedom&nbsp;of&nbsp;Information&nbsp;(Scotland)&nbsp;Act&nbsp;2002?
+    <a href="#what_is_FOISA">#</a>
+  </h2>
+
+  <p>The Freedom of Information (Scotland) Act 2002, commonly referred to as FOISA, is a law that gives you the right to access information held by public authorities in Scotland. </p>
+
+  <h2 id="who_is_covered">
+    What organisations are covered?
+    <a href="#who_is_covered">#</a>
+  </h2>
+
+  <p>FOISA applies to a wide range of public authorities based in Scotland including;</p>
+  <ul>
+    <li>All 32 Scottish local authorities (councils)</li>
+    <li>The Scottish Government, the Scottish Parliament, and various executive agencies.</li>
+    <li>Universities, colleges, and other higher and further education institutions in Scotland</li>
+    <li>NHS organisations in Scotland</li>
+    <li>Police Scotland, the Scottish Police Authority and the Scottish Fire and Rescue Service</li>
+    <li>Companies that are wholly owned by Scottish public authorities<br><small>(<b>Note</b>: This usually only applies if the authorities are listed under <a href="https://www.legislation.gov.uk/asp/2002/13/schedule/1">schedule 1 of of the Act</a>.)</small></li>
+    <li>Registered Social Landlords (including <i>housing associations</i>)</li>
+  </ul>
+  <p>Some public authorities are only subject to the act in respect of certain public functions that they perform.</p>
+
+  <h2 id="exemptions">
+    Are there any exemptions?
+    <a href="#exemptions">#</a>
+  </h2>
+  <p>There are a number of exemptions in FOISA that allow public authorities to withhold information from you. These fall into two main types, qualified exemptions and absolute exemptions.</p>
+  <h3 id="qualified_exemptions">
+    Qualified exemptions
+    <a href="#qualified_exemptions">#</a>
+  </h3>
+  <p>Qualified exemptions require the authority to apply a public interest test. This means that even if the exemption applies, the public authority must decide if the public interest in disclosing the information outweighs the public interest in withholding it. If the public interest favours disclosure, then the information must be released to you. The qualified exemptions are:</p>
+  <h4 id="future_publication">
+    Information intended for future publication (section 27)
+    <a href="#future_publication">#</a>
+  </h4>
+  <p>An authority can withhold information that it plans to publish in the future. The information that they are intending to publish has to be the same as the information that you have asked for. The planned publication must be within 12 weeks of the request date, unless the information is intended to be published as part of academic research.</p>
+  <h4 id="uk_relations">
+    Relations within the United Kingdom (section 28)
+    <a href="#uk_relations">#</a>
+  </h4>
+  <p>Information can be withheld if releasing it would damage relations between the Scottish Government and the devolved administrations in Wales and Northern Ireland, or the UK Government.</p>
+  <h4 id="policy_formation">
+    Formulation of Scottish Administration Policy (section 29)
+    <a href="#policy_formation">#</a>
+  </h4>
+  <p>Information about the creation of Government policies and correspondence sent to and from Government ministers does not have to be released. This includes advice or requests for advice by any of the Law Officers.
+  </p>
+  <h4 id="conduct_of_public_affairs">
+    Prejudice to effective conduct of public affairs (section 30)
+    <a href="#conduct_of_public_affairs">#</a>
+  </h4>
+  <p>An authority can withhold information that it believes would undermine the principle of collective responsibility, discourage public officials from saying what they really think, or make it more difficult for the public authority to operate effectively.
+  </p>
+  <h4 id="national_security">
+    National security and defence (section 31)
+    <a href="#national_security">#</a>
+  </h4>
+  <p>Information can be withheld if it relates to the security of the United Kingdom. This can include information relating the security of Government buildings and the prevention of terrorism. Information can also be withheld if it would predjuice national defence or harm the operating capability of the armed forces.</p>
+  <h4 id="international_relations">
+    International relations (section 32)
+    <a href="#international_relations">#</a>
+  </h4>
+  <p>Authorities do not need to release communications with other countries, such as correspondence between diplomats, and other information that could harm relations between the UK and other countries.</p>
+  <h4 id="commercial_interests">
+    Commercial interests and the economy (section 33)
+    <a href="#commercial_interests">#</a>
+  </h4>
+  <p>Information on trade secrets, or information that could harm the commercial interests of any company or other business is exempt from disclosure. The authority must show that the release of the information would directly cause the harm being claimed. In addition, information that an authority thinks would have a negative impact on the economic interests of the UK or any part of the UK does not have to be released. This also covers information that would have a negative impact on the finances of the UK Government or any of the devolved administrations.
+  </p>
+  <h4 id="investigations">
+    Investigations by Scottish public authorities (section 34)
+    <a href="#investigations">#</a>
+  </h4>
+  <p>A public authority does not have to provide you with information about an investigation it is conducting to find out whether or not a person should be charged with a crime or whether or not a person is guilty of a crime. This can apply to information about investigations that have already finished as well as current investigations. 
+  </p>
+  <h4 id="law_enforcement">
+    Law enforcement (section 35)
+    <a href="law_enforcement">#</a>
+  </h4>
+  <p>Information does not have to be provided, if releasing it would have a negative impact on the work of the police and other public authorities whose job it is to enforce the law. This includes information about the detection and prevention of crime and also information about catching and prosecuting people who are suspected to have committed crimes.
+  </p>
+  <h4 id="health_and_safety">
+    Health, safety and the environment (section 39)
+    <a href="#health_and_safety">#</a>
+  </h4>
+  <p>An authority does not have to provide information that, if released, could put someone’s health or safety at risk. This includes risks to both physical and mental health. This exemption also covers environmental information, which is handled under the Environmental Information (Scotland) Regulations (EISR).
+  </p>
+  <h4 id="audit">
+    Audit functions (section 40)
+    <a href="#audit">#</a>
+  </h4>
+  <p>Any information that could harm a public authority’s ability to carry out an effective audit of another public authority.</p>
+  <h4 id="royal_correspondence">
+    Communications with the Royal Family and Honours (section 41)
+    <a href="#royal_correspondence">#</a>
+  </h4>
+  <p>This exemption applies to communications to and from the King, the Royal Family and the Royal Household, as well as information relating to the awarding of honours</p>
+  <h3 id="absolute_exemptions">
+    Absolute exemptions
+    <a href="#absolute_exemptions">#</a>
+  </h3>
+  <p>Absolute exemptions</h4> allow the public authority to withhold information without considering whether it would be in the public interest to release it.</p>    
+  <h4 id="publicly_available">
+    Information accessible by other means (Section 25)
+    <a href="#publicly_available">#</a>
+  </h4>
+  <p>An authority does not have to provide you with information that is already published somewhere else e.g information that’s available to everyone online or that is in a book or newspaper. This includes information referred to in a public authority’s publication scheme. The publication scheme sets out a public authority’s commitment to make some types of information routinely available on request. Information can be considered to be accessible by other means even if there is a charge to access it.
+  </p>
+  <h4 id="prohibited">
+    Prohibitions on disclosure (Section 26)
+    <a href="#prohibited">#</a>
+  </h4>
+  <p>Information can be withheld if disclosure is prohibited by law.</p>
+  <h4 id="court_records">
+    Court records (Section 37)
+    <a href="#court_records">#</a>
+  </h4>
+  <p>Court records are exempt from disclosure, including records of what was said in court, or documents that have been submitted by parties involved in a court case. There are separate access regimes for getting access to these.</p>
+ <h4 id="personal_information">
+  Personal Information (Section 38)
+  <a href="#personal_information">#</a>
+ </h4>
+ <p>An authority can refuse to provide you with your own or someone else's personal information. The exemption only applies if the person can be identified e.g. because the data includes the person’s name or an identifier such as National Insurance number or email address. Although this is an absolute exemption, the authority might carry out a public interest test when considering whether it would be fair to release third party personal information.</p>
+  <h2 id="unhappy">
+    What if I am unhappy with my response?
+    <a href="#unhappy">#</a>
+  </h2>
+  <p>If you are unhappy with a response that you have received, or you have not received a response at all, you can ask the authority to conduct an internal review. You need to ask for a review no later than 40 working days after the date that you received a response, or 60 working days after you made your request, in the event that the authority didn't reply at all.</p>
+  <p>
+  If you are unhappy with the outcome of the internal review, or if the authority has not responded to your request for a review, you can appeal to the Scottish Information Commissioner. You need to submit your appeal within 6 months of the date that you received the outcome of your request for a review. The Scottish Information Commissioner can not consider an appeal about a response to a request that was made to the Scottish Information Commissioner.
+  </p>
+  <h3>Good to know</h3>
+  <p>When asking for an internal review, you need to tell the authority <b><I>why</I></b> you want them to review their previous response. If you don't do this, the authority might refuse to carry out a review, which may mean you are unable to appeal to the Commissioner (if you need to).
+  </p>
+  <h2 id="Appeal">
+    How do I appeal to the Scottish Information Commissioner?
+    <a href="#appeal">#</a>
+  </h2>
+  <p>
+  You can contact the Scottish Information Commissioner by email at: <b><a href="mailto:enquiries@itspublicknowledge.info">enquiries@itspublicknowledge.info</a></b>, or by post:
+  </p>
+  <p>
+  Scottish Information Commissioner<br>
+  Kinburn Castle<br>
+  Doubledykes Road<br>
+  ST ANDREWS<br>
+  KY16 9DS<br>
+  </p>
+  <p>
+  You can also contact them for advice, by calling their helpline on <b>01334 464 610</b>, or if you use <abbr title="British Sign Language">BSL</abbr>, by using <a href="http://contactscotland-bsl.org">Contact Scotland BSL</a>.
+  </p>
+  <p>There is more information on how to appeal, including a form that you can use (if you'd like), on the <abbr title="Office of the Scottish Information Commissioner">OSIC</abbr> on their website, at: <a href="https://www.itspublicknowledge.info/appeal">https://www.itspublicknowledge.info/appeal</a>.</p>
+  </p>
+  <%= render partial: 'history' %>
+  <div id="hash_link_padding"></div>
+</div>
+


### PR DESCRIPTION
## Relevant issue(s)
#11 
## What does this do?
Adds a page about the Freedom of Information Scotland Act
## Why was this needed?
We don't have guidance about Scotland on the Site
## Implementation notes

## Screenshots
<img width="893" alt="Screenshot 2023-06-28 at 08 13 22" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/f0645506-c1c5-4161-b867-65531d5ed315">

<img width="811" alt="Screenshot 2023-06-28 at 08 13 44" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/b0534ade-2f89-44e4-8265-24ec1c46342d">
## Notes to reviewer
