### PR TITLE
[ExcelAnalyzer] Provide a custom prominence reason when hiding

### DIFF
--- a/lib/excel_analyzer.rb
+++ b/lib/excel_analyzer.rb
@@ -7,6 +7,9 @@ ExcelAnalyzer.on_hidden_metadata = ->(attachment_blob, metadata) do
 
   foi_attachment.update_and_log_event(
     prominence: 'hidden',
+    prominence_reason: "We've found a problem with this file, so it's been " \
+                       "hidden while we review it. We might not be able to " \
+                       "give more details until then.",
     event: {
       editor: User.internal_admin_user,
       reason: 'ExcelAnalyzer: hidden data detected'


### PR DESCRIPTION
This is intended to provide a bit more information on the request thread and hopefully head off some questions to support.

## Relevant issue(s)

Fixes https://github.com/mysociety/whatdotheyknow-private/issues/305

## What does this do?

Provides a custom prominence reason for attachments hidden by the analyzer

## Why was this needed?

Hopefully to reduce queries to support
