### PR TITLE
Improve the glossary nav

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1763,6 +1763,14 @@ dd {
   }
 }
 
+#help_glossary {
+  .glossary-letters {
+    .no-entries {
+      color: $color_mid_grey;
+    }
+  }
+}
+
 .changes {
   background-color: darken($body-bg, 2%);
   border-radius: 2px;

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1765,6 +1765,21 @@ dd {
 
 #help_glossary {
   .glossary-letters {
+    margin-bottom: 1em;
+
+    a, .no-entries {
+      padding: 0.25em 0.3em;
+      border: 1px dotted $color_mid_grey;
+      font-family: monospace;
+
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+      background-color: $color_yellow;
+    }
+
     .no-entries {
       color: $color_mid_grey;
     }

--- a/lib/views/help/glossary.html.erb
+++ b/lib/views/help/glossary.html.erb
@@ -4,26 +4,36 @@
  <h1 id="top">Freedom of information glossary</h1>
  <p>This glossary provides guidance on some of the abbreviations and special terms used by <a href="#foi_officer">FOI officers</a> and transparency campaigners. This glossary also explains some of the terms used in our help pages. </p>
 <br/>
- <p>
-<a href="#letter_A">A</a>
-<a href="#letter_B">B</a>
-<a href="#letter_C">C</a>
-<a href="#letter_D">D</a>
-<a href="#letter_E">E</a>
-<a href="#letter_F">F</a>
-<a href="#letter_G">G</a>
-<a href="#letter_H">H</a>
-<a href="#letter_I">I</a>
-<a href="#letter_M">M</a>
-<a href="#letter_N">N</a>
-<a href="#letter_P">P</a>
-<a href="#letter_Q">Q</a>
-<a href="#letter_R">R</a>
-<a href="#letter_S">S</a>
-<a href="#letter_T">T</a>
-<a href="#letter_V">V</a>
-<a href="#letter_W">W</a>
-<a href="#letter_Z">Z</a> </p>
+
+<nav class="glossary-letters">
+  <a href="#letter_A">A</a>
+  <a href="#letter_B">B</a>
+  <a href="#letter_C">C</a>
+  <a href="#letter_D">D</a>
+  <a href="#letter_E">E</a>
+  <a href="#letter_F">F</a>
+  <a href="#letter_G">G</a>
+  <a href="#letter_H">H</a>
+  <a href="#letter_I">I</a>
+  <span class="no-entries">J</span>
+  <span class="no-entries">K</span>
+  <span class="no-entries">L</span>
+  <a href="#letter_M">M</a>
+  <a href="#letter_N">N</a>
+  <span class="no-entries">O</span>
+  <a href="#letter_P">P</a>
+  <a href="#letter_Q">Q</a>
+  <a href="#letter_R">R</a>
+  <a href="#letter_S">S</a>
+  <a href="#letter_T">T</a>
+  <span class="no-entries">U</span>
+  <a href="#letter_V">V</a>
+  <a href="#letter_W">W</a>
+  <span class="no-entries">X</span>
+  <span class="no-entries">Y</span>
+  <a href="#letter_Z">Z</a>
+</nav>
+
 <hr/>
 <br/>
 <h2 id="letter_A">A</h2>


### PR DESCRIPTION
It's a bit disorienting when you're looking for a letter and it's not next to the letter you were expecting because of the jump (e.g. I'm looking for "L", expecting it to be right of "K", but it's actually right of "I"). This PR adds missing letters, styling them with a muted colour so it's obvious there's no entries for that letter.

It also improves the styling, giving each letter a bit more of a target click space, highlights each letter as you focus (if it has entries).

<img width="785" alt="Screenshot 2023-07-05 at 10 08 55" src="https://github.com/mysociety/whatdotheyknow-theme/assets/282788/040750f2-7f7a-454f-b65a-f051cfb1b669">
