### PR TITLE
Add Bournemouth, Christchurch and Poole Council no reply address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -189,6 +189,7 @@ Rails.configuration.to_prepare do
     donotreply@hillingdon.gov.uk
     no-reply@fcdo.ecase.co.uk
     foiresponses_NO-REPLY@york.gov.uk
+    pt&e.rfi@bcpcouncil.gov.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
Adding due to known issue of escaping ampersands:

https://github.com/mysociety/alaveteli/issues/3465
