### PR TITLE
Update change request emails copy

### DIFF
--- a/lib/views/admin_public_body_change_requests/add_accepted.text.erb
+++ b/lib/views/admin_public_body_change_requests/add_accepted.text.erb
@@ -1,0 +1,9 @@
+<%= _("Dear {{user_name}},", :user_name => @change_request.get_user_name) %>
+
+<%= _("Thanks for your suggestion to add {{public_body_name}}. It's been added to the site here:", :public_body_name => @change_request.public_body_name) %>
+
+<%= _("[Authority URL will be inserted here]")%>
+
+<%= _("Yours,") %>
+
+<%= _("The {{site_name}} team.", :site_name => site_name) %>

--- a/lib/views/admin_public_body_change_requests/add_accepted.text.erb
+++ b/lib/views/admin_public_body_change_requests/add_accepted.text.erb
@@ -1,9 +1,9 @@
 <%= _("Dear {{user_name}},", :user_name => @change_request.get_user_name) %>
 
-<%= _("Thanks for your suggestion to add {{public_body_name}}. It's been added to the site here:", :public_body_name => @change_request.public_body_name) %>
+<%= _("Thank you for your suggestion to add {{public_body_name}}. It's been added to the site here:", :public_body_name => @change_request.public_body_name) %>
 
 <%= _("[Authority URL will be inserted here]")%>
 
-<%= _("Yours,") %>
+<%= _("Kind regards,") %>
 
 <%= _("The {{site_name}} team.", :site_name => site_name) %>

--- a/lib/views/admin_public_body_change_requests/update_accepted.text.erb
+++ b/lib/views/admin_public_body_change_requests/update_accepted.text.erb
@@ -1,0 +1,7 @@
+<%= _("Dear {{user_name}},", :user_name => @change_request.get_user_name) %>
+
+<%= _("Thanks for your suggestion to update the email address for {{public_body_name}} to {{public_body_email}}. This has now been done and any new requests will be sent to the new address.", :public_body_name => @change_request.public_body.name, :public_body_email => @change_request.public_body_email) %>
+
+<%= _("Yours,") %>
+
+<%= _("The {{site_name}} team.", :site_name => site_name) %>

--- a/lib/views/admin_public_body_change_requests/update_accepted.text.erb
+++ b/lib/views/admin_public_body_change_requests/update_accepted.text.erb
@@ -1,7 +1,7 @@
 <%= _("Dear {{user_name}},", :user_name => @change_request.get_user_name) %>
 
-<%= _("Thanks for your suggestion to update the email address for {{public_body_name}} to {{public_body_email}}. This has now been done and any new requests will be sent to the new address.", :public_body_name => @change_request.public_body.name, :public_body_email => @change_request.public_body_email) %>
+<%= _("Thank you for your suggestion to update the email address for {{public_body_name}} to {{public_body_email}}. This has now been done and any new requests will be sent to the new address.", :public_body_name => @change_request.public_body.name, :public_body_email => @change_request.public_body_email) %>
 
-<%= _("Yours,") %>
+<%= _("Kind regards,") %>
 
 <%= _("The {{site_name}} team.", :site_name => site_name) %>


### PR DESCRIPTION
## Relevant issue(s)

Replaces https://github.com/mysociety/alaveteli/pull/7936

## What does this do?

Minor wording changes for new authorities/authorities change emails

## Why was this needed?

This change will reduce admin time editing the default outgoing message when accepting a request to add a new authority.
