### PR TITLE
Move the blog up the frontpage

### DIFF
--- a/lib/views/general/_frontpage_extra.html.erb
+++ b/lib/views/general/_frontpage_extra.html.erb
@@ -1,4 +1,4 @@
 <%= render :partial => "frontpage_newsletter_signup" %>
+<%= render :partial => "frontpage_blog" if Blog.enabled? %>
 <%= render :partial => "frontpage_videos" %>
 <%= render :partial => "frontpage_articles" %>
-<%= render :partial => "frontpage_blog" if Blog.enabled? %>


### PR DESCRIPTION
More timely content feels like it should be further up the page, with scrolling giving you the more evergreen content.

<img width="1158" alt="Screenshot 2023-07-05 at 10 49 52" src="https://github.com/mysociety/whatdotheyknow-theme/assets/282788/468fdb8b-85c0-4e2c-a9d2-ed1098dc7287">
