### PR TITLE
Ico help page

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -72,4 +72,7 @@ Rails.application.routes.draw do
 
   get '/help/no_response' => 'help#no_response',
       as: :help_no_response
+
+  get '/help/appeals' => 'help#appeals',
+      as: :help_appeals
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -22,6 +22,7 @@ Rails.configuration.to_prepare do
     def about_foi; end
     def about_foisa; end
     def no_response; end
+    def appeals; end
 
     private
 

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -78,6 +78,10 @@
       </li>
 
       <li>
+       <%= link_to_unless_current 'Appeals', help_appeals_path %>
+      </li>
+
+      <li>
         <%= link_to_unless_current 'Glossary', help_glossary_path %>
       </li>
     </ul>

--- a/lib/views/help/appeals.html.erb
+++ b/lib/views/help/appeals.html.erb
@@ -1,0 +1,131 @@
+<% @title = "Appeals to the Regulator" %>
+<%= render :partial => 'sidebar' %>
+<div id="left_column_flip" class="left_column_flip">
+  <h1 id="appeals"><%= @title %> <a href="#appeals">#</a></h1>
+  <h2 id="ICO_and_OSIC">
+    What are the Information Commissioner's Office (ICO) and the Office of the Scottish Information Commissioner (OSIC)?
+    <a href="#ICO_and_OSIC">#</a>
+  </h2>
+<p>
+  The ICO is the public body set up to uphold your information rights in England, Wales and Northern Ireland. The OSIC 
+  has a similar role for public authorities in Scotland.
+</p>
+<p>
+  If a public authority ignores your FOI request or says 'no', you can ask the ICO or the OSIC to step in. They'll look 
+  into it and decide what should happen next. 
+</p>
+<p>
+  Both the ICO and the OSIC are there to help ensure that authorities are open and transparent, so please don't hesitate 
+  to use their services if you feel that your FOI request hasn't been properly dealt with.
+</p>
+<h2 id="when">
+  When should I appeal to the ICO or the OSIC?
+  <a href="#when">#</a>
+</h2>
+<p>
+  We’ve got some specific guidance about what to do if the
+  <%= link_to 'public authority hasn’t responded', help_no_response_path %> to
+  your request at all.
+</p>
+<p>
+  If a public authority has refused your request and you think they're wrong to do so, you should ask them to 
+  reconsider. They will carry out an internal review. If you're still unhappy with the response to your 
+  request after the review has been carried out, or you’ve had no response to your request for a review, 
+  you can ask the ICO or OSIC to take a look.
+</p>
+<h2 id="cost">
+  Do I have to pay to appeal to the ICO or the OSIC?
+  <a href="#cost">#</a>
+</h2>
+<p>
+  No, making an appeal to the ICO or the OSIC is completely free.
+</p>
+<h2 id="how">
+  How do I appeal to the ICO or the OSIC?
+  <a href="#how">#</a>
+</h2>
+<p>
+  You can complain to the ICO by email at <strong><code>
+  <a href="mailto:ICOCasework@ico.org.uk?subject=FOI%2FEIR%20Complaint">
+  icocasework@ico.org.uk</a></code></strong> or using their 
+  <a href="https://ico.org.uk/make-a-complaint/foi-and-eir-complaints/foi-and-eir-complaints/">online form</a>.
+</p>
+<p>
+  Although the ICO form asks you to attach copies of any correspondence that you have had with the authority, 
+  all you need to do is include a link to your request on WhatDoTheyKnow.
+</p>
+<p>
+  If you made your request to a Scottish Public Authority, you can complain to the OSIC by email 
+  at <strong><code><a href="mailto:enquiries@ItsPublicKnowledge.info">enquiries@ItsPublicKnowledge.info</a></code></strong>.
+</p>
+<p>
+  They provide an <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/Application_Form_-_Website.docx">application form</a> 
+  for you to use if you wish to do so. They will need to see a copy of your request and a copy of your request 
+  for an internal review, so make sure to include a link to your request as part of your complaint.
+</p>
+<p>
+  You will need to explain why you are unhappy with the response to your request. If you think that
+  the public authority has wrongly applied any exemptions, then you should say so. You may also
+  want to include any factors that show that the public interest favours the disclosure of the information
+  that you have asked for.
+</p>
+<h2 id="how_long">
+  How long do they take to make a decision?
+  <a href="#how_long">#</a>
+</h2>
+<p>
+  The time can vary depending on the complexity of your case and the current caseload of the 
+  regulator. It can take several months for them to reach a decision.
+</p>
+<h2 id="speed">
+  Is there a way to speed up the process?
+  <a href="#speed">#</a>
+</h2>
+<p>
+  Unfortunately, there's no guaranteed way to speed up the process. Until recently, the 
+  ICO and the Scottish Information Commissioner treated each case with the same level of 
+  importance and reviewed them in the order they're received. 
+</p>
+<p>
+  The ICO will now give higher priority to cases that it considers to be in the public interest. 
+  You can read more about this process on their website. If you think this applies to your case, 
+  make sure to include reasoning about this in your appeal.
+</p>
+<h2 id="enforce">
+  Can they enforce their decision?
+  <a href="#enforce">#</a>
+</h2>
+<p>
+  Yes, the ICO and the Scottish Information Commissioner can enforce their decisions. A decision notice 
+  is legally binding on the public authority, and they have a certain amount of time to appeal or comply. 
+  If they do not, they may be in contempt of court.
+</p>
+<h2 id="decision">
+  I’ve got a decision, now what?
+  <a href="#decision">#</a>
+</h2>
+<p>
+  If the ICO or OSIC has ruled in your favour, well done! If it’s been a while since you made your request, 
+  please contact us, so we can ensure that you’ll receive any information released by the authority without 
+  any unnecessary delays.
+</p>
+<p>
+  If you're not happy with the ICO’s decision, you have the right to appeal to the First-tier Tribunal 
+  (Information Rights) within 28 days of the decision being made.
+</p>
+<p>
+  If you are unhappy with a decision of the Scottish Information Commissioner, you can appeal to the Court of Session
+</p>
+<h2 id="complaints">
+  Do the ICO and OSIC investigate complaints about requests made to them?
+  <a href="#complaints">#</a>
+</h2>
+<p>
+  The ICO can (and does) investigate complaints about its own handling of FOI requests. You can’t complain 
+  to the OSIC about an FOI response by the Scottish Information Commissioner, and will need to appeal 
+  directly to the court of session.
+</p>
+  <%= render partial: 'history' %>
+
+  <div id="hash_link_padding"></div>
+</div>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1743
## What does this do?
Adds a basic help page on appealing to the regulators
## Why was this needed?
We had no information about this step in the appeals process
## Implementation notes
N/A
## Screenshots
<img width="1367" alt="Screenshot 2023-08-01 at 08 59 20" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/126fbda2-4413-4bb6-ad06-e0b7b768b4dd">

## Notes to reviewer
I'm not 100% happy with the sidebar link text, so feel free to tweak to something better.