### PR TITLE
Fixing broken links to ICO guidance

### DIFF
--- a/config/refusal_advice/section_38.yml.erb
+++ b/config/refusal_advice/section_38.yml.erb
@@ -30,7 +30,7 @@ foi:
         Has the authority demonstrated a causal link between the release of the requested information, and endangerment of an individual?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1624339/health-and-safety-section-38-foia.pdf">ICO guidance</a> says that the authority must "show that disclosure would or would be likely to have a detrimental effect on the physical or mental health of any individual, or the safety of any individual. The effect must be more than trivial or insignificant."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a> says that the authority must "show that disclosure would or would be likely to have a detrimental effect on the physical or mental health of any individual, or the safety of any individual. The effect must be more than trivial or insignificant."
 
         It goes on to explain that 'would' indicates a 50% chance or higher, while 'would be likely to' requires a 'real and significant likelihood' of endangerment occurring.
 
@@ -44,7 +44,7 @@ foi:
       html: >
         The authority must show that it has considered the balance between the potential harm that could be caused by disclosure, against the public good.
 
-        <a href="https://ico.org.uk/media/for-organisations/documents/1624339/health-and-safety-section-38-foia.pdf">ICO guidance</a> lists some of the factors that might be considered to favour disclosure:
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a> lists some of the factors that might be considered to favour disclosure:
         <ul>
         <li>"Furthering the understanding and participation in the public debate
           of issues of the day;</li>
@@ -83,7 +83,7 @@ foi:
         Would disclosure bring new information into the public domain?
     hint:
       html: >
-        The authority should consider whether the information you have requested would bring new harm to the individual/s in question, or whether the same or similar information is already in the public domain. <a href="https://ico.org.uk/media/for-organisations/documents/1624339/health-and-safety-section-38-foia.pdf">ICO guidance</a> gives the example of scientists performing tests on animals: a request asking for the names of scientists involved in a recent round of tests would not cause additional harm if there is already a public record of their previous work performing tests on animals.
+        The authority should consider whether the information you have requested would bring new harm to the individual/s in question, or whether the same or similar information is already in the public domain. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a> gives the example of scientists performing tests on animals: a request asking for the names of scientists involved in a recent round of tests would not cause additional harm if there is already a public record of their previous work performing tests on animals.
 
   - id: s38-q5
     show_if: *section-38
@@ -132,7 +132,7 @@ foi:
         Has the authority cited Section 38 as the reason for not confirming or denying?
     hint:
       html: >
-        Under Section 38 of the FOI Act authorities are permitted not to <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">confirm or deny</a> whether they hold information, IF doing so would disclose information that is likely to bring harm to an individual.
+        Under Section 38 of the FOI Act authorities are permitted not to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">confirm or deny</a> whether they hold information, IF doing so would disclose information that is likely to bring harm to an individual.
 
   - id: s38-q6n1y1
     show_if:
@@ -143,7 +143,7 @@ foi:
         Have they performed a prejudice test on the issue of whether to confirm or deny?
     hint:
       html: >
-        Where an authority uses Section 38 as a reason not to confirm or deny whether they hold information, they must also perform a prejudice test, demonstrating the causal link between confirming or denying, and the likelihood of harm to an individual. <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">The ICO provides guidance to authorities about this here</a>.
+        Where an authority uses Section 38 as a reason not to confirm or deny whether they hold information, they must also perform a prejudice test, demonstrating the causal link between confirming or denying, and the likelihood of harm to an individual. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">The ICO provides guidance to authorities about this here</a>.
 
   - id: s38-q6n1y1y1
     show_if:
@@ -154,7 +154,7 @@ foi:
         Have they performed a public interest test on the matter of whether to confirm or deny?
     hint:
       html: >
-        Where an authority uses Section 38 as a reason not to confirm or deny whether they hold information, they must also perform a public interest test on this matter. The ICO <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">provides guidance to authorities about confirming or denying  here</a>.
+        Where an authority uses Section 38 as a reason not to confirm or deny whether they hold information, they must also perform a public interest test on this matter. The ICO <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">provides guidance to authorities about confirming or denying  here</a>.
 
   - id: s38-q7
     show_if: *section-38
@@ -164,6 +164,6 @@ foi:
         Are there any steps which the authority could easily take that would mitigate the potential harm they have identified?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1624339/health-and-safety-section-38-foia.pdf">ICO guidance</a> says, "Public authorities can of course always consider whether there are any steps they can take to mitigate or manage the risk that disclosure would cause".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a> says, "Public authorities can of course always consider whether there are any steps they can take to mitigate or manage the risk that disclosure would cause".
 
         Although this is clearly not a requirement, it may be worth citing. For example, if by redacting names from the requested documents, the authority could provide anonymised information that would not implicate the individuals in question but would still be useful to you, you could suggest this.

--- a/config/refusal_advice/section_38_actions.yml.erb
+++ b/config/refusal_advice/section_38_actions.yml.erb
@@ -7,7 +7,7 @@ foi:
       - { id: s38-q1, operator: is, value: 'no' }
       advice:
         html: >
-          You have grounds for an internal review. Respond to the authority, citing the <a href="https://ico.org.uk/media/for-organisations/documents/1624339/health-and-safety-section-38-foia.pdf">ICO's guidance</a> and pointing out that they must provide details of a prejudice test and demonstrate the causal link between disclosure of the information and harm to an individual.
+          You have grounds for an internal review. Respond to the authority, citing the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO's guidance</a> and pointing out that they must provide details of a prejudice test and demonstrate the causal link between disclosure of the information and harm to an individual.
 
     - id: s38-a3
       show_if:
@@ -23,7 +23,7 @@ foi:
       - { id: s38-q2, operator: is, value: 'no' }
       advice:
         html: >
-          Request an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1624339/health-and-safety-section-38-foia.pdf">ICO guidance</a> and pointing out that the authority is obliged to conduct a public interest test when applying this exemption.
+          Request an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a> and pointing out that the authority is obliged to conduct a public interest test when applying this exemption.
 
     - id: s38-a5
       show_if:
@@ -37,7 +37,7 @@ foi:
       - { id: s38-q2y1, operator: is, value: 'no' }
       advice:
         html: >
-          Request an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1624339/health-and-safety-section-38-foia.pdf">ICO guidance</a> and pointing out that the authority is obliged to provide these details.
+          Request an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a> and pointing out that the authority is obliged to provide these details.
 
     - id: s38-a7
       show_if:


### PR DESCRIPTION
## Relevant issue(s)
Fixes broken links in s38 guidance to both the s38 guidance itself and the confirm or deny guidance
## What does this do?
Fixes the links
## Why was this needed?
The links were broken
## Implementation notes
n/a
## Screenshots
n/a
## Notes to reviewer
n/a