### PR TITLE
Adding link to FCA mutuals register and additional help text

### DIFF
--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -458,6 +458,11 @@
         re-opened so that you can respond to it, please
         <a href="<%= help_contact_path %>"> contact us</a>.
       </p>
+      <p>
+       Any responses sent to closed threads receive an auto-response 
+        letting the sender know what has happened and inviting them to get in touch
+        with us to ask for the thread to be re-opened.
+      </p>
     </dd>
   </dl>
   <p>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -44,6 +44,13 @@
   <% end %>
 <% end %>
 
+<% if public_body.has_tag?('society') %>
+  <% public_body.get_tag_values('society').each do |tag_value| %>
+      <%= link_to _('Mutual registration'),
+                    "https://mutuals.fca.org.uk/Search/Society/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <% if public_body.has_tag?('urn') %>
   <% public_body.get_tag_values('urn').each do |tag_value| %>
       <%= link_to _('Establishment information'),


### PR DESCRIPTION
## Relevant issue(s)
Adding link to FCA mutuals register on relevant authority pages and additional help text about what happens when an email is sent to a close request thread.

## What does this do?
See above.

## Why was this needed?
See above.

## Implementation notes
Authorities need to be tagged "society:[code]".

## Screenshots
N/A.

## Notes to reviewer
See above.