### PR TITLE
[#1730] Gracefully degrade legacy NHSBSA mailbox

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -162,6 +162,7 @@ Rails.configuration.to_prepare do
     donotreply@plymouth.gov.uk
     do_not_reply@sandwell.gov.uk
     request@ig.northlincs.gov.uk
+    nhsbsa.foirequests@nhs.net
   )
 
   User.content_limits = {


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1730 

## What does this do?

Adds NHSBSA email address to `ReplyToAddressValidator.invalid_reply_addresses`

## Why was this needed?

NHS Business Services Authority / PPD (body `1012`/`3301`) are changing from NHSMail, to their own domain. We need to handle this change so that users can continue to reply to older requests.

## Implementation notes

Nothing to note

## Screenshots

N/A

## Notes to reviewer

A slightly unusual change, as we wouldn't normally handle it like this - but it as the org is changing mail systems, this seems to be the 'cleanest' way to do it, as we can't rely on NHSMail redirects persisting.

Ideally, we'd have this in place for 3 July.