### PR TITLE
More links on authority pages etc

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -665,7 +665,7 @@
     the benefit of society. There is a benefit to our users in that we offer an
     easy way to make, track and publish Freedom of Information requests. The
     service also has a benefit to the public as any information released in
-    response to the request is publicly available in a historic archive for
+    response to the request is publicly available in a historical archive for
     anyone to use. There is also a benefit to authorities responding to
     requests, in that the automatic publication of the requests reduces
     duplicate requesting.

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -71,6 +71,18 @@
                     "https://get-information-schools.service.gov.uk/Groups/Group/Details/#{ tag_value }" %><br>
   <% end %>
 <% end %>
+<% if public_body.has_tag?('ror') %>
+  <% public_body.get_tag_values('ror').each do |tag_value| %>
+      <%= link_to _('Research Organization Registry'),
+                    "https://ror.org/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+<% if public_body.has_tag?('lon') %>
+  <% public_body.get_tag_values('lon').each do |tag_value| %>
+      <%= link_to _('London Stock Exchange'),
+                    "https://www.londonstockexchange.com/stock/#{ tag_value }"/company-page %><br>
+  <% end %>
+<% end %>
 
 <% if public_body.has_tag?('su_parent') %>
   <% public_body.get_tag_values('su_parent').each do |tag_value| %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -80,7 +80,7 @@
 <% if public_body.has_tag?('lon') %>
   <% public_body.get_tag_values('lon').each do |tag_value| %>
       <%= link_to _('London Stock Exchange'),
-                    "https://www.londonstockexchange.com/stock/#{ tag_value }"/company-page %><br>
+                    "https://www.londonstockexchange.com/stock/#{ tag_value }/company-page" %><br>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## Relevant issue(s)
This would add more links to some of the authority pages if the relevant tags are present.

(1) Research Organization Registry (ROR) - https://ror.org/ - based on "ror:" tag.
(2) London Stock Exchange - https://www.londonstockexchange.com/ - based on "lon:" tag.

Also, there is a minor wording correction to a help page.

## What does this do?
See above.

## Why was this needed?
See above.

## Implementation notes
N/A.

## Screenshots
N/A.

## Notes to reviewer
See above.