### PR TITLE
Add no reply for city of York council

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -167,6 +167,7 @@ Rails.configuration.to_prepare do
     nhsbsa.foirequests@nhs.net
     donotreply@hillingdon.gov.uk
     no-reply@fcdo.ecase.co.uk
+    foiresponses_NO-REPLY@york.gov.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1785 
## What does this do?
Adds the no reply address that York have been using to issue responses
## Why was this needed?
They use a no reply address to issue responses
## Implementation notes

## Screenshots

## Notes to reviewer
