### PR TITLE
Send targeted request

### DIFF
--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -201,7 +201,7 @@
         </li>
         <li>
           <p>
-            <strong>Send targetted requests:</strong>
+            <strong>Send targeted requests:</strong>
             You might be planning to make a request to, for
             example, all local councils, or even all public bodies in the country,
             but  it’s worth stopping to reflect. Such bulk requests result in a

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -201,7 +201,7 @@
         </li>
         <li>
           <p>
-            <strong>Don’t carpet-bomb:</strong>
+            <strong>Send targetted requests:</strong>
             You might be planning to make a request to, for
             example, all local councils, or even all public bodies in the country,
             but  it’s worth stopping to reflect. Such bulk requests result in a


### PR DESCRIPTION

## Relevant issue(s)
Send targeted requests is better than "Don't carpet bomb" for two reasons: (1) it is more accessible language and (2) it is likely to evoke images of violence.

## What does this do?
See above.

## Why was this needed?
See above.

## Implementation notes
See above.

## Screenshots
N/A.

## Notes to reviewer
See above.