### PR TITLE
Add missing space in school working day copy

### DIFF
--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -267,7 +267,7 @@
       <p>
         The date thus calculated is shown on requests with the text “By law,
         Liverpool City Council should normally have responded by...”.  Schools
-        are a special case, which WhatDoTheyKnow displays differently.Since June
+        are a special case, which WhatDoTheyKnow displays differently. Since June
         2009, schools have “20 working days disregarding any working day which
         is not a school day, or 60 working days, whichever is first” (<a
         href="http://www.legislation.gov.uk/uksi/2009/1369/contents/made">FOI


### PR DESCRIPTION
## Relevant issue(s)

None

## What does this do?

Trivial change to add a space at the end of a sentence in the help.

## Why was this needed?

So clearer to read.

## Implementation notes

Trivial.

## Screenshots

Before:

<img width="736" alt="image" src="https://github.com/user-attachments/assets/1f6215ee-1962-458f-a0a2-e429886ccdac">

## Notes to reviewer

None.