### PR TITLE
1885 improve the language on selected help pages with poor readability

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -1,7 +1,8 @@
 <% @title = "About" %>
-<%= render :partial => 'sidebar' %>
+<%= render partial: 'sidebar' %>
+
 <div id="left_column_flip" class="left_column_flip">
-  <h1 id="introduction">Introduction to WhatDoTheyKnow <a href="#introduction">#</a> </h1>
+  <h1 id="introduction">Introduction to WhatDoTheyKnow <a href="#introduction">#</a></h1>
   <dl>
     <dt id="purpose">
       What is WhatDoTheyKnow for?
@@ -9,36 +10,33 @@
     </dt>
     <dd>
       <p>
-        Under the Freedom of Information Act, it’s everyone’s right to request
-        information from the UK Government and other UK public bodies.
+        Under the Freedom of Information Act, everyone has the right to request information from the UK Government and other UK public bodies.
       </p>
       <p>
-        WhatDoTheyKnow shows you how to make a Freedom of Information request and
-        access information about central government, local government, Parliament,
-        the NHS, the armed forces, state-funded schools and universities and other
-        public authorities.
+        WhatDoTheyKnow shows you how to make a Freedom of Information request. You can access information about central government, local government, Parliament, the NHS, the armed forces, state-funded schools and universities, and other public authorities.
       </p>
       <p>
-        You can also use the site to find out information that regulators hold
-        about businesses, charities and other organisations.
+        You can also use the site to find information that regulators hold about businesses, charities, and other organisations.
       </p>
     </dd>
-    <dt id="premise">How does the site work? <a href="#premise">#</a> </dt>
+    <dt id="premise">
+      How does the site work?
+      <a href="#premise">#</a>
+    </dt>
     <dd>
-      You choose the public authority that you would like information from, then
-      write a brief note describing what you want to know. We will then send your
-      request to the public authority. Both your request, and any response
-      received, are automatically published on the website for you and anyone
-      else to find and read.
+      Choose the public authority you want information from, then write a brief note describing what you want to know. We will send your request to the public authority. Your request and any response are automatically published on the website for anyone to find and read.
     </dd>
-     <dt id="does_it_cost_money">Does it cost money to get an account on the site? <a href="#does_it_cost_money">#</a> </dt>
+    <dt id="does_it_cost_money">
+      Does it cost money to get an account on the site?
+      <a href="#does_it_cost_money">#</a>
+    </dt>
     <dd>
-      <p>No. You can create an account on the site for free. Once you have an account, 
-      you can make up to ten freedom of information requests free of charge each day. 
-        The ten a day limit is more than enough for almost all of our users.</p>
-      <p>We do offer a paid service for journalists and others who may need to make
-      a higher number of requests or have other special requirements. 
-      The paid services is called <a href="https://www.whatdotheyknow.com/pro">WhatDoTheyKnow Pro</a>.</p>
+      <p>
+        No. You can create a free account on the site. Once you have an account, you can make up to ten free Freedom of Information requests each day. The ten-per-day limit is more than enough for almost all of our users.
+      </p>
+      <p>
+        We offer a paid service called <a href="https://www.whatdotheyknow.com/pro">WhatDoTheyKnow Pro</a> for journalists and others who may need to make more requests or have special requirements.
+      </p>
     </dd>
     <dt id="whybother_me">
       Why would I bother to do this?
@@ -46,22 +44,10 @@
     </dt>
     <dd>
       <p>
-        Public bodies are funded by the public purse: you pay taxes, and then
-        government funds its activities with your money: all sorts of things
-        that affect your life, from health care through to national defence.
-        Some it does well, some it does badly.
+        Public bodies are funded using public money. Since it's your money that public bodies are spending, you might want to check that they are running efficiently, making good decisions, and doing their job.
       </p>
       <p>
-        Since it’s your money that public bodies are spending, you might be
-        interested to check that they are running efficiently, making good
-        decisions, and doing the job they are supposed to do.
-      </p>
-      <p>
-        The more we find out about how government works, the better able we are
-        to make suggestions to celebrate the things that are done well, and
-        improve the things that are done badly. Some people and organisations
-        use the site for research; others for journalism, campaigning or
-        awareness-raising. Some are simply curious.
+        The more we find out about how government works, the better we can suggest ways to improve things that are done badly and celebrate things done well. Some people use the site for research, journalism, campaigning, or raising awareness. Others are simply curious.
       </p>
     </dd>
     <dt id="whybother_them">
@@ -69,51 +55,37 @@
       <a href="#whybother_them">#</a>
     </dt>
     <dd>
-      Under Freedom of Information (FOI) law, or sometimes other access to
-      information laws, public authorities have to respond. The response will
-      either contain the information you want, or give a legal reason why it
-      has not been provided.
+      Under Freedom of Information and other access to information laws, public authorities have to respond. The response will either contain the information you want or give a legal reason why it hasn't been provided.
     </dd>
     <dt id="useful">
       Does useful information get released through the site?
       <a href="#useful">#</a>
     </dt>
     <dd>
-      Yes. Thousands of documents have been released through the site.
-      See also: <a href="http://www.guardian.co.uk/news/datablog/2012/mar/20/freedom-of-information-foi">366
-      Interesting things that we know because of WhatDoTheyKnow</a>.
+      Yes. Thousands of documents have been released through the site. See also: <a href="http://www.guardian.co.uk/news/datablog/2012/mar/20/freedom-of-information-foi">366 Interesting things that we know because of WhatDoTheyKnow</a>.
     </dd>
     <dt id="reporting">
-      What if I see a request I feel to be inappropriate?
-      <a href="#reporting">#</a></dt>
+      What if I see a request I feel is inappropriate?
+      <a href="#reporting">#</a>
+    </dt>
     <dd>
       <p>
-        Requests for personal information and vexatious requests are not
-        considered valid for FOI purposes. See our <a href="<%=
-        help_house_rules_path %>">House Rules</a> for more
-        information on how we expect people to use this site.
+        Requests for personal information and vexatious requests are not considered valid for FOI purposes. See our <a href="<%= help_house_rules_path %>">House Rules</a> for more on how we expect people to use this site.
       </p>
       <p>
-        If you believe a request is not suitable, you can report it for
-        attention by the site administrators.
+        If you believe a request is not suitable, you can report it for attention by the site administrators.
       </p>
     </dd>
     <dt id="reporting_unavailable">
-      Why are there some requests I can’t report?
+      Why are there some requests I can't report?
       <a href="#reporting_unavailable">#</a>
     </dt>
     <dd>
       <p>
-        If a request has already been reported to the site administrators, you
-        can’t report it a second time - this is to prevent the administrators
-        being notified multiple times about the same issue before they’ve had
-        a chance to conduct a review.
+        If a request has already been reported to the site administrators, you can't report it a second time. This prevents the administrators from being notified multiple times about the same issue before they've had a chance to review it.
       </p>
       <p>
-        Where a request that you think should be taken down has been previously
-        reported, but a decision has been made not to remove it from public
-        view, you can use the form in the sidebar of the request page to contact
-        the administrators.
+        If you think a request that's been previously reported should be taken down, but a decision has been made not to remove it from public view, you can use the form in the sidebar of the request page to contact the administrators.
       </p>
     </dd>
     <dt id="how_many">
@@ -122,48 +94,28 @@
     </dt>
     <dd>
       <p>
-        We have over <%= number_with_delimiter(User.count.round(-4), :locale => @locale) %>
-        registered users and around 15% to 20% of requests to UK Central
-        Government are made through WhatDoTheyKnow.
+        We have over <%= number_with_delimiter(User.count.round(-4), locale: @locale) %> registered users. Around 15% to 20% of requests to UK Central Government are made through WhatDoTheyKnow.
       </p>
       <p>
-        But that’s just the people who request information. Most visitors to our
-        website don’t make requests themselves, but benefit from being able to
-        access information that’s held in the requests and responses of others.
-        Around six million people per year visit the site.
+        But that's just the people who request information. Most visitors to our site don't make requests themselves. They benefit from being able to access information in the requests and responses of others. Around six million people per year visit the site.
       </p>
     </dd>
-    <dt id="who">Who makes WhatDoTheyKnow? <a href="#who">#</a> </dt>
+    <dt id="who">
+      Who makes WhatDoTheyKnow?
+      <a href="#who">#</a>
+    </dt>
     <dd>
       <p>
-        WhatDoTheyKnow is run and maintained by
-        <a href="http://www.mysociety.org/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a>.
-        mySociety is a registered charity in England and Wales (no.
-        <a href="https://register-of-charities.charitycommission.gov.uk/charity-search/-/charity-details/3078648">
-        1076346</a>).
-        mySociety is also a limited company registered in England and Wales (no.
-        <a href="http://opencorporates.com/companies/gb/03277032">03277032</a>)
-        and a registered data controller (no.
-        <a href="https://ico.org.uk/ESDWebPages/Entry/Z9602302">Z9602302</a>).
-        The <a href="https://www.mysociety.org/about/structure-and-governance/?utm_source=whatdotheyknow.com&utm_medium=link">
-        mySociety trustees</a> form the governing body of the charity
-        and are ultimately responsible for controlling the management and
-        administration of the charity. mySociety’s registered
-        office is mySociety, 483 Green Lanes, London, N13 4BS.
+        <a href="http://www.mysociety.org/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety</a> runs and maintains WhatDoTheyKnow. mySociety is a registered charity in England and Wales (no. <a href="https://register-of-charities.charitycommission.gov.uk/charity-search/-/charity-details/3078648">1076346</a>). mySociety is also a limited company registered in England and Wales (no. <a href="http://opencorporates.com/companies/gb/03277032">03277032</a>) and a registered data controller (no. <a href="https://ico.org.uk/ESDWebPages/Entry/Z9602302">Z9602302</a>). The <a href="https://www.mysociety.org/about/structure-and-governance/?utm_source=whatdotheyknow.com&utm_medium=link">mySociety trustees</a> form the governing body of the charity and are ultimately responsible for controlling the management and administration of the charity. mySociety's registered office is mySociety, 483 Green Lanes, London, N13 4BS.
       </p>
       <p>
         mySociety is not a public body.
       </p>
       <p>
-        The site was initially
-        <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/?utm_source=whatdotheyknow.com&utm_medium=link">
-        funded by the JRSST Charitable Trust</a>.
+        The <a href="http://www.mysociety.org/2006/12/06/funding-for-freedom-of-information/?utm_source=whatdotheyknow.com&utm_medium=link">JRSST Charitable Trust initially funded the site</a>.
       </p>
       <p>
-        If you like what we’re doing, then you can
-          <%= link_to 'make a donation', donation_url(
-             utm_campaign: 'wdtk-help', utm_content: 'about-who-makes-wdtk'
-          ) %>.
+        If you like what we're doing, you can <%= link_to 'make a donation', donation_url(utm_campaign: 'wdtk-help', utm_content: 'about-who-makes-wdtk') %>.
       </p>
     </dd>
     <dt id="updates">
@@ -171,17 +123,12 @@
       <a href="#updates">#</a>
     </dt>
     <dd>
-      We have a <a href="<%= blog_path %>">blog</a> and we’re on
-      <a href="https://www.facebook.com/whatdotheyknowcom/">Facebook</a> and
-      <a href="http://www.twitter.com/whatdotheyknow">Twitter</a> too.
+      We have a <a href="<%= blog_path %>">blog</a> and we're on <a href="https://www.facebook.com/whatdotheyknowcom/">Facebook</a> and <a href="http://www.twitter.com/whatdotheyknow">Twitter</a> too.
     </dd>
   </dl>
   <p>
-    <strong>Next</strong>, read about
-    <a href="<%= help_requesting_path %>">making requests</a> --&gt;
+    <strong>Next</strong>, read about <a href="<%= help_requesting_path %>">making requests</a> --&gt;
   </p>
-
   <%= render partial: 'history' %>
-
   <div id="hash_link_padding"></div>
 </div>

--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -1,97 +1,32 @@
 <% @title = "House rules" %>
-<%= render :partial => 'sidebar' %>
+<%= render partial: 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
-  <h1><%=@title %></h1>
-  <h2> How we expect people to use and behave on the site </h2>
-  <p>
-    Violation of any of the below rules is likely to lead to the suspension of
-    your account, and you will no longer be able to make requests or updates on
-    WhatDoTheyKnow.
-  </p>
-  <p>
-    In some cases, breaking these rules could lead to legal action being taken
-    against you by the authorities or an aggrieved party.
-  </p>
-  <p>
-    Additionally, breaches often take significant amounts of volunteer time to
-    deal with and risk mySociety’s ability to run the service.
-  </p>
+  <h1><%= @title %></h1>
+  <p>If you break any of these rules, we may suspend your account. This means you won't be able to make requests or updates on WhatDoTheyKnow.</p>
+  <p>When rules are broken, our volunteers have to spend a lot of time fixing things. This could make it harder for mySociety to keep running this service.</p>
   <ul>
-    <li>
-      Use WhatDoTheyKnow only to request specific information, not for general
-      correspondence with public authorities, and certainly not for personal
-      correspondence.
-    </li>
-    <li>
-      Do not include potentially defamatory/potential libellous comments (such
-      as allegations) in your requests and annotations.
-    </li>
-    <li>
-      Do not post information that is unlawful, harassing, defamatory, abusive,
-      threatening, harmful, obscene, discriminatory or profane
-    </li>
-    <li>
-      Only use WhatDoTheyKnow to request information which anyone could
-      expect to obtain if they requested it. If you have a specific right to
-      information, for example because you are seeking your own personal 
-      information, then you should correspond privately with the public body
-      concerned to request it. The same principle applies for requests for information 
-      about members of your family. Requests for your own personal information are
-      known as Subject Access requests and
-      <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/"
-      title="Guidance from the Information Commissioner on your right of access">
-      the Information Commissioner (ICO) has published advice on making such requests</a>.
-    </li>
-    <li>
-      Keep messages sent via our service concise and tightly focused on the
-      subject of the request for information. Heed our
-      <%= link_to help_requesting_path(anchor: 'responsible') do -%>
-        advice on making responsible and effective requests.
-      <% end %>
-    </li>
-    <li>
-      Do not try to impersonate someone else.
-    </li>
-    <li>
-      Do not use any language likely to offend in your usage of the service, including requests and annotations.
-    </li>
-    <li>
-      No spamming.
-    </li>
-    <li>
-      Requests must be made in mixed case letters, i.e. not all in capitals and
-      not all in lowercase (this is automatically enforced by the software that
-      WhatDoTheyKnow runs on).
-    </li>
-    <li>
-      Do not make vexatious requests (requests with no serious purpose, or which
-      are intended to disrupt the operation of a public body). The ICO has
-      guidance on vexatious requests
-      <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/"
-      title="Guidance from the Information Commissioner on vexatious requests">
-      here</a>.
-    </li>
-    <li>
-      Do not use our service to request other people’s personal information and 
-      do not include such information in requests, annotations or follow-ups, 
-      unless it is fair to do so.
-    </li>
-    <li>
-      Do not seek to evade the actions of site administrators by, for example,
-      creating new accounts to evade a ban, or a rate-limiting cap, or by
-      republishing material which you know has been removed by moderators.
-    </li>
+    <li>Only use WhatDoTheyKnow to request specific information. Don't use it to send general messages to public authorities or for personal messages.</li>
+    <li>Don't include things that could be seen as harmful or untrue in your requests and comments. Don't make allegations.</li>
+    <li>Don't post anything that is against the law, threatening, abusive, or offensive.</li>
+    <li>Only request information that anyone could expect to get. If you have a special right to certain information, 
+    like your personal data, contact the public body directly. The same goes for personal information about your family 
+    members. Requests for your own data are called Subject Access Requests. The Information Commissioner (ICO) has 
+    <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/" title="Guidance from the Information Commissioner on your right of access">
+    advice on making these requests</a>.</li>
+    <li>Keep your messages short and focused on the information you want. Follow our <%= link_to help_requesting_path(anchor: 'responsible') do %>tips for making good requests.<% end %></li>
+    <li>Don't pretend to be someone else.</li>
+    <li>Don't use language that might offend people in your requests and comments.</li>
+    <li>No spamming.</li>
+    <li>Write requests using both upper and lowercase letters.</li>
+    <li>Don't make vexatious requests that have no real purpose or are meant to cause problems for a public body. The ICO has 
+    <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/" title="Guidance from the Information Commissioner on vexatious requests">
+    guidance on this type of request</a>.</li>
+    <li>Don't use WhatDoTheyKnow to ask for other people's personal information. Don't include this type of information in requests, comments or follow-ups, unless it's fair to do so.</li>
+    <li>Don't try to get around the actions of site administrators. For example, don't make new accounts to avoid a ban or limits on how many requests you can make. Don't repost things you know moderators have removed.</li>
   </ul>
-  <p>
-    By breaking the rules above, you risk being banned from using the site,
-    and/or your requests/annotations being removed.  In cases where it’s clear
-    that your intentions are not malicious, we will contact you first so that we
-    can give advice on how better to use the service.
-  </p>
-  <p>
- The use of threats and abusive language will result in no further contact from mySociety staff and volunteers, and a ban from using the site.
-  </p>
-
+  
+  <p>If you break these rules, you could be banned from the site. We may also remove your requests or annotations. We'll usually contact you first to give advice on how to use the service better.</p>
+  <p>If you use threats or abusive language, mySociety staff and volunteers will stop responding to you. You'll also be banned from using the site.</p>
   <%= render partial: 'history' %>
 
   <div id="hash_link_padding"></div>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -1,5 +1,5 @@
 <% @title = "Making requests" %>
-<%= render :partial => 'sidebar' %>
+<%= render partial: 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
   <h1 id="making_requests"><%= @title %> <a href="#making_requests">#</a></h1>
   <strong>Never made a request before?</strong> Follow our
@@ -12,68 +12,61 @@
       <a href="#which_authority">#</a>
     </dt>
     <dd>
-    <p>It can be hard to untangle the complicated structure of government,
-      and work out who has the information you want. Here are a few tips:
-    </p>
-    <ul>
-      <li>
-        Browse or <a href="<%= search_redirect_path %>">search</a>
-        WhatDoTheyKnow and look for similar requests to the one you plan to
-        make: which authority were they sent to, and were they successful? If
-        so, it&rsquo;s probably the one you want.
-      </li>
-
-      <li>
-        It&rsquo;s always worth double-checking though, so when you&rsquo;ve found an
-        authority you think might have the information, use the
-        &ldquo;home page&rdquo; link on the right hand side of their page to
-        check their website and see exactly what their responsibilities are.
-      </li>
-
-      <li>
-        You might even contact the authority by phone or email to ask if they
-        hold the kind of information you&rsquo;re after.
-      </li>
-
-      <li>
-        But at the end of the day, there’s no need to worry too much about
-        getting the right authority. If you get it wrong, they ought to advise
-        you who to make the request to instead.
-      </li>
-
-      <li>
-        If you&rsquo;ve got a tricky case, please
-        <a href="<%= help_contact_path %>">contact us</a> for help. We have a
-        great team of volunteer administrators who are willing to help.
-      </li>
-
-    </ul>
+      <p>Understanding the structure of the government and finding the information you need can be tricky. 
+      Here are a few tips to help you:
+      </p>
+      <ul>
+        <li>
+          Browse or <a href="<%= search_redirect_path %>">search</a> WhatDoTheyKnow for similar requests to 
+          yours. Check who they were sent to, and if they were successful. If they were, that's 
+          probably the right authority for your request.
+        </li>
+        <li>
+          It&rsquo;s always a good idea to double-check. When you&rsquo;ve found an
+          authority that might have the information, use the
+          &ldquo;home page&rdquo; link on the right hand side of their page. This 
+          will take you to their website where you can see what their responsibilities are.
+        </li>
+        <li>
+          You can also contact the authority by phone or email to ask if they
+          have the kind of information you&rsquo;re looking for.
+        </li>
+        <li>
+          But don&rsquo;t worry too much about finding the right authority. If you make 
+          a mistake, they should tell you who to contact instead.
+        </li>
+        <li>
+          If you have a tricky case, please
+          <a href="<%= help_contact_path %>">contact us</a>. We have a
+          great team of volunteer administrators who are ready to help you.
+        </li>
+      </ul>
     </dd>
     <dt id="missing_body">
-      You&rsquo;re missing the public authority that I want to request from!
+      You&rsquo;re missing the public authority that I want to ask!
       <a href="#missing_body">#</a>
     </dt>
     <dd>
       <p>
         Please <a href="<%= new_change_request_path %>">contact us</a> with the
-        name of the public authority and, if you can find it, their contact email
+        name of the public authority and, if possible, their contact email
         address for Freedom of Information requests.
       </p>
-
       <p>
         If you&rsquo;d like to help add a whole category of public authorities
-        to the site, we&rsquo;d love to hear from you too.
+        to the site, we&rsquo;d love to hear from you.
       </p>
     </dd>
     <dt id="authorities">
       Why do you include some authorities that aren’t formally subject to laws
       on access to public information?
-      <a href="#authorities">#</a> </dt>
+      <a href="#authorities">#</a>
+    </dt>
     <dd>
       <p>
-        As well as providing a simple way to make Freedom of Information
-        requests, WhatDoTheyKnow actively campaigns for the expansion of the scope
-        of Freedom of Information law to cover a wider number of public bodies.
+        WhatDoTheyKnow not only provides a simple way to make Freedom of Information
+        requests, but also actively campaigns to expand the scope of Freedom of 
+        Information law to cover more public bodies.
       </p>
       <p>
         Via the site, you can make requests for information to a range of
@@ -81,29 +74,26 @@
       </p>
       <ul>
         <li>
-          Those formally subject to the FOI Act (as set out in Schedule 1
-          of the Act, as amended).
+          Those subject to the Freedom of Information Act (FOI).
         </li>
         <li>
-          Those formally subject to the Environmental Information Regulations or
-          EIR (a more ambiguous group which includes bodies subject to FOI, and in
-          addition a wider group of bodies with some public role such as utility
-          companies. Currently the legal precedent for setting out which bodies
-          are subject to EIR is the judgement in the
-          <a href="https://actnowtraining.wordpress.com/2015/03/06/open-the-floodgates-water-companies-subject-to-eir/">
-          Fish Legal</a> case).
+          Those subject to The Environmental Information Regulations (EIR). This group is broader 
+          and includes bodies subject to FOI, as well as other organizations with a public 
+          role, such as water companies.
         </li>
         <li>
-          Public bodies which voluntarily comply with the FOI Act even though
-          they are not legally obliged to.
+          Those subject to access to information law in Scotland.
         </li>
         <li>
-          Those which aren’t subject to the Act
+          Organisations which voluntarily comply with FOI even though
+          they don't have to.
+        </li>
+        <li>
+          Those which are not subject to the Act
           <a href="https://www.whatdotheyknow.com/body/list/foi_no">but which we
           think should be</a>, for example because they have significant public
-          responsibilities. These include bodies which operate as regulators,
-          make public appointments, or distribute significant amounts of public
-          funds.
+          responsibilities. These include those who enforce rules,
+          choose people for public roles, or give out a lot of public money.
         </li>
       </ul>
     </dd>
@@ -112,54 +102,48 @@
       <a href="#focused">#</a>
     </dt>
     <dd>
-    <p>
-      A Freedom of Information request is just what the name implies: a request
-      for information, or data. If the authority holds the data, in most cases,
-      the law obliges them to release it.
-    </p>
-    <p>
-      You can speed up the process by making your request concise, clear and
-      focused. Include nothing more than what is needed for the Information
-      Officer to understand what information you are asking for.
-    </p>
-    <p>
-      You should <i>not</i> include:
-    </p>
-    <ul>
-      <li>
-        arguments about your cause
-      </li>
-      <li>
-        statements that could defame or insult others
-      </li>
-      <li>
-        questions or requests for comment rather than for specific information
-      </li>
-    </ul>
-    <p>
-      The Freedom of Information process does not allow for general
-      correspondence, background details or the rights and wrongs of a
-      situation. It simply gives you the right to ask for documents or data
-      that the authority holds.
-    </p>
-    <p>
-      Framing your request accordingly will get better results, so for example,
-      instead of asking  “why are you doing X?” or “how do you feel about the
-      results of doing X” (which makes it more likely that your message will
-      not be seen as a valid FOI request, both by us and by the public authority)
-      you should ask for “copies of all policies and procedures regarding X”.
-      If you include extraneous material, we may have to remove your request to
-      avoid problems with libel law, which is inconvenient for both you and us.
-    </p>
+      <p>
+        A Freedom of Information request is a request for information or data. If the authority has the information, 
+        the law usually requires them to share it. 
+      </p>
+      <p>
+        You can get a quicker response by making your request short, clear, and to the point. Only include what you 
+        really need. This helps the authority to know exactly what you're asking for.
+      </p>
+      <p>
+        You should <i>not</i> include:
+      </p>
+      <ul>
+        <li>
+          arguments about your cause
+        </li>
+        <li>
+          statements that could defame or insult others
+        </li>
+        <li>
+          questions or requests for opinions, instead of asking for specific information
+        </li>
+      </ul>
+      <p>
+        The Freedom of Information process isn't for general discussion, sharing background details, 
+        or debating what is right and wrong. It just lets you ask for documents or data that the 
+        authority has.
+      </p>
+      <p>
+        To get better results, set out your request properly. Asking "why are you 
+        doing X?" or "how do you feel about the results of doing X?" might not be seen as a valid FOI request.
+        Instead, you could ask for "copies of all policies and procedures regarding X." If you include extra
+        information, we may have to remove your request to avoid legal issues, which is not good for 
+        you or us.
+      </p>
+    </dd>
     <dt id="responsible">
       How can I make responsible and effective FOI requests?
       <a href="#responsible">#</a>
     </dt>
     <dd>
       <p>
-        At WhatDoTheyKnow, we have an interest in making sure that our users’
-        FOI requests are as effective as possible, because that’s better for
-        everyone.
+        We want to help you make good FOI requests because it's better for everyone.
       </p>
       <ul>
         <li>
@@ -170,11 +154,11 @@
           because it makes their jobs easier.
         </li>
         <li>
-          It’s better for us, because we rely on the goodwill both of our users
-          and of authorities to continue operation.
+          It’s better for us, because we rely on the goodwill of our users
+          and of authorities to be able to keep the site running.
         </li>
         <li>
-          It’s better for our rights to information as a whole, because if
+          It’s better for our rights to information as a whole. If
           requests become too much of a burden, there’s a greater chance of
           laws being passed that restrict our access to information in the
           future.
@@ -184,98 +168,75 @@
         Here are the ways you can optimise your request:
       </p>
       <ul>
-         <li>
+        <li>
           <strong>Don't make requests for information which is already published:</strong>
           Search WhatDoTheyKnow and the public authority's website to check the material you want isn't already available.
         </li>
         <li>
           <strong>Send it to the right place:</strong>
-          Make an effort to ensure that your request
-          is directed to the appropriate body. We appreciate that’s not always
-          easy, and if you’re not sure after doing some research, by all means
-          make your request to the body you think is most likely to hold the
-          information are seeking. You can expect them to provide advice and
-          assistance to point you to the right place if you get it wrong; or if
-          you get stuck you’re <a href="https://www.whatdotheyknow.com/help/contact">
-          welcome to seek help from the WhatDoTheyKnow volunteer team</a>.
+          Make sure your request goes to the right place. We know this can be hard. If you're not sure, 
+          send your request to the body you think is most likely to have the information. They should 
+          help guide you to the right place if you get it wrong. If you need more help, you can 
+          <a href="https://www.whatdotheyknow.com/help/contact">ask the WhatDoTheyKnow team</a> for help.
         </li>
         <li>
           <p>
             <strong>Send targeted requests:</strong>
-            You might be planning to make a request to, for
-            example, all local councils, or even all public bodies in the country,
-            but  it’s worth stopping to reflect. Such bulk requests result in a
-            lot of data, and cost a lot in staff time for the authorities.
+            You might want to ask all local councils or every public body in the country for information, but it's good 
+            to think about it first. These bulk requests can give you a lot of data and take up a lot of time for the 
+            staff to handle.
           </p>
           <p>
-            Will you actually be able to handle that quantity of data? Consider
-            if your needs could be met by requesting information from a
-            representative sample of bodies, or by requesting information from
-            your local council and a set of councils covering areas with similar
-            characteristics.
+            Will you actually be able to handle that amount of data? Think about if you could get the information you need 
+            by asking a few authorities instead. For example, you could ask your local council and a few others that are 
+            similar.
           </p>
           <p>
-            Also consider if the information may be held centrally, for example
-            by a Government department, and so obtained via a single request
-            rather than many.
+            Is the information may be held centrally by a Government department. If it is you might be able to make a single 
+            request, rather than a large number.
           </p>
         </li>
         <li>
           <strong>Word your question carefully:</strong>
-          It can be worth specifying the format
-          you’d like your response in, and making sure that you ask for exactly
-          the data you need, or you may find that, when making requests to a
-          range of bodies, they answer in so many different formats that you
-          can’t compare like with like.
+          It helps to say what format you want the response in and ask for exactly the data you need. If you don't, different 
+          places might give you answers in different formats, making it hard to compare them.
         </li>
         <li>
-          <strong>Avoid acronyms and ambiguous terms:</strong> Acronyms and
-          jargon whose meaning might appear obvious to you may not be
-          understood by officers receiving your request. Consider expanding
-          acronyms, explaining highly technical terms, and pre-empting
-          potential requests for clarification.
+          <strong>Avoid acronyms and special terms:</strong> Acronyms and special terms that make sense
+
+ to you might 
+          not be clear to the people reading your request. It's better to spell out acronyms and explain technical terms. 
+          This makes sure everything is easy to understand.
         </li>
         <li>
-          <strong>Fine-tune your request:</strong>  Make the right request the
-          first time, and you won’t have to return for further information
-          later. So, consider what you want to do with the information when you
-          receive it and whether you will need additional information to put the
-          material in context.  For example, statistics on the numbers of
-          potholes fixed by a council this year might be more useful if obtained
-          with context such as the figures for previous years.
+          <strong>Fine-tune your request:</strong>  Make the right request the first time so you won't need to ask for 
+          more information later. Think about what you will do with the information and if you need extra details to 
+          understand it better. For example, if you ask for the number of potholes fixed this year, it might help to 
+          also ask for the numbers from past years to compare.
         </li>
         <li>
-          <strong>But don’t ask for too much:</strong> On the flip side, one of
+          <strong>But don’t ask for too much:</strong> One of
           the reasons that authorities can turn down a request is that it would
-          take too many resources (ie staff time and financial cost) to answer
-          fully — so only ask for what you need. Restricting your request to
-          material from a specific time period is a responsible approach and it
-          can prevent your request being rejected on the grounds of being too
-          broad to deal with.
+          take too long and cost too much to answer. Only ask for what you need. 
+          Limiting your request to information for a specific time period is a good 
+          approach. It can stop your request being refused for being too
+          broad.
         </li>
         <li>
-          <strong>Stay courteous:</strong> The FOI officer is often the defender
-          of the public’s right to information within an authority.  They may
-          well be acting as your advocate within the public body, and you’ll
-          find that they’re often  keen to help you. They’ll remain all the more
-          so if you treat them politely.
+          <strong>Be polite:</strong> The FOI officer is the person who helps you get the information you need. 
+          They are like your helper inside the public body and usually want to assist you. They will be even 
+          more willing to help if you treat them politely.
         </li>
         <li>
-          <strong>Remember it’s all going online:</strong> So take care not to
-          include any defamatory material in your request, such as allegations
-          of illegal or abusive behaviour. Not only can such material cause
-          serious problems for us, it can put you at risk of committing libel,
-          and your request being deemed vexatious — in which case you won’t
-          receive a response.
+          <strong>Remember it’s all going online:</strong> Don't include any defamatory claims in your request, 
+          such as allegations. This causes serious problems for us. It can also put you at risk of committing 
+          libel. Your request could be deemed vexatious, which means that you won’t receive a response.
         </li>
         <li>
           <strong>Consider asking for proactive publication:</strong>
-          To save you from having to make a similar request again in the future
-          you might want to ask the public body to consider starting to
-          proactively publish the information on their website. In some cases,
-          where the “datasets” provisions of Freedom of Information law apply,
-          public bodies are required to publish up-to-date versions of requested
-          material.
+          To avoid making the same request in the future, you can ask the public body to start publishing the 
+          information on their website. Sometimes, the law around datasets applies, public bodies have to regularly update and 
+          share the information.
         </li>
       </ul>
       <p>
@@ -298,37 +259,32 @@
       <a href="#campaigning">#</a>
     </dt>
     <dd>
-    <p>
-      If you want information to support an argument or campaign, Freedom of
-      Information is a powerful tool.
-    </p>
-    <ul>
-      <li>
-        Although we can’t help you run your campaign, we encourage you to use
-        WhatDoTheyKnow to get the information you need. You are welcome to link
-        to your campaign from this site in an annotation to your request (you
-        can make annotations after submitting the request).
-      </li>
-      <li>
-        Some campaigners have guided their supporters in making requests for
-        information via WhatDoTheyKnow for their cause, using the
-        <a href="https://www.mysociety.org/2016/12/19/alaveteli-for-campaigners-how-to-create-pre-written-requests-for-your-supporters/?utm_source=whatdotheyknow.com&utm_medium=link">
-        pre-written
-        request tool</a>. There is guidance on how to create pre-written requests
-        <a href="https://www.mysociety.org/2016/12/19/alaveteli-for-campaigners-how-to-create-pre-written-requests-for-your-supporters/?utm_source=whatdotheyknow.com&utm_medium=link">
-        here</a>. You can use annotations to link between requests; this is useful
-        if your request builds on a response that someone else receives, or is
-        for more a more up to date version of information which has been
-        released previously.
-      </li>
-      <li>
-        You may find it useful to get in touch with others who are campaigning
-        on the same issue as you are. Site users can send messages to one
-        another: click on any user’s name to see their profile and a link via
-        which you may contact them.
-      </li>
-
-    </p>
+      <p>
+        Freedom of Information is a powerful tool if you need information to support an argument or campaign.
+      </p>
+      <ul>
+        <li>
+          Although we can’t help you run your campaign, we encourage you to use
+          WhatDoTheyKnow to get the information you need. You are welcome to link
+          to your campaign from this site in an annotation to your request (you
+          can make annotations after submitting the request).
+        </li>
+        <li>
+          Some campaigners have asked their supporters to make requests for
+          information via WhatDoTheyKnow using the
+          <a href="https://www.mysociety.org/2016/12/19/alaveteli-for-campaigners-how-to-create-pre-written-requests-for-your-supporters/?utm_source=whatdotheyknow.com&utm_medium=link">
+          pre-written
+          request tool</a>. There is guidance on how to create pre-written requests
+          <a href="https://www.mysociety.org/2016/12/19/alaveteli-for-campaigners-how-to-create-pre-written-requests-for-your-supporters/?utm_source=whatdotheyknow.com&utm_medium=link">
+          here</a>. You can use annotations to link between requests; this is useful
+          if your request builds on a response that someone else receives, or is
+          for more a more up to date version of information which has already been released.
+        </li>
+        <li>
+          You may find it useful to contact others who are campaigning
+          on the same issue as you are. You can send messages to other users. Click on any user’s name to see their profile, and use the link to contact them.
+        </li>
+      </ul>
     </dd>
     <dt id="fees">
       Does it cost me anything to make a request?
@@ -341,24 +297,19 @@
       <p>
         Authorities often include standardised text in their acknowledgement
         messages saying they “may” charge a fee, which, understandably, can be a
-        little frightening. Ignore such notices. They hardly ever will actually
-        charge a fee.
+        little frightening. Ignore such notices. Most of the things that authorities 
+        can charge for don’t apply to requests made via WhatDoTheyKnow. You will hardly 
+        ever be asked for money. If you are, you would always have the chance to say no. 
+        A public body can only charge you if you have agreed in advance to pay. See 
+        <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#15">more details</a>
+        from the ICO.
       </p>
       <p>
-        Most of the activities that authorities can charge for, such as
-        photocopying, and postage, don’t usually apply to requests made via
-        WhatDoTheyKnow, which are all conducted via email. Additionally, a
-        public body  can only charge you if you have specifically agreed in
-        advance to pay. See <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#15">more details</a>
-        from the Information Commissioner.
-      </p>
-      <p>
-        Sometimes an authority will refuse your request, saying that the cost to
-        them of handling it exceeds <a
-        href="http://www.legislation.gov.uk/uksi/2004/3244/made"> the limits</a>
-        of £600 (for central government) or £450 (for all other public
-        authorities).  At this point you could choose to refine your request:
-        for example, it would be much cheaper for an authority to tell you the
+        Sometimes an authority will refuse your request, saying that it would cost them too much to answer.
+        <a href="http://www.legislation.gov.uk/uksi/2004/3244/made"> The limits</a>
+        are £600 (for central government) or £450 (for all other public
+        authorities).  At this point you can refine your request:
+        for example, it could be cheaper for an authority to tell you the
         amount spent on advertising in the past year than in the past ten years.
       </p>
     </dd>
@@ -368,21 +319,18 @@
     </dt>
     <dd>
       <p>
-        The law requires that if you ask for the information to be provided in a
-        particular format the public authority is required to do so,  so long as
-        it is as reasonably practicable. If you would like to receive the information
-        in a specific format, you should ask for this when you make your request.
+        If you ask for the information to be provided in a particular format, the public authority has to do so, so long as
+        it is reasonably practicable. If you want to receive the information in a specific format, you must 
+        ask for this when you make your request.
       </p>
       <p>
         You might want to explicitly request data in a reusable format such as a
-        .csv file (which you can import into spreadsheet software); this helps
-        prevent the response being provided as  images, or screenshots of
-        spreadsheets which are much harder to extract data from.
+        .csv file. This helps prevent the response being provided as images, or 
+        screenshots of spreadsheets that are harder to extract data from.
       </p>
       <p>
-        There’s no need to explicitly request a response ‘via email’, though: we
-        consider that by making your request via WhatDoTheyKnow, you are already
-        making this clear.
+        There’s no need to explicitly request a response ‘via email’. By making your request via WhatDoTheyKnow, 
+        you are already making this clear.
       </p>
     </dd>
     <dt id="quickly_response">
@@ -391,26 +339,24 @@
     </dt>
     <dd>
       <p>
-        By law, public authorities must respond <i>“promptly”</i> to requests.
-        We interpret this to mean that you should expect a response as soon as
-        is practical for the authority in question, taking into consideration
-        factors such as the quantity of information you have requested, the
-        authority’s workload from other requests, and the staff available to
-        deal with them.
+        Public authorities must respond <i>“promptly”</i> to requests.
+        This means that you should expect a response as soon as
+        is practical for the authority to answer, taking into consideration
+        the amount of information you have asked for, their
+        workload, and the staff available to deal with your request.
       </p>
       <p>
-        In any case,  the law states that they must respond within 20 working
+        The law states that they must respond within 20 working
         days, with a couple of exceptions: if you had to clarify your request,
-        or your request is to  a school, or in one or two other scenarios, then
+        or your request is to a school, or in one or two other scenarios, then
         they may have more time — <a
         href="https://www.whatdotheyknow.com/help/officers#days">you can read
         more about timescales here</a>.
       </p>
       <p>
-        WhatDoTheyKnow will automatically send you an email reminder if you don’t
-        get a response  within the time limit. You can then send the public
-        authority a message to chase your request, and tell them if they are
-        breaking the law.
+        We will automatically send you an email reminder if you don’t
+        get a response within the time limit. You can then send the public
+        authority a message to prompt them to reply.
       </p>
     </dd>
     <dt id="no_response">
@@ -418,50 +364,14 @@
       <a href="#no_response">#</a>
     </dt>
     <dd>
-    <p>
-      There are several things you can do if your request goes unanswered.
-    </p>
-    <ul>
-      <li>
-        <strong>First, check it went through.</strong>  If you see <a
-        href="https://www.mysociety.org/2016/07/29/the-small-symbol-that-tells-you-all-is-well/?utm_source=whatdotheyknow.com&utm_medium=link">
-        a little green tick</a> on your request page, you can
-        be sure that your request went through smoothly from our end and has
-        been received by the authority’s mail server. Nonetheless, there can
-        sometimes be a hitch at the other end, so it is worth telephoning the
-        authority and politely checking that they received your request. Quote
-        any reference number that may have been included in an auto-response.
-        They may also ask what format your request was sent in: all
-        WhatDoTheyKnow requests are sent by  email.
-      </li>
-      <li>
-        <strong>If it went through, follow up.</strong> Use the “Write a reply”
-        option under “Actions” on your request, to request an acknowledgement
-        of your request if one isn’t forthcoming.
-      </li>
-      <li>
-        <strong>If they have not received it,</strong> the problem is most
-        likely due to “spam filters”. Refer the authority to the measures in the
-        answer &lsquo;<a href="<%= help_officers_path(:anchor =>
-        'spam_problems') %>">I can see a request on WhatDoTheyKnow, but we never
-        got it by email!</a>&rsquo; in the FOI officers&rsquo; section of this
-        help.  If you don’t see the little green tick on your request page, you
-        should use the “Report this request” option under “Actions” to alert the
-        volunteer support team to the problem.
-      </li>
-      <li>
-        <strong>If you&rsquo;re still having no luck,</strong>then you can first
-        ask for an internal review, and then complain to the Information
-        Commissioner about the authority. If you get no response at all then you
-        can ask the ICO for help without waiting for an internal review. Read
-        our page &lsquo;<a href="<%= help_general_path(:template => 'unhappy')
-        %>">Unhappy about the response you got?</a>&rsquo;.
-      </li>
-    </ul>
+      <p>
+        You can read more about what to do if you don't get a response at all on our <a href="<%= help_general_path(template: 'no_response') %>">
+        dedicated help page</a>.
+      </p>
     </dd>
-    <dt id="not_satifised">
+    <dt id="not_satisfied">
       What if I&rsquo;m not satisfied with the response?
-      <a href="#not_satifised">#</a>
+      <a href="#not_satisfied">#</a>
     </dt>
     <dd>
       If you didn&rsquo;t get the information you asked for, or you
@@ -474,71 +384,62 @@
       <a href="#reuse">#</a>
     </dt>
     <dd>
-    <p>
-      Authorities often add legal boilerplate citing the
-      “<a href="http://www.opsi.gov.uk/si/si2005/20051515">Re-Use of Public Sector
-      Information Regulations 2005</a>”, which at first glance implies you may not
-      be able do anything with the information. They also sometimes put copyright
-      notices on material.
-    </p>
-    <p>
-      Careful scrutiny of the legislation, however, shows that you are at
-      liberty to  write articles about the information, summarise it, or quote
-      parts of it.  It’s WhatDoTheyKnow’s belief that  you should feel free to
-      republish the information in full, just as we do, even though in theory
-      you might not be allowed to do so: <a href="<%= help_officers_path(:anchor => 'copyright') %>">
-      our policy on copyright</a> explains why.
-    </p>
-    <p>
-      If the information you have received is Crown Copyright then you are able to
-      reproduce it under the
-      <a href="http://www.nationalarchives.gov.uk/information-management/government-licensing/about-the-ogl.htm">Open
-      Government Licence</a> but there are some conditions — check that link for
-      more details.
-    </p>
+      <p>
+        Authorities often add legal boilerplate citing the
+
+
+        “<a href="http://www.opsi.gov.uk/si/si2005/20051515">Re-Use of Public Sector
+        Information Regulations 2005</a>”. They also sometimes put copyright
+        notices on material.
+      </p>
+      <p>
+        If the information you have received is Crown Copyright then you are able to
+        reproduce it under the
+        <a href="http://www.nationalarchives.gov.uk/information-management/government-licensing/about-the-ogl.htm">Open
+        Government Licence</a> but there are some conditions — check that link for
+        more details.
+      </p>
     </dd>
     <dt id="ico_help">
       Can you get into the details about the process of making requests?
       <a href="#ico_help">#</a>
     </dt>
     <dd>
-    <p>
-      Have a look at the
-      <a href="https://ico.org.uk/for-the-public/official-information/">
-      access to official information</a> pages on the Information
-      Commissioner&rsquo;s website.
-    </p>
-    <p>If you&rsquo;re requesting information from a Scottish public authority,
-      the process is very similar, although there are differences around time
-      limits for compliance.
-      See the
-      <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">
-      Scottish Information Commissioner&rsquo;s guidance</a> for details.
-    </p>
+      <p>
+        Have a look at the
+        <a href="https://ico.org.uk/for-the-public/official-information/">
+        access to official information</a> pages on the Information
+        Commissioner&rsquo;s website.
+      </p>
+      <p>
+        If you&rsquo;re requesting information from a Scottish public authority,
+        the process is very similar, although there are differences around time
+        limits for compliance.
+        See the
+        <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">
+        Scottish Information Commissioner&rsquo;s guidance</a> for details.
+      </p>
     </dd>
     <dt id="data_protection">
       Can I request information about myself?
       <a href="#data_protection">#</a>
     </dt>
     <dd>
-    <p>
-      No. The correct channel for requesting any information that a public
-      authority holds about you is via a Subject Access request using the Data
-      Protection law.
-    </p>
-    <p>
-      This website does not allow for such requests, not least because we
-      publish correspondence online, where anyone would be able to see the
-      potentially sensitive information that can result from such requests.
-      <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">
-      The Information Commissioner’s website</a> provides advice on how to make a
-      Subject Access request.
-    </p>
-    <p>
-      If you see that somebody has included personal information, perhaps
-      by mistake, in a request, please <a href="<%= help_contact_path %>">
-      contact us</a> immediately so we can remove it.
-    </p>
+      <p>
+        No. If you want to access information that a public
+        authority holds about you, you need to make a Subject Access request in private.
+      </p>
+      <p>
+        We don't allow subject access requests to be made using WhatDoTheyKnow.
+        <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">
+        The Information Commissioner’s website</a> provides advice on how to make a
+        Subject Access request.
+      </p>
+      <p>
+        If you see that somebody has included personal information in a request, please 
+        <a href="<%= help_contact_path %>">
+        contact us</a> so that we can remove it.
+      </p>
     </dd>
     <dt id="data_protection_deceased_persons">
       Can I request information about a deceased person?
@@ -546,15 +447,15 @@
     </dt>
     <dd>
       <p>
-        When seeking information relating to a deceased person please carefully
-        consider if a Freedom of Information request via WhatDoTheyKnow is
-        appropriate and think about the potential impacts of making the request,
+        When seeking information relating to a deceased person please
+        consider if a Freedom of Information request is
+        appropriate. Think about the potential impacts of making the request,
         and receiving a response, in public.
       </p>
       <p>
         WhatDoTheyKnow is only for making requests for information which anyone
-        could expect to obtain if they requested it. There are some laws, and
-        procedures, which give certain people special rights to information, 
+        could expect to be given. There are laws, and
+        procedures, which give some people special rights to information, 
         such as the
         <a href="https://www.nhs.uk/common-health-questions/nhs-services-and-treatments/can-i-access-the-medical-records-health-records-of-someone-who-has-died/"
         title="NHS England guidance on the Access to Health Records Act 1990">
@@ -562,9 +463,8 @@
         <a href="https://www.gov.uk/guidance/request-records-of-deceased-service-personnel"
         title="MoD Guidance: Request records of deceased service personnel">
         Ministry of Defence procedure for accessing records of deceased service
-        personnel</a>. Where the requester has a special right to the
-        information being sought requests should be made privately and directly
-        and not via WhatDoTheyKnow.
+        personnel</a>. If you have a special right to the
+        information, your request should be made directly, and not via WhatDoTheyKnow.
       </p>
       <p>
         If you think there is information about a deceased person that we
@@ -579,17 +479,16 @@
     </dt>
     <dd>
       <p>
-        WhatDoTheyKnow is currently only designed for public requests. All
+        WhatDoTheyKnow is currently designed for public requests. Almost all
         responses that we receive are automatically published on the website for
         anyone to read.
       </p>
       <p>
-        However, WhatDoTheyKnow<sup>Pro</sup> is a service for journalists and
-        campaigners which includes the ability to delay publication of your
+        WhatDoTheyKnow<sup>Pro</sup> is a service for journalists and
+        campaigners that includes the ability to delay publication of your
         requests and responses. If you are a journalist, campaigner, activist,
-        or someone else with a need to make requests for information which are,
-        at least initially, private then <a href="<%= account_request_index_path %>">
-        find out more and get in touch</a>.
+        or someone else with a need to make requests for information which are initially private 
+        then <a href="<%= account_request_index_path %>"> find out more and get in touch</a>.
       </p>
     </dd>
     <dt id="eir">
@@ -598,25 +497,24 @@
       <a href="#eir">#</a>
     </dt>
     <dd>
-    <p>
-      <a href="https://www.whatdotheyknow.com/body?tag=eir_only">Some public
-      authorities</a>, such as <a href="http://www.whatdotheyknow.com/body/milford_haven_port_authority">
-      Milford Haven Port Authority</a>, don&rsquo;t
-      come under the Freedom of Information Act, but do come under another law
-      called the Environmental Information Regulations (EIR).
-    </p>
-    <p>It&rsquo;s a very similar law, so you make a request
-      to them using WhatDoTheyKnow in just the same way as an FOI request. The only
-      difference is that on the page where your write you request, it reminds you
-      that you can only request &ldquo;environmental information&rdquo; and tells you what that
-      means. It is quite broad.
-    </p>
-    <p>
-      You can, of course, request environmental information from other
-      authorities. Just make a Freedom of Information (FOI) request as normal. The
-      authority has a duty to work out if the Environmental Information Regulations
-      (EIR) is the more appropriate legislation to reply under.
-    </p>
+      <p>
+        <a href="https://www.whatdotheyknow.com/body?tag=eir_only">Some public
+        authorities</a>, such as <a href="http://www.whatdotheyknow.com/body/milford_haven_port_authority">
+        Milford Haven Port Authority</a>, don&rsquo;t
+        come under the Freedom of Information Act, but do come under another law
+        called the Environmental Information Regulations (EIR).
+      </p>
+      <p>It&rsquo;s a very similar law, so you make a request
+        to them using WhatDoTheyKnow in just the same way as an FOI request. The only
+        difference is that on the page where your write your request, it reminds you
+        that you can only request &ldquo;environmental information&rdquo; and tells you what that
+        means. It is quite broad.
+      </p>
+      <p>
+        You can ask for environmental information from other
+        authorities. Just make a request as normal. The
+        authority has a duty to work out what the right law is to reply under.
+      </p>
     </dd>
     <dt id="multiple">
       Can I make the same request to lots of authorities, e.g. all councils?
@@ -624,32 +522,13 @@
     </dt>
     <dd>
       <p>
-        This is possible, under certain circumstances. We urge those considering
-        making requests to large numbers of bodies to carefully consider if
-        doing so is justified. Thought should be given to the potential cost to
-        the public sector, the reputation of Freedom of Information and
-        WhatDoTheyKnow as well as the potential benefits of having the
-        information released.
+        This is possible, under some circumstances. There is a daily cap on the 
+        number of requests that can be using WhatDoTheyKnow. This is to help prevent 
+        spam. We would recommend sending a test version of your request to a few authorities. 
+        Their responses will help you improve the wording of your request.
       </p>
       <p>
-        Once you are sure that your requests are valid and defensible, we ask
-        you to first send a test version to a few authorities. Their responses
-        will help you improve the wording of your request, so that you get the
-        best information when you go on to send it to the remaining authorities.
-      </p>
-      <p>
-        There are some automated restrictions on the number of requests that
-        can be sent through WhatDoTheyKnow at a time. These are for spam
-        prevention and can be overridden on request. Before removing
-        restrictions on accounts the team may make suggestions aimed at
-        improving the requests, and checking information isn’t already
-        published, or hasn’t already been collated centrally, and can’t be
-        obtained by a request to just one body.
-      </p>
-      <p>
-        There is currently no automated system for sending the request to
-        multiple authorities: you must copy and paste it by hand; however, if
-        you are a journalist, activist, campaigner or someone else who would
+        If you are a journalist, activist, campaigner or someone else who would
         find it useful to have a tool enabling you to make requests to multiple
         bodies at the same time, then you might be interested in our
         <%= link_to 'WhatDoTheyKnow Pro service', account_request_index_path %>.
@@ -661,52 +540,45 @@
     </dt>
     <dd>
       <p>
-        WhatDoTheyKnow is an archive of requests made through the site, and does
-        not aspire to be an archive of <i>all</i> FOI requests.
+        WhatDoTheyKnow is an archive of requests made using our service. We don’t 
+        allow users to upload requests that were made by other means. We have no 
+        plans to add this feature in the future. This is because we can’t verify 
+        that responses received from outside of our system actually came from the 
+        authority. We want to make sure that all content on WhatDoTheyKnow is 100% verifiable.
       </p>
-      <p>
-        For that reason, we don’t  provide a means by which to upload requests
-        that were made by other means, and we have no plans to do so in the
-        future. The main reason for this is that we can’t verify that responses
-        received from outside our system actually came from the authority they
-        purport to — and we are keen to ensure that all content on
-        WhatDoTheyKnow is 100% verifiable.
-      </p>
-      <p>
     </dd>
-
-
     <dt id="attachments">
-      How can I attach a document to my message?
+      How can I attach a file to my request?
       <a href="#attachments">#</a>
     </dt>
     <dd>
       <p>
-        It is exceptionally rare that a Freedom of Information request requires
-        an attached document, so we don’t offer this functionality. If
-        necessary, you can upload material to other services such as flickr.com,
+        It is not possible to add attachments to requests made using WhatDoTheyKnow. 
+        You could upload the file to services such as flickr.com,
         Google Docs, or scribd.com and then provide a link in the body of your
-        request.  Where a location on map is required as part of a request, many
+        request. Where a location on map is required as part of a request, many
         online mapping services, such as Google Maps, allow you to share exact
         co-ordinates via a link.
       </p>
-    <dd>
+    </dd>
     <dt id="whistleblowers">
       Do you have any advice for public sector whistleblowers?
       <a href="#whistleblowers">#</a>
     </dt>
     <dd>
       <p>
-        If you work for a public body and you know of  information that the
+        If you work for a public body and you know of information that the
         public should have access to, making a Freedom of Information request
-        via WhatDoTheyKnow can be a good way to get it into the public domain.
+        via WhatDoTheyKnow can be a good way to get it released.
         We’re happy for people to use our service under a pseudonym (although
         you should first read <a
         href="<%= help_privacy_path(:anchor => 'real_name') %>">our advice
         on using pseudonyms</a>).
       </p>
       <p>
-        Whistleblowers keen to keep their identity secret should take
+        Whistleblowers who want to keep their identity secret
+
+ should take
         precautions such as not making their request from their workplace, and
         not using their work email address (it’s possible a court may order us
         to release user information we hold). Using a pre-paid mobile phone
@@ -715,42 +587,35 @@
       </p>
       <p>
         You may wish to consider setting up a new account for your
-        whistleblowing request as your history of requests may help people to identify you.
-        
+        whistleblowing request, as previous requests may help people to identify you.
         The UK charity <a href="https://protect-advice.org.uk/">Protect</a> aims to make whistleblowing work for individuals, organisations and society and offers a free, confidential whistleblowing advice line.
         For EU citizens and residents <a
         href="https://hrdrelocation.eu/">the EU Human Rights Defenders Relocation
         Platform</a> may be able to offer assistance.
-        
         See also: <a
-        href="https://p10.secure.hostingprod.com/@spyblog.org.uk/ssl/ht4w/2011/06/table-of-contents.html">Hints and Tips for Whistleblowing from Spy Blog</a> and 
+        href="https://p10.secure.hostingprod.com/@spyblog.org.uk/ssl/ht4w/2011/06/table-of-contents.html">Hints and Tips for Whistleblowing from Spy Blog</a>
       </p>
-    <dd>
+    </dd>
     <dt id="moderation">
       How do you moderate request annotations?
       <a href="#moderation">#</a>
     </dt>
     <dd>
       <p>
-        Annotations on WhatDoTheyKnow have a specific purpose: they are provided
-        so that the site’s community of users can help people get the
-        information they want, or, once they’ve received it, give them advice
-        about the next steps they might take. We reserve the right to remove
-        annotations that don’t fit into one of these categories.
+        Annotations on WhatDoTheyKnow are for helping other people to get the
+        information they want, or, giving advice about the next steps they might take. 
+        We reserve the right to remove annotations that don’t fit into one of these categories.
       </p>
       <p>
         Political discussions and personal opinions are not allowed in
-        annotations: if you feel strongly that you need to provide background
+        annotations. If you feel strongly that you need to provide background
         context, you may post a link to a suitable forum, blog post or campaign
-        site elsewhere. Please see our <a href="<%= help_house_rules_path
-        %>">House Rules</a> section for more information about the standards we
-        expect our users to adhere to.
+        site elsewhere. Please see our <a href="<%= help_house_rules_path %>">House Rules</a> for more information.
       </p>
       <p>
-        We want to keep our service tightly focused on its purpose, and with
-        limited administrative resources, we prioritise substantive FOI requests
-        and responses. For that reason we spend less time on the moderation of
-        annotations than of FOI correspondence, and the threshold for removal of
+        With limited administrative resources, we prioritise substantive FOI requests
+        and responses. We spend less time on the moderation of
+        annotations than of FOI requests, and the threshold for removal of
         annotations is relatively low.
       </p>
     </dd>
@@ -761,3 +626,4 @@
 
   <div id="hash_link_padding"></div>
 </div>
+```


### PR DESCRIPTION
## Relevant issue(s)
Closed #1885 
## What does this do?
Improves the wording on some of the lower ranked help pages to make it more accessible. 
## Why was this needed?
We used a lot of archaic sentence structures and overly formal language, where this wasn't needed. 
## Implementation notes

## Screenshots

## Notes to reviewer
This will need sign-off before merging due to changes in the wording of the site rules, which could have wider implications.