### PR TITLE
Update Github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master, develop]
   pull_request:
-  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,0 +1,53 @@
+name: Labeller
+
+on:
+  pull_request_review:
+    types: [review_requested, submitted]
+
+jobs:
+  add-remove-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add awaiting-review label
+      if: github.event.action == 'review_requested'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            name: 'awaiting-deploy'
+          });
+          github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            labels: ['awaiting-review']
+          })
+
+    - name: Check reviews and manage labels
+      if: github.event.action == 'submitted' && github.event.review.state == 'approved'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const reviews = await github.rest.pulls.listReviews({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+          const unapproved = reviews.data.find(review => review.state !== 'approved');
+          if (!unapproved) {
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'awaiting-review'
+            });
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['awaiting-deploy']
+            });
+          }

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -5,18 +5,13 @@
 name: Mirror to git.mysociety.org
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
 
 jobs:
-
-  ci:
-    uses: ./.github/workflows/ci.yml
-
-  rubocop:
-    uses: ./.github/workflows/rubocop.yml
-
   mirror:
-    needs: [ci, rubocop]
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,7 @@
 name: RuboCop
 
-on: [pull_request, workflow_call]
+on:
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/whatdotheyknow-theme/pull/1734#issuecomment-1633219934

## What does this do?

Update Github workflows to:
1. Prevent CI/RuboCop workflows running twice for every PR
2. Add auto labeller workflow for our awaiting-review/awaiting-deploy labels

