### PR TITLE
Link to our own guidance on FOI

### DIFF
--- a/lib/views/general/_frontpage_how_it_works.html.erb
+++ b/lib/views/general/_frontpage_how_it_works.html.erb
@@ -39,7 +39,7 @@
           </li>
         </ol>
         <div class="learn-more-foi">
-          <a href="https://ico.org.uk/for-the-public/official-information/" class="button-secondary learn-more-foi__link"><%= _("Learn more about the Freedom of Information act &rarr;") %></a>
+          <%= link_to _("Learn more about the Freedom of Information act &rarr;"), help_about_foi_path, class: 'button-secondary learn-more-foi__link' %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Now possible after 15 years!

Looks the same; just links to `/help/about_foi`.

![Screenshot 2023-07-14 at 17 17 14](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/04623df3-34ef-481e-b551-01f0ff57aabb)
