### PR TITLE
[ExcelAnalyzer] republish attachments automatically

### DIFF
--- a/lib/excel_analyzer/jobs/pii_badger_job.rb
+++ b/lib/excel_analyzer/jobs/pii_badger_job.rb
@@ -22,7 +22,7 @@ module ExcelAnalyzer
         ))
       end
 
-      ExcelAnalyzer::NotifierMailer.report(attachment_blob).deliver_now
+      ExcelAnalyzer::RepublishOrReportJob.perform_later(attachment_blob)
     end
   end
 end

--- a/lib/excel_analyzer/jobs/republish_or_report_job.rb
+++ b/lib/excel_analyzer/jobs/republish_or_report_job.rb
@@ -1,0 +1,80 @@
+##
+# Job to republish or report to admins files stored as ActiveStorage::Blob
+#
+# Examples:
+#   ExcelAnalyzer::RepublishOrReportJob.perform(ActiveStorage::Blob.first)
+#
+module ExcelAnalyzer
+  class RepublishOrReportJob < ApplicationJob
+    queue_as :excel_analyzer
+
+    attr_reader :attachment_blob
+
+    def perform(attachment_blob)
+      @attachment_blob = attachment_blob
+
+      if safe_to_republish?
+        # Republish attachment
+        attachment.update_and_log_event(
+          prominence: hide_event.params[:old_prominence],
+          prominence_reason: hide_event.params[:old_prominence_reason],
+          event: { editor: User.internal_admin_user }
+        ) && attachment.log_event("manual", {
+          attachment: attachment,
+          type: "excel-analyzer-safe",
+          reason: "No data breach found after automated review"
+        })
+      else
+        # Report attachment
+        ExcelAnalyzer::NotifierMailer.report(attachment_blob).deliver_now
+      end
+    end
+
+    private
+
+    def safe_to_republish?
+      !potential_pii_leaks? &&
+        !(xls? && pivot_cache?) &&
+        !(named_ranges? && external_links?) &&
+        !(data_model?)
+    end
+
+    def potential_pii_leaks?
+      attachment_blob.metadata[:pii_badger][:potential_pii_leaks].any?
+    end
+
+    def xls?
+      attachment_blob.content_type == ExcelAnalyzer::XlsAnalyzer::CONTENT_TYPE
+    end
+
+    def pivot_cache?
+      attachment_blob.metadata[:excel][:pivot_cache] > 0
+    end
+
+    def named_ranges?
+      attachment_blob.metadata[:excel][:named_ranges] > 0
+    end
+
+    def external_links?
+      attachment_blob.metadata[:excel][:external_links] > 0
+    end
+
+    def data_model?
+      attachment_blob.metadata[:excel][:data_model] > 0
+    end
+
+    def attachment
+      @attachment ||= FoiAttachment.joins(:file_blob).find_by(
+        active_storage_blobs: { id: attachment_blob.to_param }
+      )
+    end
+
+    def hide_event
+      attachment.info_request.info_request_events.
+        where(event_type: "edit_attachment").
+        where("params->>'attachment_id' = ?", attachment.to_param).
+        where("params->>'reason' = ?", "ExcelAnalyzer: hidden data detected").
+        first
+    end
+  end
+end

--- a/spec/excel_analyzer/jobs/republish_or_report_job_spec.rb
+++ b/spec/excel_analyzer/jobs/republish_or_report_job_spec.rb
@@ -1,0 +1,102 @@
+require_relative '../../spec_helper'
+
+RSpec.describe ExcelAnalyzer::RepublishOrReportJob, type: :job do
+  let(:message) { FactoryBot.create(:incoming_message) }
+  let(:attachment) { message.foi_attachments.first }
+  let(:blob) { attachment.file_blob }
+
+  let(:excel_metadata) do
+    { pivot_cache: 0, named_ranges: 0, external_links: 0, data_model: 0 }
+  end
+  let(:pii_metadata) { { potential_pii_leaks: [] } }
+
+  around do |example|
+    to = ENV['EXCEL_ANALYZER_NOTIFICATION_EMAIL']
+    ENV['EXCEL_ANALYZER_NOTIFICATION_EMAIL'] = 'excel@localhost'
+    example.call
+    ENV['EXCEL_ANALYZER_NOTIFICATION_EMAIL'] = to
+  end
+
+  before do
+    # set blob content type and metadata
+    blob.update(
+      content_type: ExcelAnalyzer::XlsxAnalyzer::CONTENT_TYPE,
+      metadata: blob.metadata.merge(
+        excel: excel_metadata,
+        pii_badger: pii_metadata
+      )
+    )
+
+    # hide attachment
+    attachment.update(prominence: 'hidden')
+
+    # create hide event
+    message.info_request.info_request_events.create(
+      event_type: 'edit_attachment', params: {
+        attachment_id: attachment.id,
+        reason: 'ExcelAnalyzer: hidden data detected',
+        old_prominence: 'normal',
+        old_prominence_reason: ''
+      }
+    )
+  end
+
+  def perform
+    described_class.new.perform(blob)
+  end
+
+  it 'republished attachment' do
+    expect { perform; attachment.reload }.to change(attachment, :prominence).
+      from('hidden').to('normal')
+  end
+
+  it 'logs manual safe event' do
+    perform
+    event = message.info_request.info_request_events.last
+    expect(event.event_type).to eq('manual')
+    expect(event.params[:type]).to eq('excel-analyzer-safe')
+    expect(event.params[:reason]).
+      to eq('No data breach found after automated review')
+  end
+
+  shared_examples :attachment_reported do
+    it 'sents report email' do
+      deliveries = ActionMailer::Base.deliveries
+      expect(deliveries.size).to eq(0)
+
+      expect(ExcelAnalyzer::NotifierMailer).to receive(:report).with(blob).
+        and_call_original
+      perform
+      expect(deliveries.size).to eq(1)
+
+      deliveries.clear
+    end
+  end
+
+  context 'when potential PII leaks were detected' do
+    let(:pii_metadata) { { potential_pii_leaks: [:foo] } }
+    include_examples :attachment_reported
+  end
+
+  context 'when XLS and pivot cache present' do
+    let(:excel_metadata) { { pivot_cache: 1 } }
+    before { blob.content_type = ExcelAnalyzer::XlsAnalyzer::CONTENT_TYPE }
+    include_examples :attachment_reported
+  end
+
+  context 'when named ranges and external links present' do
+    let(:excel_metadata) do
+      { pivot_cache: 0, named_ranges: 1, external_links: 1 }
+    end
+
+    include_examples :attachment_reported
+  end
+
+  context 'when data model present' do
+    let(:excel_metadata) do
+      { pivot_cache: 0, named_ranges: 0, external_links: 0, data_model: 1 }
+    end
+
+    include_examples :attachment_reported
+  end
+end


### PR DESCRIPTION
If the attachment doesn't get flagged as containing potential PII there are cases where we're comfortable in republishing the attachment automatically, exceptions are:
1. If XLS with pivot cache - the conversion to XLSX means the pivot cache is lost
2. With named ranges and external links present - the data cached isn't being scanned for PII
3. With a data model present - we can't, at present, scan the data inside this data model.

Fixes https://github.com/mysociety/whatdotheyknow-private/issues/312
