### PR TITLE
Improve non response flow

### DIFF
--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -59,17 +59,22 @@
       </li>
 
       <li>
-      <%= link_to_unless_current 'Didn’t get a response?',
-                                 help_no_response_path %>
-      </li>
-     
-      <li>
         <%= link_to_unless_current 'Environmental Information',
                                    help_environmental_information_path %>
       </li>
 
       <li>
         <%= link_to_unless_current 'Exemptions', help_exemptions_path %>
+      </li>
+
+      <li>
+        <%= link_to_unless_current 'Unhappy with a response?',
+                                   help_unhappy_path %>
+      </li>
+
+      <li>
+        <%= link_to_unless_current 'Didn’t get a response?',
+                                   help_no_response_path %>
       </li>
 
       <li>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -105,10 +105,13 @@
 
 <details>
   <summary>
-    If the authority hasn't responded to your request at all after 20 working days, you can complain straight to the 
-    Information Commissioner without needing to request an internal review. If the public authority has done their internal 
-    review and you are unhappy with their response, or if the public authority has refused to carry out an internal review, 
-    you can refer your request to the Information Commissioner.
+    If the authority hasn't <%= link_to 'responded to your request at all',
+    help_no_response_path %> after 20 working days, you can complain straight
+    to the Information Commissioner without needing to request an internal
+    review. If the public authority has done their internal review and you
+    are unhappy with their response, or if the public authority has refused
+    to carry out an internal review, you can refer your request to the
+    Information Commissioner.
   </summary>
 
   <p>


### PR DESCRIPTION
## Relevant issue(s)

Related to https://github.com/mysociety/whatdotheyknow-theme/issues/1743

## What does this do?

Links up the new non-response guidance added in https://github.com/mysociety/whatdotheyknow-theme/pull/1748

## Why was this needed?

Give users the help they need when they're in the specific context

## Screenshots

Sidebar:

![Screenshot 2023-07-14 at 12 29 40](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/b3e03d1d-dbcc-4c17-8540-21caa4564cf7)

Link to `/help/no_response` from relevant section on `/help/unhappy`

![Screenshot 2023-07-14 at 12 29 25](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/916bd531-11a7-4ade-a807-8a0f0362ff0e)

## Notes to Reviewer

We might want to consider shortening the guidance on  `/help/unhappy` now that we have the specific page on non-responses, but can tackle that as a separate change.
