### PR TITLE
Patch authority only response gatekeeper

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -58,7 +58,8 @@ for patch in ['patch_mailer_paths.rb',
               'school_late_calculator.rb',
               'volunteer_contact_form.rb',
               'data_breach.rb',
-              'excel_analyzer.rb']
+              'excel_analyzer.rb',
+              'authority_only_response_gatekeeper.rb']
     require File.expand_path "../#{patch}", __FILE__
 end
 

--- a/lib/authority_only_response_gatekeeper.rb
+++ b/lib/authority_only_response_gatekeeper.rb
@@ -1,0 +1,16 @@
+module AuthorityOnlyResponseGatekeeper
+  EXTRA_ALLOWED_EMAILS = [
+    { public_body_id: 27, email: 'no-reply@cabinetoffice.ecase.co.uk' }
+  ]
+
+  def allow?(mail)
+    public_body_id = info_request.public_body_id
+    email = MailHandler.get_from_address(mail)
+
+    return true if EXTRA_ALLOWED_EMAILS.any? do |a|
+      a[:public_body_id] == public_body_id && a[:email] == email
+    end
+
+    super
+  end
+end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -58,6 +58,9 @@ Rails.configuration.to_prepare do
     end
   end
 
+  InfoRequest::ResponseGatekeeper::AuthorityOnly.
+    prepend AuthorityOnlyResponseGatekeeper
+
   Legislation.refusals = {
     foi: [
       's 11', 's 12', 's 14', 's 21', 's 22', 's 30', 's 31', 's 35', 's 38',

--- a/spec/authority_only_response_gatekeeper_spec.rb
+++ b/spec/authority_only_response_gatekeeper_spec.rb
@@ -1,0 +1,38 @@
+require_relative 'spec_helper'
+
+RSpec.describe AuthorityOnlyResponseGatekeeper do
+  let(:public_body) do
+    FactoryBot.create(
+      :public_body,
+      id: 27,
+      name: 'Cabinet Office',
+      request_email: 'foi@localhost'
+    )
+  end
+
+  let(:info_request) do
+    FactoryBot.create(
+      :info_request,
+      public_body: public_body,
+      allow_new_responses_from: 'authority_only'
+    )
+  end
+
+  def receive_from(from)
+    info_request.receive Mail.new(from: from), ''
+  end
+
+  it 'allows responses from main request email and extra addresses' do
+    expect { receive_from('foi@localhost') }.to change {
+      info_request.incoming_messages.count
+    }.from(0).to(1)
+
+    expect { receive_from('other@example.com') }.to_not change {
+      info_request.incoming_messages.count
+    }
+
+    expect { receive_from('no-reply@cabinetoffice.ecase.co.uk') }.to change {
+      info_request.incoming_messages.count
+    }.from(1).to(2)
+  end
+end


### PR DESCRIPTION
## What does this do?

Patch authority only response gatekeeper

## Why was this needed?

Accept responses to authority only requests from extra addresses which authorities might use. For example no-reply addresses from case management systems which aren't changeable.

## Implementation notes

Made it so adding other addresses is trivial so volunteers can open PRs for other addresses like they do for `invalid_reply_addresses`