### PR TITLE
Appealing to the regulator when you haven't had a response at all

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -62,4 +62,7 @@ Rails.application.routes.draw do
 
   get '/help/about_foisa' => 'help#about_foisa',
       as: :help_about_foisa
+
+  get '/help/no_response' => 'help#no_response',
+      as: :help_no_response
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -20,6 +20,7 @@ Rails.configuration.to_prepare do
     def search_engines; end
     def about_foi; end
     def about_foisa; end
+    def no_response; end
 
     private
 

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -59,6 +59,11 @@
       </li>
 
       <li>
+      <%= link_to_unless_current 'Didn’t get a response?',
+                                 help_no_response_path %>
+      </li>
+     
+      <li>
         <%= link_to_unless_current 'Environmental Information',
                                    help_environmental_information_path %>
       </li>

--- a/lib/views/help/no_response.html.erb
+++ b/lib/views/help/no_response.html.erb
@@ -1,0 +1,101 @@
+<% @title = "What to do if you didn't get a response to your request" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+  <h1 id="title">
+    <%= @title %>
+    <a href="#title">#</a>
+  </h1>
+  <p>
+    By law, public authorities normally have to respond to Freedom of 
+    Information or Environmental Information requests promptly and within 
+    20 working days. Unfortunately, authorities don't always provide a 
+    response within this timeframe. 
+  </p>
+  <p>
+    If 20 working days have passed and 
+     you’ve had no response at all, you should first start by sending 
+    the authority a polite reminder, which might prompt them to respond to 
+    you. If that doesn’t work, the next step will depend on where the 
+    authority is based.
+  </p>
+    
+  <h2 id="ICO">
+    For Public Authorities in England, Wales and Northern Ireland:
+    <a href="#ICO">#</a>
+  </h2>
+        
+  <p>
+    If the public authority has not replied to a request at all, you can 
+    complain directly to the Information Commissioner (ICO) by email at 
+    <a href="mailto:ICOCasework@ico.org.uk">ICOCasework@ico.org.uk</a> or 
+    using their online form:
+  </p>
+  
+  <p>
+    <a href="https://ico.org.uk/make-a-complaint/foi-and-eir-complaints/foi-and-eir-complaints/">
+        https://ico.org.uk/make-a-complaint/foi-and-eir-complaints/foi-and-eir-complaints/
+    </a>
+  </p>
+    
+  <p>
+    Although the ICO form asks you to attach copies of any correspondence 
+    that you have had with the authority, all you need to do is include a 
+    link to your request on WhatDoTheyKnow.
+  </p>
+    
+  <p>
+    The ICO typically takes around 3 to 7 days to process this type of 
+    complaint. If your complaint is valid, the ICO will write to the 
+    authority and tell them to provide you with a response within 10 
+    working days.
+  </p>
+    
+  <p>
+    If the authority still doesn't comply, you can then ask the ICO to 
+    issue a formal decision notice. This decision notice will require the 
+    authority to respond to you within 35 calendar days.
+  </p>
+    
+  <h2 id=OSIC>
+    For Scottish Public Authorities:
+    <a href="#OSIC">#</a>
+  </h2>
+    
+  <p>
+    Unlike the ICO, the Scottish Information Commissioner (OSIC) considers a lack 
+    of response by a public authority as being a refusal, and will not look 
+    at complaints unless you have first requested an internal review, and 
+    waited a further 20 working days for a response.
+  </p>
+    
+  <p>
+    You can request an internal review by clicking on the grey actions 
+    button on the request page, and selecting “Request an Internal Review”. 
+    You should tell the authority that you are requesting a review because 
+    they have not responded to your request.
+  </p>
+    
+  <p>
+    If the authority doesn’t respond to your request for an internal review, 
+    then you can complain to the OSIC. You can do this by sending an email to:
+  </p>
+
+  <p>
+    <a href="mailto:enquiries@ItsPublicKnowledge.info">enquiries@ItsPublicKnowledge.info</a>.
+  </p>  
+
+  <p>  
+    They provide an 
+    <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/Application_Form_-_Website.docx">
+    application form</a> for you to use if you wish to do so. They will need to see a copy of your request and 
+    a copy of your request for an internal review, so make sure to include a link to your request as part of 
+    your complaint.
+  </p>
+    
+  <p>
+    The OSIC will look into your complaint, and if upheld, will issue a decision notice finding that the authority 
+    failed to respond to both your request for information and review. The decision notice will require the authority 
+    to respond to your request.
+  </p>
+  <%= render partial: 'history' %>
+</div>


### PR DESCRIPTION
## Relevant issue(s)
#1743 
## What does this do?
Adds a page on how to appeal to the ICO/OSIC if you've not had any response to your request at all.
## Why was this needed?
Our guidance around this was buried on the unhappy page and a bit limited
## Implementation notes

## Screenshots
<img width="1204" alt="Screenshot 2023-07-13 at 12 09 18" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/af80f4a2-68ff-44f7-ba83-0404ae1613e3">
<img width="1217" alt="Screenshot 2023-07-13 at 12 09 35" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/51c56eaf-ebb1-4949-bac5-ef1b32d6e474">
## Notes to reviewer

I consistently misspell receive, so please check none have snuck in.
