### PR TITLE
Handle when ExcelAnalyzer detects issues

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -59,7 +59,8 @@ for patch in ['patch_mailer_paths.rb',
               'public_body_questions.rb',
               'school_late_calculator.rb',
               'volunteer_contact_form.rb',
-              'data_breach.rb']
+              'data_breach.rb',
+              'excel_analyzer.rb']
     require File.expand_path "../#{patch}", __FILE__
 end
 

--- a/lib/excel_analyzer.rb
+++ b/lib/excel_analyzer.rb
@@ -1,0 +1,43 @@
+ExcelAnalyzer.on_hidden_metadata = ->(attachment_blob, metadata) do
+  foi_attachment = FoiAttachment.joins(:file_blob).
+    find_by(active_storage_blobs: { id: attachment_blob })
+
+  incoming_message = foi_attachment.incoming_message
+  next if incoming_message.sent_at < 1.day.ago
+
+  foi_attachment.update_and_log_event(
+    prominence: 'hidden',
+    event: {
+      editor: User.internal_admin_user,
+      reason: 'ExcelAnalyzer: hidden data dectected'
+    }
+  )
+
+  ExcelAnalyzerNotifier.report(foi_attachment, metadata).deliver_now
+end
+
+Rails.configuration.to_prepare do
+  class ExcelAnalyzerNotifier < ApplicationMailer
+    include Rails.application.routes.url_helpers
+    default_url_options[:host] = AlaveteliConfiguration.domain
+
+    def report(foi_attachment, metadata)
+      @foi_attachment = foi_attachment
+      @metadata = metadata
+
+      from = email_address_with_name(
+        blackhole_email, 'WhatDoTheyKnow.com Execl Analyzer report'
+      )
+
+      headers['X-WDTK-Contact'] = 'wdtk-excel-anaylzer-report'
+      headers['X-WDTK-CaseRef'] = @foi_attachment.id
+
+      mail(
+        from: from,
+        to: pro_contact_from_name_and_email,
+        subject: _('ExcelAnalyzer: hidden data dectected [{{reference}}]',
+                   reference: @foi_attachment.id)
+      )
+    end
+  end
+end

--- a/lib/views/excel_analyzer_notifier/report.text.erb
+++ b/lib/views/excel_analyzer_notifier/report.text.erb
@@ -1,0 +1,11 @@
+ExcelAnalyzer has flagged and automatically set hidden prominence of a received
+spreadsheet due to the detection of potentially suspect hidden data.
+
+Admin URL: <%= edit_admin_foi_attachment_url(@foi_attachment) %>
+
+The following was detected:
+<% @metadata.each do |key, value| %>
+  <%= key %>: <%= value %>
+<% end %>
+
+Please review the file carefully.


### PR DESCRIPTION
## Relevant issue(s)

Depends on https://github.com/mysociety/alaveteli/pull/8136
Connected to https://github.com/mysociety/alaveteli/issues/8048

## What does this do?

Handle when ExcelAnalyzer detects issues

## Why was this needed?

Hide spreadsheets and automatically send a report.

## Screenshots

![image](https://github.com/mysociety/whatdotheyknow-theme/assets/5426/36100b4f-8944-4051-8526-f547f89f3159)

