### PR TITLE
Fix button-tertiary styling

### DIFF
--- a/app/assets/stylesheets/responsive/_mixins.scss
+++ b/app/assets/stylesheets/responsive/_mixins.scss
@@ -14,6 +14,7 @@
   font-weight: 600;
   text-decoration: none;
   transition: background-color 300ms ease-out;
+  line-height: normal;
   margin-bottom: 0;
   font-family: $font-family;
   &:hover,


### PR DESCRIPTION
Ensure these button are the same height as primary buttons.

Before (with button hover to show difference):
![image](https://github.com/user-attachments/assets/817214d1-2da2-4607-9e11-a540fe011bb8)

After:
![image](https://github.com/user-attachments/assets/e0ad43ad-890d-4d09-8f4e-d7e695b05b36)

The remaining difference is sue to the primary button boarder styling:
<img width="271" alt="image" src="https://github.com/user-attachments/assets/1857faf2-7640-4958-be83-3c944b59fdf5">
