### PR TITLE
Add wording about specifying format at time of making request

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -370,7 +370,8 @@
       <p>
         The law requires that if you ask for the information to be provided in a
         particular format the public authority is required to do so,  so long as
-        it is as reasonably practicable.
+        it is as reasonably practicable. If you would like to receive the information
+        in a specific format, you should ask for this when you make your request.
       </p>
       <p>
         You might want to explicitly request data in a reusable format such as a


### PR DESCRIPTION
## Relevant issue(s)
fixes #1757 
## What does this do?
Adds a line about asking for a set format when you make your request.
## Why was this needed?
We didn't say this before
## Implementation notes

## Screenshots
<img width="793" alt="Screenshot 2023-08-01 at 10 28 12" src="https://github.com/mysociety/whatdotheyknow-theme/assets/120410992/f7a7a16c-2e37-4b02-9d67-b30834193b1d">

## Notes to reviewer
