### PR TITLE
[ExcelAnalyzer] remove prominence contact us link

### DIFF
--- a/lib/excel_analyzer.rb
+++ b/lib/excel_analyzer.rb
@@ -8,6 +8,10 @@ Rails.application.config.before_initialize do
   loader.inflector.inflect("pii_badger_job" => "PIIBadgerJob")
 end
 
+ExcelAnalyzer::PROMINENCE_REASON = "We've found a problem with this file, so " \
+  "it's been hidden while we review it. We might not be able to give more " \
+  "details until then."
+
 ExcelAnalyzer.on_hidden_metadata = ->(attachment_blob, _) do
   foi_attachment = FoiAttachment.joins(:file_blob).
     find_by(active_storage_blobs: { id: attachment_blob })
@@ -17,9 +21,7 @@ ExcelAnalyzer.on_hidden_metadata = ->(attachment_blob, _) do
 
   foi_attachment.update_and_log_event(
     prominence: 'hidden',
-    prominence_reason: "We've found a problem with this file, so it's been " \
-                       "hidden while we review it. We might not be able to " \
-                       "give more details until then.",
+    prominence_reason: ExcelAnalyzer::PROMINENCE_REASON,
     event: {
       editor: User.internal_admin_user,
       reason: 'ExcelAnalyzer: hidden data detected'

--- a/lib/helper_patches.rb
+++ b/lib/helper_patches.rb
@@ -15,4 +15,20 @@ Rails.configuration.to_prepare do
   end
 
   DatasetteHelper.datasette_url = 'https://data.mysociety.org/datasette/'
+
+  ProminenceHelper::Base.class_eval do
+    module ExcelAnalyzerDisableContactUs
+      def contact_us
+        return if hidden_by_excel_analyzer?
+        super
+      end
+
+      def hidden_by_excel_analyzer?
+        prominenceable.prominence == 'hidden' &&
+          prominenceable.prominence_reason == ExcelAnalyzer::PROMINENCE_REASON
+      end
+    end
+
+    prepend ExcelAnalyzerDisableContactUs
+  end
 end


### PR DESCRIPTION
The ProminenceHelper automatically injects a contact us link into the reason why an object has been hidden. While normally this is okay we want to remove this for files hidden by ExcelAnalyzer to reduce inbox support.
