### PR TITLE
Add GitHub CI and Rubocop actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,107 @@
+name: CI
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rspec:
+    name: Ruby ${{ matrix.ruby }} / PostgreSQL ${{ matrix.postgres }}
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { ruby: '3.2', postgres: 13.5 }
+
+    services:
+      postgres:
+        image: fixmystreet/postgres:${{ matrix.postgres }}
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+        - '5432:5432'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/alaveteli_test
+      RAILS_ENV: test
+
+    steps:
+    - name: Checkout Alaveteli
+      uses: actions/checkout@v2
+      with:
+        repository: mysociety/alaveteli
+        ref: develop
+        path: core
+        submodules: true
+        fetch-depth: 0
+
+    - name: Create Alaveteli theme directory
+      run: |
+        mkdir alaveteli-themes
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        path: alaveteli-themes/whatdotheyknow-theme
+
+    - name: Install packages
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install exim4-daemon-light
+        sudo apt-get -y install `cut -d " " -f 1 config/packages.ubuntu-focal | egrep -v "(^#|wkhtml|bundler|^ruby|^rake)"`
+      working-directory: core
+
+    - name: Install Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+        working-directory: core
+
+    - name: Setup database
+      run: |
+        psql postgres://postgres:postgres@localhost:5432 <<-EOSQL
+          CREATE DATABASE template_utf8 TEMPLATE template0 ENCODING "UTF-8";
+          UPDATE pg_database SET datistemplate=true WHERE datname='template_utf8';
+          CREATE DATABASE alaveteli_test TEMPLATE template_utf8;
+        EOSQL
+      working-directory: core
+
+    - name: Configure application and storage
+      run: |
+        cp config/general.yml-example config/general-whatdotheyknow-theme.yml
+        cp config/storage.yml-example config/storage.yml
+      working-directory: core
+
+    - name: Install theme
+      run: |
+        script/switch-theme.rb whatdotheyknow-theme
+        bundle exec rake themes:install
+      working-directory: core
+
+    - name: Migrate database
+      run: |
+        bundle exec rails db:migrate
+      working-directory: core
+
+    - name: Run tests
+      run: |
+        bundle exec rspec --format Fivemat lib/themes/whatdotheyknow-theme/spec
+      working-directory: core

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,38 @@
+name: RuboCop
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout Alaveteli
+      uses: actions/checkout@v2
+      with:
+        repository: mysociety/alaveteli
+        ref: develop
+        submodules: true
+        fetch-depth: 0
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        path: lib/themes/whatdotheyknow-theme
+
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
+        bundler-cache: true
+
+    - name: Run RuboCop linter
+      uses: reviewdog/action-rubocop@v1
+      with:
+        github_token: ${{ secrets.github_token }}
+        rubocop_flags: -DES lib/themes/whatdotheyknow-theme
+        rubocop_version: gemfile
+        rubocop_extensions: rubocop-performance:gemfile rubocop-rails:gemfile
+        level: warning


### PR DESCRIPTION
## What does this do?

Add GitHub CI and Rubocop actions

## Why was this needed?

Based on those in core Alaveteli. It would be good to get these running in themes as well to ensure we're deploying with confidence.

