### PR TITLE
Make correspondence headers sticky.

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -829,17 +829,17 @@ div.correspondence {
   box-shadow: 0 1px 2px rgba(0,0,0,0.25);
   border-radius: 5px;
   margin-bottom: 2.5em;
+  position: relative; // So we can position the rounded corners below
 
   &.collapsed {
     .correspondence__header {
-      border-radius: 0 0 5px 5px;
+      border-radius: 5px;
     }
   }
 }
 
 .incoming.correspondence {
   border: none;
-  border-top: 8px solid $incoming-correspondence-color;
   background-color: $incoming-correspondence-background;
   a.link_to_this {
     background-color: $incoming-correspondence-color;
@@ -848,10 +848,68 @@ div.correspondence {
 
 .outgoing.correspondence {
   border: none;
-  border-top: 8px solid $outgoing-correspondence-color;
   background-color: $outgoing-correspondence-background;
   a.link_to_this {
     background-color: $outgoing-correspondence-color;
+  }
+}
+
+/* Make the header sticky so it's always visible as you scroll through a
+ * message. */
+.correspondence__header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  border-radius: 5px 5px 0 0;
+  .incoming & {
+    border-top: 8px solid $incoming-correspondence-color;
+  }
+  .outgoing & {
+    border-top: 8px solid $outgoing-correspondence-color;
+  }
+
+  /* This is so you can't see the text box under the rounded corners of the
+   * sticky header. Can all be removed if you don't have rounded corners. */
+  &::before, &::after {
+    background-position: top left;
+    background-size: 7px 8px;
+    background-repeat: no-repeat;
+    width: 7px;
+    height: 8px;
+    content: "";
+    display: block;
+    position: absolute;
+    top: -8px;
+  }
+  &::before {
+    left: -2px;
+  }
+  &::after {
+    right: -2px;
+  }
+  .incoming &::before {
+    background-image:
+      linear-gradient(to right, $body-bg 2px, transparent 0),
+      linear-gradient(to bottom, transparent 5px, $incoming-correspondence-color 0),
+      radial-gradient(circle at 7px 5px, $incoming-correspondence-color 5px, $body-bg 0);
+  }
+  .outgoing &::before {
+    background-image:
+      linear-gradient(to right, $body-bg 2px, transparent 0),
+      linear-gradient(to bottom, transparent 5px, $outgoing-correspondence-color 0),
+      radial-gradient(circle at 7px 5px, $outgoing-correspondence-color 5px, $body-bg 0);
+  }
+  .incoming &::after {
+    background-image:
+      linear-gradient(to left, $body-bg 2px, transparent 0),
+      linear-gradient(to bottom, transparent 5px, $incoming-correspondence-color 0),
+      radial-gradient(circle at 0 5px, $incoming-correspondence-color 5px, $body-bg 0);
+  }
+  .outgoing &::after {
+    background-image:
+      linear-gradient(to left, $body-bg 2px, transparent 0),
+      linear-gradient(to bottom, transparent 5px, $outgoing-correspondence-color 0),
+      radial-gradient(circle at 0 5px, $outgoing-correspondence-color 5px, $body-bg 0);
   }
 }
 


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/4504

## What does this do?

Makes the correspondence headers sticky so they're always visible as you scroll through the correspondence.

## Why was this needed?

So that when you're reading some correspondence, you can always know if it's incoming or outgoing, who it's from and when it was sent.

## Implementation notes

Wasn't sure if any bit of this would be in core rather than theme, but seemed to all fit nicely here anyway.

## Screenshots

(before I fixed rounded corners)

<img src="https://user-images.githubusercontent.com/154364/253045264-99b576e3-198f-49c9-a99b-bcf5ebd24221.gif" width="50%" alt="">

## Notes to reviewer

The rounded corners made it quite a bit more complicated because you don't want to see anything underneath the outside of the rounded corner. If you get rid of the rounded corners, most of it isn't needed.