### PR TITLE
Signpost data breach form

### DIFF
--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -132,16 +132,39 @@
         </ul>
     </div>
 
+    <h2 class="contact-page__goal" id="report-data-breach">
+      <label class="houdini-label" for="goal5">
+        I want to <strong>report a data breach</strong>.
+      </label>
+    </h2>
+
+    <input class="houdini-input" type="radio" name="goals" id="goal5"
+      <% if params["contact"] && params[:current_form] == 'report-data-breach' %>checked<% end %>>
+    <div class="houdini-target contact-page__options">
+      <ul>
+        <li>
+          We are keen to understand your concerns, and will act in line with our
+          procedure on
+          <%= link_to "handling accidentally released personal information", help_how_path(anchor: 'accidentally_released') %>.
+        </li>
+
+        <li style="font-size: larger;">
+          To allow us to help more quickly, please use our
+          <%= link_to 'report a data breach', help_report_a_data_breach_path %>
+          form.
+        </li>
+      </ul>
+    </div>
 
     <h2 class="contact-page__goal" id="wdtk">
-        <label class="houdini-label" for="goal5">
+        <label class="houdini-label" for="goal6">
             I have another issue, or feedback relating to the
             WhatDoTheyKnow.com website, that I want to raise with the
             <strong>team that runs WhatDoTheyKnow</strong>.
         </label>
     </h2>
 
-    <input class="houdini-input" type="radio" name="goals" id="goal5"
+    <input class="houdini-input" type="radio" name="goals" id="goal6"
         <% if params["contact"] && params[:current_form] == 'wdtk' %>checked<% end %>>
     <div class="houdini-target contact-page__options">
         <ul>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -106,7 +106,7 @@
 
     <h2 class="contact-page__goal" id="wdtk-volunteer">
         <label class="houdini-label" for="goal4">
-            I’d like to get involved and become a <strong>volunteer</strong>
+            I’d like to get involved and become a <strong>volunteer</strong>.
         </label>
     </h2>
 


### PR DESCRIPTION
While it's linked from the sidebar, it might not be obvious to FOI officers navigating to the contact page (likely via the footer).

<img width="1040" alt="Screenshot 2023-08-25 at 10 02 35" src="https://github.com/mysociety/whatdotheyknow-theme/assets/282788/aabd2d10-1c91-4a30-8f94-be111d2bc531">
