### PR TITLE
Exclude schools from batch requests

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -73,6 +73,8 @@ Rails.configuration.to_prepare do
     prepend ProAccountBans::ModelMethods
   end
 
+  PublicBody.batch_excluded_tags += %w[school]
+
   PublicBody.excluded_calculated_home_page_domains += %w[
     aol.co.uk
     blueyonder.co.uk


### PR DESCRIPTION
## Relevant issue(s)

Depends on: https://github.com/mysociety/alaveteli/pull/8258

## What does this do?

Exclude schools from batch requests

## Why was this needed?

This previously was done in Alaveteli core for the batch category UI. This will now also exclude schools from the batch authority search.
