### PR TITLE
[#1750] Fix minor glitches in `about_foisa.html.erb`

### DIFF
--- a/lib/views/help/about_foisa.html.erb
+++ b/lib/views/help/about_foisa.html.erb
@@ -156,7 +156,7 @@
   <p>
   You can also contact them for advice, by calling their helpline on <b>01334 464 610</b>, or if you use <abbr title="British Sign Language">BSL</abbr>, by using <a href="http://contactscotland-bsl.org">Contact Scotland BSL</a>.
   </p>
-  <p>There is more information on how to appeal, including a form that you can use (if you'd like), on the <abbr title="Office of the Scottish Information Commissioner">OSIC</abbr> on their website, at: <a href="https://www.itspublicknowledge.info/appeal">https://www.itspublicknowledge.info/appeal</a>.</p>
+  <p>There is more information on how to appeal, including a form that you can use (if you'd like), on their website, at: <a href="https://www.itspublicknowledge.info/appeal">https://www.itspublicknowledge.info/appeal</a>.</p>
   </p>
   <%= render partial: 'history' %>
   <div id="hash_link_padding"></div>

--- a/lib/views/help/about_foisa.html.erb
+++ b/lib/views/help/about_foisa.html.erb
@@ -4,8 +4,7 @@
   <h1 id="freedom_of_information_scotland_act"><%= @title %></h1>
 
   <h2 id="what_is_FOISA">
-    What&nbsp;is&nbsp;the&nbsp;Freedom&nbsp;of&nbsp;Information&nbsp;(Scotland)&nbsp;Act&nbsp;2002?
-    <a href="#what_is_FOISA">#</a>
+    What&nbsp;is&nbsp;the&nbsp;Freedom&nbsp;of&nbsp;Information&nbsp;(Scotland)&nbsp;Act&nbsp;2002?&nbsp;<a href="#what_is_FOISA">#</a>
   </h2>
 
   <p>The Freedom of Information (Scotland) Act 2002, commonly referred to as FOISA, is a law that gives you the right to access information held by public authorities in Scotland. </p>

--- a/lib/views/help/about_foisa.html.erb
+++ b/lib/views/help/about_foisa.html.erb
@@ -144,7 +144,7 @@
     <a href="#appeal">#</a>
   </h2>
   <p>
-  You can contact the Scottish Information Commissioner by email at: <b><a href="mailto:enquiries@itspublicknowledge.info">enquiries@itspublicknowledge.info</a></b>, or by post:
+  You can contact the Scottish Information Commissioner (OSIC) by email at: <b><a href="mailto:enquiries@itspublicknowledge.info">enquiries@itspublicknowledge.info</a></b>, or by post:
   </p>
   <p>
   Scottish Information Commissioner<br>
@@ -156,7 +156,7 @@
   <p>
   You can also contact them for advice, by calling their helpline on <b>01334 464 610</b>, or if you use <abbr title="British Sign Language">BSL</abbr>, by using <a href="http://contactscotland-bsl.org">Contact Scotland BSL</a>.
   </p>
-  <p>There is more information on how to appeal, including a form that you can use (if you'd like), on their website, at: <a href="https://www.itspublicknowledge.info/appeal">https://www.itspublicknowledge.info/appeal</a>.</p>
+  <p>There is more information on how to appeal, including a form that you can use (if you'd like), on the <abbr title="Office of the Scottish Information Commissioner">OSIC</abbr> website, at: <a href="https://www.itspublicknowledge.info/appeal">https://www.itspublicknowledge.info/appeal</a>.</p>
   </p>
   <%= render partial: 'history' %>
   <div id="hash_link_padding"></div>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1750
#1725 

## What does this do?

1. Fixes the spacing in the first `h2` heading - to stop the anchor flowing onto a new line
2. Removes some duplicate wording in the copy, which could have caused confusion

## Why was this needed?

A couple of minor glitches snuck in when #1725 was pushed. Mea culpa.

## Implementation notes

Nothing of note here.

## Screenshots

| Before | After |
|:-------|:------------|
| <img width="796" alt="Screenshot showing text in heading is split across two lines" src="https://github.com/mysociety/whatdotheyknow-theme/assets/249418/48d3deb2-c427-4894-b0f2-2b23b0bb7e90"> | <img width="819" alt="Screenshot showing that the heading is now correctly displayed on a single line" src="https://github.com/mysociety/whatdotheyknow-theme/assets/249418/cad6670e-dbb0-460d-a4a9-e0c77d053302"> |

## Notes to reviewer

N/A
