### PR TITLE
Update unhappy.html.erb

### DIFF
--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -199,15 +199,6 @@
       local authorities can talk directly to council officers.
     </li>
 
-    <% if can_ask_the_eu?(@country_code) %>
-      <li>
-        Try <%= link_to 'asking for the information from the European Union',
-        'http://www.asktheeu.org' %>.
-        <%= link_to 'AskTheEU.org', 'http://www.asktheeu.org' %> is a version of
-        this website for the European Union.
-      </li>
-    <% end %>
-
     <li>
       Ask <strong>other researchers</strong> who are interested in a similar
       issue to yours for ideas. You can sometimes find them by browsing this


### PR DESCRIPTION

## Relevant issue(s)
Fixes #1889

## What does this do?
Removed reference to AsktheEU because it is no longer as relevant given passage of time since Brexit.

## Why was this needed?
The 'unhappy' page appears when someone says their request to a UK public authority was unsuccessful or partially successful. Suggesting the user might make a request to the EU to obtain the information seems less relevant now given the time that has elapsed since the UK left the EU.

## Implementation notes
N/A.

## Screenshots
N/A.

## Notes to reviewer
N/A.