### PR TITLE
Fix specs

### DIFF
--- a/spec/integration/spam_terms_integration_spec.rb
+++ b/spec/integration/spam_terms_integration_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'creating a request with spam terms' do
 
   before do
     File.write(Rails.root + 'tmp/spam_terms.txt', "Potato\n")
+    stub_request(:get, /research\.mysociety\.org/)
   end
 
   it 'redirects to home page if the user is not signed in' do

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -16,11 +16,12 @@ RSpec.describe RequestMailer do
       expected = <<-EOF.strip_heredoc
         -- the Test team
 
-        ----------------------------------------------------------
+        --------------------------------------------------------------------------------
 
-        Help WDTK - http://test.host/en/help/volunteers
+        WhatDoTheyKnow is a project of mySociety run by a small team of staff and
+        dedicated volunteers.
         EOF
-      expect(mail.body).to include(expected)
+      expect(mail.body.to_s.gsub(/\r/, '')).to include(expected)
     end
 
   end


### PR DESCRIPTION
While doing #1696 I noticed that some of the other specs were failing, this fixes them.

I've been running the specs from within my alaveteli install with the following command (I use docker):

```
docker-compose run --rm app bin/rspec lib/themes/whatdotheyknow-theme/spec
```

Would be nice if these tests could run automatically for this repo, but guessing that would mean getting alaveteli installed and setup as part of the testing process?