### PR TITLE
Add a case reference to data breach form

### DIFF
--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -63,7 +63,8 @@ module DataBreach
       mail(
         from: from,
         to: contact_from_name_and_email,
-        subject: _('New data breach report'),
+        subject: _('New data breach report [{{reference}}]',
+                   reference: case_reference('BR'))
       )
     end
   end

--- a/spec/integration/report_a_data_breach_spec.rb
+++ b/spec/integration/report_a_data_breach_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'report a data breach page' do
     last_email = ActionMailer::Base.deliveries.last
     expect(last_email.from).to eq(['do-not-reply-to-this-address@localhost'])
     expect(last_email.to).to eq(['postmaster@localhost'])
-    expect(last_email.subject).to eq('New data breach report')
+    expect(last_email.subject).to match(/New data breach report \[BR\/.*\]/)
     expect(last_email.header["Reply-To"].value).to eq('test@example.com')
     expect(last_email.body).to include('URL: https://example.com')
     expect(last_email.body).to include('Special category or criminal offence data: Yes')


### PR DESCRIPTION
Add a unique case reference to the data breach form to prevent incorrect threading by GMail.

Requires https://github.com/mysociety/alaveteli/pull/7967
Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/1774

## Screenshots

![Screenshot 2023-10-20 at 12 05 21](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/8292c8f8-593b-4e58-af10-095e1bcd3b32)

Note that I changed the prefix from "BREACH" to "BR" after the screenshot as "BR" maps more closely to our tracker sheet refs.
