### PR TITLE
Use email_field for data breach form DPO

### DIFF
--- a/lib/views/help/report_a_data_breach.html.erb
+++ b/lib/views/help/report_a_data_breach.html.erb
@@ -37,7 +37,7 @@
 
     <p>
       <%= f.label :contact_email, "Please provide the email address for the Data Protection Officer (if known):" %>
-      <%= f.text_field :contact_email %>
+      <%= f.email_field :contact_email %>
     </p>
 
     <p>


### PR DESCRIPTION
Adds basic HTML validation to check that the submitted value looks like a valid email address.

Allows empty values.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/1792.

![Screenshot 2023-10-09 at 15 41 43](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/a0bd839e-2570-4a98-add6-d78730d34957)
