### PR TITLE
Update calls to universal analytics

### DIFF
--- a/lib/helper_patches.rb
+++ b/lib/helper_patches.rb
@@ -8,5 +8,13 @@ Rails.configuration.to_prepare do
     def is_contact_page?
       controller.controller_name == 'help' && controller.action_name == 'contact'
     end
+
+    def request_url_with_query
+      uri = URI.parse(request.original_url);
+      uri.query = URI.encode_www_form(
+        URI.decode_www_form(String(uri.query)).push(['query', @query])
+      );
+      uri.to_s
+    end
   end
 end

--- a/lib/views/general/_before_body_end.html.erb
+++ b/lib/views/general/_before_body_end.html.erb
@@ -10,7 +10,8 @@
 <% if @total_hits %>
   <%# we're on a search page; make it look to Google Analytics like we're using a query string, so it can track the search keywords %>
   <script type="text/javascript">
-    ga('set', 'anonymizeIp', true)
-    ga('send', 'pageview', '<%= request.fullpath %>?query=<%=u @query %>');
+    gtag('send', 'page_view', {
+      page_location: '<%= request_url_with_query %>'
+    });
   </script>
 <% end %>

--- a/lib/views/request/show.html.erb
+++ b/lib/views/request/show.html.erb
@@ -8,11 +8,6 @@
   <%= render partial: 'request_sent' %>
 <% end %>
 
-<% content_for :ga_pageview do %>
-  window.dataLayer = window.dataLayer || [];
-  ga('require', 'GTM-53XVLCX');
-<% end %>
-
 <%= render partial: 'request/ga_events' %>
 
 <%= render partial: 'request/hidden_request_messages' %>


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/sysadmin/issues/1768

## What does this do?

- Remove call to old Google Tag Manager experiment.
- Switching to GA4 so needs to replace calls to `ga` with `gtag`.

