### PR TITLE
WIP: Add citation promo to pro mailouts

### DIFF
--- a/lib/views/alaveteli_pro/embargo_mailer/expired_alert.html.erb
+++ b/lib/views/alaveteli_pro/embargo_mailer/expired_alert.html.erb
@@ -1,0 +1,5 @@
+<p style="background:#fdf07a;border:2px solid #fdd906;padding:10px;">
+  <a href="">Tell us how you've used your requests</a> and get free Pro credit!
+<p>
+
+<%= simple_format(render(template: 'alaveteli_pro/embargo_mailer/expired_alert', formats: [:text])) %>

--- a/lib/views/alaveteli_pro/embargo_mailer/expiring_alert.html.erb
+++ b/lib/views/alaveteli_pro/embargo_mailer/expiring_alert.html.erb
@@ -1,0 +1,5 @@
+<p style="background:#fdf07a;border:2px solid #fdd906;padding:10px;">
+  <a href="">Tell us how you've used your requests</a> and get free Pro credit!
+<p>
+
+<%= simple_format(render(template: 'alaveteli_pro/embargo_mailer/expiring_alert', formats: [:text])) %>

--- a/lib/views/notification_mailer/daily_summary.html.erb
+++ b/lib/views/notification_mailer/daily_summary.html.erb
@@ -1,0 +1,5 @@
+<p style="background:#fdf07a;border:2px solid #fdd906;padding:10px;">
+  <a href="">Tell us how you've used your requests</a> and get free Pro credit!
+<p>
+
+<%= simple_format(render(template: 'notification_mailer/daily_summary', formats: [:text])) %>


### PR DESCRIPTION
Fixes https://github.com/mysociety/whatdotheyknow-private/issues/332.

Adding only the HTML part to the theme seems to prevent the mail being sent as multipart. IDK whether this is an issue with the rails previewer not working well with our theme override, or whether this will also happen in production with it stopping at the theme `embargo_mailer` directory instead of falling back to the core one to get the text version. If so, we'll just have to override the text template without modification.

Obviously need to add the link to the blog post, and maybe tweak phrasing / design of the banner.

![Screenshot 2024-07-05 at 16 17 16](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/199c4760-0c5d-48d1-9216-11be41ad43c7)

![Screenshot 2024-07-05 at 16 17 29](https://github.com/mysociety/whatdotheyknow-theme/assets/282788/888fa161-459b-46c8-8f60-bd8268c1942b)
