### PR TITLE
[#1813] Breach form submitter contact email

### DIFF
--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -6,6 +6,7 @@ module DataBreach
     attribute :url, :string
     attribute :special_category_or_criminal_offence_data, :boolean
     attribute :message, :string
+    attribute :contact_email, :string
     attribute :dpo_contact_email, :string
     attribute :is_public_body, :boolean
 
@@ -43,6 +44,7 @@ module DataBreach
         url
         special_category_or_criminal_offence_data
         message
+        contact_email
         dpo_contact_email
         is_public_body
       ]

--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -9,9 +9,11 @@ module DataBreach
     attribute :contact_email, :string
     attribute :dpo_contact_email, :string
     attribute :is_public_body, :boolean
+    attribute :current_user
 
     validates_presence_of :url, :message => N_("Please enter the URL of the page where the data breach occurred")
     validates_presence_of :message, :message => N_("Please describe the data breach")
+    validates_presence_of :contact_email, message: N_('Please include your email address'), unless: :current_user
 
     validates :is_public_body, inclusion: { in: [true, false], message: N_("Please confirm whether you are reporting on behalf of the public body responsible for the data breach") }
   end
@@ -22,7 +24,7 @@ module DataBreach
     end
 
     def report_a_data_breach_handle_form_submission
-      @report = Report.new(report_params)
+      @report = Report.new(report_params_with_current_user)
       if @report.valid?
         # TODO: Handle a successful submission
         ContactMailer.data_breach(@report, current_user).deliver_now
@@ -50,6 +52,10 @@ module DataBreach
       ]
 
       params.require(:data_breach_report).permit(permittable_attrs)
+    end
+
+    def report_params_with_current_user
+      report_params.merge(current_user: current_user)
     end
   end
 

--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -39,7 +39,15 @@ module DataBreach
     private
 
     def report_params
-      params.require(:data_breach_report).permit(:url, :special_category_or_criminal_offence_data, :message, :contact_email, :is_public_body)
+      permittable_attrs = %i[
+        url
+        special_category_or_criminal_offence_data
+        message
+        contact_email
+        is_public_body
+      ]
+
+      params.require(:data_breach_report).permit(permittable_attrs)
     end
   end
 
@@ -53,6 +61,7 @@ module DataBreach
       from = MailHandler.address_from_name_and_email(
         'WhatDoTheyKnow.com data breach report', blackhole_email
       )
+
       if report.contact_email
         set_reply_to_headers(nil, 'Reply-To' => report.contact_email)
       end

--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -6,7 +6,7 @@ module DataBreach
     attribute :url, :string
     attribute :special_category_or_criminal_offence_data, :boolean
     attribute :message, :string
-    attribute :contact_email, :string
+    attribute :dpo_contact_email, :string
     attribute :is_public_body, :boolean
 
     validates_presence_of :url, :message => N_("Please enter the URL of the page where the data breach occurred")
@@ -43,7 +43,7 @@ module DataBreach
         url
         special_category_or_criminal_offence_data
         message
-        contact_email
+        dpo_contact_email
         is_public_body
       ]
 
@@ -62,8 +62,8 @@ module DataBreach
         'WhatDoTheyKnow.com data breach report', blackhole_email
       )
 
-      if report.contact_email
-        set_reply_to_headers(nil, 'Reply-To' => report.contact_email)
+      if report.dpo_contact_email
+        set_reply_to_headers(nil, 'Reply-To' => report.dpo_contact_email)
       end
 
       # Set a header so we can filter in the mailbox

--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -62,6 +62,8 @@ module DataBreach
   module MailerMethods
     def data_breach(report, logged_in_user)
       @report = report
+      # Setup a case reference so we can find this in the mailbox
+      @caseref = case_reference('BR')
       @logged_in_user = logged_in_user
 
       # From is an address we control so that strict DMARC senders don't get
@@ -78,12 +80,13 @@ module DataBreach
 
       # Set a header so we can filter in the mailbox
       headers['X-WDTK-Contact'] = 'wdtk-data-breach-report'
+      headers['X-WDTK-CaseRef'] = @caseref
 
       mail(
         from: from,
         to: contact_from_name_and_email,
         subject: _('New data breach report [{{reference}}]',
-                   reference: case_reference('BR'))
+                   reference: @caseref)
       )
     end
   end

--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -70,8 +70,10 @@ module DataBreach
         'WhatDoTheyKnow.com data breach report', blackhole_email
       )
 
-      if report.dpo_contact_email
-        set_reply_to_headers(nil, 'Reply-To' => report.dpo_contact_email)
+      if @logged_in_user
+        set_reply_to_headers(nil, 'Reply-To' => @logged_in_user.email)
+      elsif report.contact_email
+        set_reply_to_headers(nil, 'Reply-To' => report.contact_email)
       end
 
       # Set a header so we can filter in the mailbox

--- a/lib/views/contact_mailer/data_breach.text.erb
+++ b/lib/views/contact_mailer/data_breach.text.erb
@@ -10,9 +10,8 @@ Message:
 
 ---------------------------------------------------------------------
 <%= _('Message sent using {{site_name}} data breach form, ',
-      :site_name => site_name.html_safe) -%>
+      site_name: site_name.html_safe) -%>
 <%= @logged_in_user ?
-  _("logged in as user {{user_name}}",
-    :user_name => user_url(@logged_in_user)) :
+  _("logged in as user {{user_name}}", user_name: user_url(@logged_in_user)) :
   _("not logged in") %>
 ---------------------------------------------------------------------

--- a/lib/views/contact_mailer/data_breach.text.erb
+++ b/lib/views/contact_mailer/data_breach.text.erb
@@ -14,4 +14,6 @@ Message:
 <%= @logged_in_user ?
   _("logged in as user {{user_name}}", user_name: user_url(@logged_in_user)) :
   _("contact email: {{email}}", email: @report.contact_email) %>
+
+Case reference: <%= @caseref %>
 ---------------------------------------------------------------------

--- a/lib/views/contact_mailer/data_breach.text.erb
+++ b/lib/views/contact_mailer/data_breach.text.erb
@@ -2,7 +2,7 @@ Someone has submitted a data breach report.
 
 URL: <%= @report.url %>
 Special category or criminal offence data: <%= @report.special_category_or_criminal_offence_data ? 'Yes' : 'No' %>
-DPO email: <%= @report.contact_email %>
+DPO email: <%= @report.dpo_contact_email %>
 Reporting on behalf of public body: <%= @report.is_public_body ? 'Yes' : 'No' %>
 
 Message:

--- a/lib/views/contact_mailer/data_breach.text.erb
+++ b/lib/views/contact_mailer/data_breach.text.erb
@@ -13,5 +13,5 @@ Message:
       site_name: site_name.html_safe) -%>
 <%= @logged_in_user ?
   _("logged in as user {{user_name}}", user_name: user_url(@logged_in_user)) :
-  _("not logged in") %>
+  _("contact email: {{email}}", email: @report.contact_email) %>
 ---------------------------------------------------------------------

--- a/lib/views/help/report_a_data_breach.html.erb
+++ b/lib/views/help/report_a_data_breach.html.erb
@@ -52,6 +52,14 @@
         <% end %>
     </p>
 
+    <% unless @user %>
+      <p>
+        <%= f.label :contact_email, 'My email:' %>
+        <%= f.email_field :contact_email %>
+        (or <%= link_to 'sign in', signin_url(r: request.fullpath) %>)
+      </p>
+    <% end %>
+
     <div class="actions">
       <%= f.submit "Send" %>
     </div>

--- a/lib/views/help/report_a_data_breach.html.erb
+++ b/lib/views/help/report_a_data_breach.html.erb
@@ -36,8 +36,8 @@
     </p>
 
     <p>
-      <%= f.label :contact_email, "Please provide the email address for the Data Protection Officer (if known):" %>
-      <%= f.email_field :contact_email %>
+      <%= f.label :dpo_contact_email, "Please provide the email address for the Data Protection Officer (if known):" %>
+      <%= f.email_field :dpo_contact_email %>
     </p>
 
     <p>

--- a/lib/views/help/report_a_data_breach.html.erb
+++ b/lib/views/help/report_a_data_breach.html.erb
@@ -55,7 +55,7 @@
     <% unless @user %>
       <p>
         <%= f.label :contact_email, 'My email:' %>
-        <%= f.email_field :contact_email %>
+        <%= f.email_field :contact_email, required: true %>
         (or <%= link_to 'sign in', signin_url(r: request.fullpath) %>)
       </p>
     <% end %>

--- a/spec/integration/report_a_data_breach_spec.rb
+++ b/spec/integration/report_a_data_breach_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'report a data breach page' do
     expect(last_email.from).to eq(['do-not-reply-to-this-address@localhost'])
     expect(last_email.to).to eq(['postmaster@localhost'])
     expect(last_email.subject).to match(/New data breach report \[BR\/.*\]/)
-    expect(last_email.header["Reply-To"].value).to eq('dpo@example.com')
+    expect(last_email.header["Reply-To"].value).to eq('test@example.com')
     expect(last_email.body).to include('URL: https://example.com')
     expect(last_email.body).to include('Special category or criminal offence data: Yes')
     expect(last_email.body).to include('DPO email: dpo@example.com')
@@ -73,6 +73,7 @@ RSpec.describe 'report a data breach page' do
 
       user_url = show_user_url(user.url_name, host: 'test.host')
       last_email = ActionMailer::Base.deliveries.last
+      expect(last_email.header["Reply-To"].value).to eq(user.email)
       expect(last_email.body).to include("logged in as user #{user_url}")
     end
   end

--- a/spec/integration/report_a_data_breach_spec.rb
+++ b/spec/integration/report_a_data_breach_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'report a data breach page' do
 
     expect(page).to have_css('input[name="data_breach_report[url]"]')
     expect(page).to have_css('textarea[name="data_breach_report[message]"]')
-    expect(page).to have_css('input[name="data_breach_report[contact_email]"]')
+    expect(page).to have_css('input[name="data_breach_report[dpo_contact_email]"]')
     expect(page).to have_css('input[name="data_breach_report[url]"]')
   end
 
@@ -26,7 +26,7 @@ RSpec.describe 'report a data breach page' do
     visit help_report_a_data_breach_path
     fill_in 'data_breach_report[url]', with: 'https://example.com'
     fill_in 'data_breach_report[message]', with: 'A data breach occurred'
-    fill_in 'data_breach_report[contact_email]', with: 'test@example.com'
+    fill_in 'data_breach_report[dpo_contact_email]', with: 'dpo@example.com'
     choose 'data_breach_report[is_public_body]', option: 'true'
     check 'data_breach_report[special_category_or_criminal_offence_data]'
     click_button 'Send'
@@ -37,10 +37,10 @@ RSpec.describe 'report a data breach page' do
     expect(last_email.from).to eq(['do-not-reply-to-this-address@localhost'])
     expect(last_email.to).to eq(['postmaster@localhost'])
     expect(last_email.subject).to match(/New data breach report \[BR\/.*\]/)
-    expect(last_email.header["Reply-To"].value).to eq('test@example.com')
+    expect(last_email.header["Reply-To"].value).to eq('dpo@example.com')
     expect(last_email.body).to include('URL: https://example.com')
     expect(last_email.body).to include('Special category or criminal offence data: Yes')
-    expect(last_email.body).to include('DPO email: test@example.com')
+    expect(last_email.body).to include('DPO email: dpo@example.com')
     expect(last_email.body).to include('Reporting on behalf of public body: Yes')
     expect(last_email.body).to include("Message:\nA data breach occurred")
   end

--- a/spec/integration/report_a_data_breach_spec.rb
+++ b/spec/integration/report_a_data_breach_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'report a data breach page' do
 
     expect(page).to have_css('input[name="data_breach_report[url]"]')
     expect(page).to have_css('textarea[name="data_breach_report[message]"]')
+    expect(page).to have_css('input[name="data_breach_report[contact_email]"]')
     expect(page).to have_css('input[name="data_breach_report[dpo_contact_email]"]')
     expect(page).to have_css('input[name="data_breach_report[url]"]')
   end
@@ -26,6 +27,7 @@ RSpec.describe 'report a data breach page' do
     visit help_report_a_data_breach_path
     fill_in 'data_breach_report[url]', with: 'https://example.com'
     fill_in 'data_breach_report[message]', with: 'A data breach occurred'
+    fill_in 'data_breach_report[contact_email]', with: 'test@example.com'
     fill_in 'data_breach_report[dpo_contact_email]', with: 'dpo@example.com'
     choose 'data_breach_report[is_public_body]', option: 'true'
     check 'data_breach_report[special_category_or_criminal_offence_data]'
@@ -50,6 +52,10 @@ RSpec.describe 'report a data breach page' do
 
     around do |example|
       using_session(login(user, r: help_report_a_data_breach_path), &example)
+    end
+
+    it 'does not require email address' do
+      expect(page).to have_no_field('data_breach_report[contact_email]')
     end
 
     it 'includes logged in user in emailed report' do

--- a/spec/integration/report_a_data_breach_spec.rb
+++ b/spec/integration/report_a_data_breach_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'report a data breach page' do
     expect(page).to have_content('Please enter the URL of the page where the data breach occurred')
     expect(page).to have_content('Please describe the data breach')
     expect(page).to have_content('Please confirm whether you are reporting on behalf of the public body responsible for the data breach')
+    expect(page).to have_content('Please include your email address')
   end
 
   it 'user can submit the form and the result is emailed' do
@@ -45,6 +46,7 @@ RSpec.describe 'report a data breach page' do
     expect(last_email.body).to include('DPO email: dpo@example.com')
     expect(last_email.body).to include('Reporting on behalf of public body: Yes')
     expect(last_email.body).to include("Message:\nA data breach occurred")
+    expect(last_email.body).to include("contact email: test@example.com")
   end
 
   context 'when user is logged in' do
@@ -56,6 +58,8 @@ RSpec.describe 'report a data breach page' do
 
     it 'does not require email address' do
       expect(page).to have_no_field('data_breach_report[contact_email]')
+      click_button 'Send'
+      expect(page).to have_no_content('Please include your email address')
     end
 
     it 'includes logged in user in emailed report' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1813 
Depends on https://github.com/mysociety/alaveteli/pull/8074

## What does this do?

* Collect breach form submitter email

## Screenshots

Signed out:

![Screenshot 2023-12-15 at 08 57 26](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/5e9e092f-dc8d-4354-b67c-0d1ea6d2e3ca)

Signed in:

![Screenshot 2023-12-15 at 08 57 12](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/33377c35-4f5f-42a8-adf9-9cff6c325483)

## Notes to reviewer
