### PR TITLE
[#1886] Update links for Scottish Information Commissioner

### DIFF
--- a/lib/views/help/about_foisa.html.erb
+++ b/lib/views/help/about_foisa.html.erb
@@ -144,7 +144,7 @@
     <a href="#appeal">#</a>
   </h2>
   <p>
-  You can contact the Scottish Information Commissioner (<abbr title="Office of the Scottish Information Commissioner">OSIC</abbr>) by email at: <b><a href="mailto:enquiries@itspublicknowledge.info">enquiries@itspublicknowledge.info</a></b>, or by post:
+  You can contact the Scottish Information Commissioner (<abbr title="Office of the Scottish Information Commissioner">OSIC</abbr>) by email at: <b><a href="mailto:enquiries@foi.scot">enquiries@foi.scot</a></b>, or by post:
   </p>
   <p>
   Scottish Information Commissioner<br>
@@ -156,7 +156,7 @@
   <p>
   You can also contact them for advice, by calling their helpline on <b>01334 464 610</b>, or if you use <abbr title="British Sign Language">BSL</abbr>, by using <a href="http://contactscotland-bsl.org">Contact Scotland BSL</a>.
   </p>
-  <p>There is more information on how to appeal, including a form that you can use (if you'd like), on the <abbr title="Office of the Scottish Information Commissioner">OSIC</abbr> website at: <a href="https://www.itspublicknowledge.info/appeal">https://www.itspublicknowledge.info/appeal</a>.</p>
+  <p>There is more information on how to appeal, including a form that you can use (if you'd like), on the <abbr title="Office of the Scottish Information Commissioner">OSIC</abbr> website at: <a href="https://www.foi.scot/appeal">https://www.foi.scot/appeal</a>.</p>
   </p>
   <%= render partial: 'history' %>
   <div id="hash_link_padding"></div>

--- a/lib/views/help/appeals.html.erb
+++ b/lib/views/help/appeals.html.erb
@@ -56,10 +56,10 @@
 </p>
 <p>
   If you made your request to a Scottish Public Authority, you can complain to the OSIC by email 
-  at <strong><code><a href="mailto:enquiries@ItsPublicKnowledge.info">enquiries@ItsPublicKnowledge.info</a></code></strong>.
+  at <strong><code><a href="mailto:enquiries@foi.scot">enquiries@foi.scot</a></code></strong>.
 </p>
 <p>
-  They provide an <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/Application_Form_-_Website.docx">application form</a> 
+  They provide an <a href="https://www.foi.scot/sites/default/files/2024-08/ApplicationForm2024.docx">application form</a> 
   for you to use if you wish to do so. They will need to see a copy of your request and a copy of your request 
   for an internal review, so make sure to include a link to your request as part of your complaint.
 </p>

--- a/lib/views/help/environmental_information.html.erb
+++ b/lib/views/help/environmental_information.html.erb
@@ -102,7 +102,7 @@
   excessively large or deemed unreasonable.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(b)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/manifestly-unreasonable-requests-regulation-12-4-b-environmental-information-regulations/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(b)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingRegulation104bManifestlyUnreasonableRequests.docx%20(1).pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(b)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingRegulation104bManifestlyUnreasonableRequests.pdf">OSIC guidance</a></li>
   </ul>
   <strong>😕 Formulated in too general a manner</strong>
   <p>An authority is not required to release information if the request is not specific or clear enough.</p>
@@ -160,7 +160,7 @@
   <p>If the requested information includes personal data, the public authority may refuse to disclose it if doing so would breach data protection law.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/13/made">Regulation 13</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2619056/s40-personal-information-section-40-regulation-13.pdf">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/11/made">Regulation 11</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRs%20Guidance%20Regualtion%2011%20Personal%20Data.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/11/made">Regulation 11</a> - <a href="https://www.foi.scot/sites/default/files/2023-08/EIRsGuidanceRegulation11Personaldata.pdf">OSIC guidance</a></li>
   </ul>
   <strong>💣 International relations, defence, and security</strong>
   <p>Authorities may refuse to provide information if doing so would harm international relations, defence, national security, or public safety.</p>

--- a/lib/views/help/environmental_information.html.erb
+++ b/lib/views/help/environmental_information.html.erb
@@ -95,26 +95,26 @@
   not have to provide you with it.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(a)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/#holding">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(a)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/InformationNotHeldEIRs%20%281%29.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(a)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/InformationNotHeldEIRs%20(1).pdf">OSIC guidance</a></li>
   </ul>
   <strong>✋ Manifestly unreasonable requests</strong>
   <p>Public authorities may refuse to disclose information if the amount of information that you have asked for is 
   excessively large or deemed unreasonable.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(b)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/manifestly-unreasonable-requests-regulation-12-4-b-environmental-information-regulations/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(b)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingRegulation104bManifestlyUnreasonableRequests.docx%20%281%29.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(b)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingRegulation104bManifestlyUnreasonableRequests.docx%20(1).pdf">OSIC guidance</a></li>
   </ul>
   <strong>😕 Formulated in too general a manner</strong>
   <p>An authority is not required to release information if the request is not specific or clear enough.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(c)</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1619/requests_formulated_in_too_general_a_manner_eir_guidance.pdf">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(c)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/EIRsGuidanceRegulation104cRequestswhicharetoogeneral.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(c)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation104cRequestswhicharetoogeneral.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🚧 Unfinished Material</strong>
   <p>An authority is not required to release information that it is still working on/is unfinished.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(d)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-124d-eir/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(d)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(d)</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🤫 Confidentiality of proceedings</strong>
   <p>Public authorities may refuse a request if disclosing the information would breach the confidentiality 
@@ -122,57 +122,57 @@
   exchanged during legal proceedings, such as court hearings or tribunal proceedings.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(d)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-d-confidentiality-of-proceedings-environmental-information-regulations/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(d)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(d)</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
   </ul>
   <strong>📧 Internal communications</strong>
   <p>Public authorities may refuse to disclose internal communications, such as draft documents or internal discussions.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(e)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-4-e-internal-communications/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(e)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2023-03/EIRsGuidanceRegulation104eInternalCommunications.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(e)</a> - <a href="https://www.foi.scot/sites/default/files/2023-03/EIRsGuidanceRegulation104eInternalCommunications.pdf">OSIC guidance</a></li>
   </ul>
   <strong>📄 Intellectual property rights</strong>
   <p>If disclosing the information would infringe on intellectual property rights, such as copyrights or trademarks, 
   the public authority may refuse the request.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(c)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-c-intellectual-property-rights/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(c)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/EIRsGuidanceRegulation105cIntellectualpropertyrights.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(c)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105cIntellectualpropertyrights.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🏭 Confidentiality of commercial or industrial information</strong>
   <p>Public authorities may refuse to disclose information if it would adversely affect the confidentiality of commercial 
   or industrial information, where such confidentiality is protected by law to safeguard a legitimate economic interest.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(e)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/commercial-or-industrial-information-regulation-12-5-e/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(e)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(e)</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🤝 Interests of the person who provided the information</strong>
   <p>If the information requested was provided voluntarily and the person who supplied it has not consented to its disclosure, the public authority may refuse the request. This exception applies only if the person who supplied the information was not legally required to do so, and if the public authority can guarantee that the information will remain confidential.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(f)</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1638/eir_voluntary_supply_of_information_regulation.pdf">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(f)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/EIRsGuidanceRegulation105fThirdpartyinterests.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(f)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105fThirdpartyinterests.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🐻 Protection of the environment</strong>
   <p>Public authorities may refuse to disclose information if it would adversely affect the protection of the environment to which the information relates.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(g)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-g-protection-of-the-environment/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(g)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/EIRsGuidanceRegulation105gProtectionoftheEnvironment.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(g)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105gProtectionoftheEnvironment.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🙋 Personal data</strong>
   <p>If the requested information includes personal data, the public authority may refuse to disclose it if doing so would breach data protection law.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/13/made">Regulation 13</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2619056/s40-personal-information-section-40-regulation-13.pdf">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/11/made">Regulation 11</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/EIRs%20Guidance%20Regualtion%2011%20Personal%20Data.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/11/made">Regulation 11</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRs%20Guidance%20Regualtion%2011%20Personal%20Data.pdf">OSIC guidance</a></li>
   </ul>
   <strong>💣 International relations, defence, and security</strong>
   <p>Authorities may refuse to provide information if doing so would harm international relations, defence, national security, or public safety.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(a)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-a-international-relations-defence-national-security-or-public-safety/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(a)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/EIRsGuidanceRegulation105aInternationalRelations.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(a)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105aInternationalRelations.pdf">OSIC guidance</a></li>
   </ul>
   <strong>⚖️ Justice and fair trials</strong>
   <p>If sharing the information would negatively affect the course of justice, a person's ability to receive a fair trial, or an authority's ability to conduct a criminal or disciplinary inquiry.</p>
   <ul>
     <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(b)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-b-the-course-of-justice-and-inquiries-exception/">ICO guidance</a></li>
-    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(b)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/EIRsGuidanceRegulation105bCourseofJustice.pdf">OSIC guidance</a></li>
+    <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(b)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105bCourseofJustice.pdf">OSIC guidance</a></li>
   </ul>
   <p>All of the exceptions to EIR are subject to the public interest test, which means that the public 
   authority must weigh the benefits of disclosure against any potential harm when deciding whether to withhold

--- a/lib/views/help/exemptions.html.erb
+++ b/lib/views/help/exemptions.html.erb
@@ -16,7 +16,7 @@
   </p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/21">Section 21</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/25">Section 25</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection25InformationOtherwiseAccessible.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/25">Section 25</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection25InformationOtherwiseAccessible_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id=security_services>
@@ -39,7 +39,7 @@
   not normally be covered by this exemption.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/32">Section 32</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619028/s32-court-inquiry-and-arbitration-records.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/37">Section 37</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection37CourtRecords.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/37">Section 37</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection37CourtRecords_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id="parliamentary_privilege">
@@ -64,7 +64,7 @@
   public interest on that basis.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/41">Section 41</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(2)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(2)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection36Confidentiality_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id="legal">
@@ -75,7 +75,7 @@
   where someone’s actions risk unfairly influencing a court case. This could include disobeying a court order.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/44">Section 44</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619033/s44-prohibitions-on-disclosure.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/26">Section 26</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection26ProhibitionsOnDisclosure.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/26">Section 26</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection26ProhibitionsOnDisclosure_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id="future_publication">
@@ -88,7 +88,7 @@
   request date. For all other public authorities in the UK, this exemption applies even if no publication date has been set.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22">Section 22</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1172/information-intended-for-future-publication-and-research-information-sections-22-and-22a-foi.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/27">Section 27</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection27InformationIntendedforFuturePublication.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/27">Section 27</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection27InformationIntendedforFuturePublication_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="research">
@@ -111,7 +111,7 @@
   Government buildings and the prevention of terrorism.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/24">Section 24</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-24-safeguarding-national-security/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection31NationalSecurityandDefence_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="defence">
@@ -122,7 +122,7 @@
   This can also include information about the armed forces of the UK’s allies.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/26">Section 26</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-26-defence/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(4)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(4)</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection31NationalSecurityandDefence_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="international_relations">
@@ -133,7 +133,7 @@
   would harm relations between the UK and other countries if it was released.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/27">Section 27</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-27-international-relations/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/32">Section 32</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection32InternationalRelations.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/32">Section 32</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection32InternationalRelations_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="uk_relations">
@@ -143,7 +143,7 @@
   <p>Communications between the UK Government and the devolved administrations in Wales, Scotland, and Northern Ireland.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/28">Section 28</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-28-relations-within-the-uk/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/28">Section 28</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection28RelationswithintheUnitedKingdom.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/28">Section 28</a> - <a href="hhttps://www.foi.scot/sites/default/files/2023-05/BriefingSection28RelationswithintheUnitedKingdom_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="economy">
@@ -155,7 +155,7 @@
     administrations. This exemption can be used in cases where information could result in volatility in foreign exchange rates.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/29">Section 29</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619027/s29-the-economy.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(2)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(2)</a> - <a href="https://www.foi.scot/sites/default/files/2023-06/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="law_enforcement">
@@ -180,7 +180,7 @@
   finished as well as current investigations.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/30">Section 30</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/34">Section 34</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection34InvestigationsbyScottishPublicAuthoritiesandProceedings.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/34">Section 34</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection34InvestigationsbyScottishPublicAuthoritiesandProceedings_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="audit">
@@ -191,7 +191,7 @@
   This covers formal ‘value for money’ reviews as well as the auditing of accounts.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/33">Section 33</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1210/public-audit-functions-s33-foi-guidance.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/40">Section 40</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/Briefing_Section40AuditFunctions.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/40">Section 40</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/Briefing_Section40AuditFunctions2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="policy_formation">
@@ -213,7 +213,7 @@
   <p>Information that, if released, could put someone’s health or safety at risk. This includes risks to both physical and mental health.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/38">Section 38</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection39HealthSafetyandtheEnvironment_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="environmental">
@@ -225,7 +225,7 @@
   because your rights under EIR and EISR are much stronger.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/39">Section 39</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1043419/exemption-for-environmental-information-section-39.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(2)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(2)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection39HealthSafetyandtheEnvironment_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="legal_privilege">
@@ -237,7 +237,7 @@
   exists so that people are able to talk openly with their lawyers and receive appropriate legal advice.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/42">Section 42</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1208/legal_professional_privilege_exemption_s42.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection36Confidentiality_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="commercial">
@@ -247,7 +247,7 @@
   <p>Information on trade secrets (such as secret recipes) or information that could harm the commercial interests of any company or other business. The authority must show that the release of the information would directly cause the harm being claimed.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/43">Section 43</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-06/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="royal">

--- a/lib/views/help/exemptions.html.erb
+++ b/lib/views/help/exemptions.html.erb
@@ -257,8 +257,8 @@
   <p>Communications to and from the King, the Royal Family, and the Royal Household. This also covers information relating to the 
   awarding of honours such as knighthoods and seats in the House of Lords (peerages).</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/37">Section 37</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/communications-with-her-majesty-and-the-awarding-of-honours-section-37/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/41">Section 41</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection41CommunicationsWithHerMajestyetcandHonours.pdf">OSIC guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/37">Section 37</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/communications-with-his-majesty-and-the-awarding-of-honours-section-37/">ICO guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/41">Section 41</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection41CommunicationsWithHisMajestyetcandHonours_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Sometimes</li>
   </ul>
   <h2 id="personal_information">

--- a/lib/views/help/exemptions.html.erb
+++ b/lib/views/help/exemptions.html.erb
@@ -16,7 +16,7 @@
   </p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/21">Section 21</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/25">Section 25</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection25InformationOtherwiseAccessible.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/25">Section 25</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection25InformationOtherwiseAccessible.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id=security_services>
@@ -39,7 +39,7 @@
   not normally be covered by this exemption.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/32">Section 32</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619028/s32-court-inquiry-and-arbitration-records.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/37">Section 37</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection37CourtRecords.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/37">Section 37</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection37CourtRecords.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id="parliamentary_privilege">
@@ -64,7 +64,7 @@
   public interest on that basis.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/41">Section 41</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(2)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(2)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id="legal">
@@ -75,7 +75,7 @@
   where someone’s actions risk unfairly influencing a court case. This could include disobeying a court order.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/44">Section 44</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619033/s44-prohibitions-on-disclosure.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/26">Section 26</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection26ProhibitionsOnDisclosure.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/26">Section 26</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection26ProhibitionsOnDisclosure.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
   <h2 id="future_publication">
@@ -88,7 +88,7 @@
   request date. For all other public authorities in the UK, this exemption applies even if no publication date has been set.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22">Section 22</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1172/information-intended-for-future-publication-and-research-information-sections-22-and-22a-foi.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/27">Section 27</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection27InformationIntendedforFuturePublication.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/27">Section 27</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection27InformationIntendedforFuturePublication.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="research">
@@ -111,7 +111,7 @@
   Government buildings and the prevention of terrorism.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/24">Section 24</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-24-safeguarding-national-security/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="defence">
@@ -122,7 +122,7 @@
   This can also include information about the armed forces of the UK’s allies.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/26">Section 26</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-26-defence/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(4)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(4)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection31NationalSecurityandDefence.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="international_relations">
@@ -133,7 +133,7 @@
   would harm relations between the UK and other countries if it was released.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/27">Section 27</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-27-international-relations/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/32">Section 32</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection32InternationalRelations.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/32">Section 32</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection32InternationalRelations.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="uk_relations">
@@ -143,7 +143,7 @@
   <p>Communications between the UK Government and the devolved administrations in Wales, Scotland, and Northern Ireland.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/28">Section 28</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-28-relations-within-the-uk/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/28">Section 28</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/BriefingSection28RelationswithintheUnitedKingdom.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/28">Section 28</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/BriefingSection28RelationswithintheUnitedKingdom.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="economy">
@@ -155,7 +155,7 @@
     administrations. This exemption can be used in cases where information could result in volatility in foreign exchange rates.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/29">Section 29</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619027/s29-the-economy.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(2)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(2)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="law_enforcement">
@@ -168,7 +168,7 @@
   collection of taxes, the prison system, and certain types of civil proceedings.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/31">Section 31</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/35">Section 35</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection35LawEnforcement.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/35">Section 35</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection35LawEnforcement.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="investigations">
@@ -180,7 +180,7 @@
   finished as well as current investigations.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/30">Section 30</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/34">Section 34</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection34InvestigationsbyScottishPublicAuthoritiesandProceedings.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/34">Section 34</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection34InvestigationsbyScottishPublicAuthoritiesandProceedings.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="audit">
@@ -191,7 +191,7 @@
   This covers formal ‘value for money’ reviews as well as the auditing of accounts.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/33">Section 33</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1210/public-audit-functions-s33-foi-guidance.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/40">Section 40</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/Briefing_Section40AuditFunctions.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/40">Section 40</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/Briefing_Section40AuditFunctions.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="policy_formation">
@@ -203,7 +203,7 @@
   ministerial offices and advice from the government’s senior legal advisers who are known as the Law Officers.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/35">Section 35</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/29">Section 29</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection29FormulationofScottishAdministrationPolicy.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/29">Section 29</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection29FormulationofScottishAdministrationPolicy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="health_and_safety">
@@ -213,7 +213,7 @@
   <p>Information that, if released, could put someone’s health or safety at risk. This includes risks to both physical and mental health.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/38">Section 38</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="environmental">
@@ -225,7 +225,7 @@
   because your rights under EIR and EISR are much stronger.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/39">Section 39</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1043419/exemption-for-environmental-information-section-39.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(2)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(2)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection39HealthSafetyandtheEnvironment.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="legal_privilege">
@@ -237,7 +237,7 @@
   exists so that people are able to talk openly with their lawyers and receive appropriate legal advice.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/42">Section 42</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1208/legal_professional_privilege_exemption_s42.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection36Confidentiality.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="commercial">
@@ -247,7 +247,7 @@
   <p>Information on trade secrets (such as secret recipes) or information that could harm the commercial interests of any company or other business. The authority must show that the release of the information would directly cause the harm being claimed.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/43">Section 43</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(1)</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(1)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
   <h2 id="royal">
@@ -258,7 +258,7 @@
   awarding of honours such as knighthoods and seats in the House of Lords (peerages).</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/37">Section 37</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/communications-with-her-majesty-and-the-awarding-of-honours-section-37/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/41">Section 41</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection41CommunicationsWithHerMajestyetcandHonours.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/41">Section 41</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection41CommunicationsWithHerMajestyetcandHonours.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Sometimes</li>
   </ul>
   <h2 id="personal_information">
@@ -271,7 +271,7 @@
   on how personal data can be used and stored in the UK is set out in a law called UK GDPR.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/40">Section 40</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2619056/s40-personal-information-section-40-regulation-13.pdf">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/38">Section 38</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection38PersonalInformationGDPR.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/38">Section 38</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection38PersonalInformationGDPR.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Sometimes</li>
   </ul>
   <h2 id="public_affairs">
@@ -284,7 +284,7 @@
     is usually a minister or chief executive. If this is used against you, it’s quite hard to overturn.</p>
   <ul>
     <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/36">Section 36</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/section-36-prejudice-to-the-effective-conduct-of-public-affairs/">ICO guidance</a></li>
-    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/30">Section 30</a> - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-04/BriefingSection30PrejudicetotheEffectiveConductofPublicAffairs.pdf">OSIC guidance</a></li>
+    <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/30">Section 30</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/FeesandExcessiveCostofComplianceBriefing.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Sometimes</li>
   </ul>
   <%= render partial: 'history' %>

--- a/lib/views/help/glossary.html.erb
+++ b/lib/views/help/glossary.html.erb
@@ -73,7 +73,7 @@
 <p>In Scotland, most authorities will be responding under the Freedom of Information (Scotland) Act 2002, which sets a cost limit of £600. 
  This is set out in the Freedom of Information (Fees for Required Disclosure) (Scotland) Regulations 2004
  (<a href="https://www.legislation.gov.uk/ssi/2004/467/contents/made">SSI 2004 no. 467</a>).
- There is more information in the Scottish Information Commissioner's guidance document - <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/FeesandExcessiveCostofComplianceBriefing.pdf">Charging a fee or refusing to comply with a request on excessive cost grounds</a> - which also explains the circumstances in which a public authority might occasionally issue a "fees notice".</p>
+ There is more information in the Scottish Information Commissioner's guidance document - <a href="https://www.foi.scot/sites/default/files/2022-03/FeesandExcessiveCostofComplianceBriefing.pdf">Charging a fee or refusing to comply with a request on excessive cost grounds</a> - which also explains the circumstances in which a public authority might occasionally issue a "fees notice".</p>
 </dd>
 </dl>
 <a href="#top">[Top]</a>

--- a/lib/views/help/no_response.html.erb
+++ b/lib/views/help/no_response.html.erb
@@ -26,9 +26,10 @@
         
   <p>
     If the public authority has not replied to a request at all, you can 
-    complain directly to the Information Commissioner (ICO) by email at 
-    <a href="mailto:ICOCasework@ico.org.uk">ICOCasework@ico.org.uk</a> or 
-    using their online form:
+    complain directly to the Information Commissioner 
+    (<abbr title="Information Commissioner's Office">ICO</abbr>) by email at 
+    <strong><code><a href="mailto:ICOCasework@ico.org.uk">ICOCasework@ico.org.uk</a>
+    </strong></code> or using their online form:
   </p>
   
   <p>
@@ -62,10 +63,11 @@
   </h2>
     
   <p>
-    Unlike the ICO, the Scottish Information Commissioner (OSIC) considers a lack 
-    of response by a public authority as being a refusal, and will not look 
-    at complaints unless you have first requested an internal review, and 
-    waited a further 20 working days for a response.
+    Unlike the ICO, the Scottish Information Commissioner 
+    (<abbr title="Office of the Scottish Information Commissioner">OSIC</abbr>) 
+    considers a lack of response by a public authority as being a refusal, and 
+    will not look at complaints unless you have first requested an internal 
+    review, and waited a further 20 working days for a response.
   </p>
     
   <p>
@@ -81,12 +83,12 @@
   </p>
 
   <p>
-    <a href="mailto:enquiries@ItsPublicKnowledge.info">enquiries@ItsPublicKnowledge.info</a>.
+    <strong><code><a href="mailto:enquiries@foi.scot">enquiries@foi.scot</a></strong></code>.
   </p>  
 
   <p>  
     They provide an 
-    <a href="https://www.itspublicknowledge.info/sites/default/files/2022-03/Application_Form_-_Website.docx">
+    <a href="https://www.foi.scot/sites/default/files/2024-08/ApplicationForm2024.docx">
     application form</a> for you to use if you wish to do so. They will need to see a copy of your request and 
     a copy of your request for an internal review, so make sure to include a link to your request as part of 
     your complaint.

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -192,7 +192,7 @@
       <p>
         Os ydych yn gwneud cais am wybodaeth gan awdurdod cyhoeddus yn yr Alban, mae’r broses yn debyg iawn. 
         Mae gwahaniaethau o gwmpas y terfynau amser ar gyfer cydymffurfio. 
-        Gweler <a href="https://www.itspublicknowledge.info/your-rights">
+        Gweler <a href="https://www.foi.scot/your-rights">
         canllawiau Comisiynydd Gwybodaeth yr Alban</a> am fanylion.
       </p>
     </dd>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -249,7 +249,7 @@
         </li>
         <li>
           The Scottish Information Commissioner’s
-          <a href="http://www.itspublicknowledge.info/YourRights/tipsforrequesters.aspx">
+          <a href="https://www.foi.scot/how-do-i-ask">
           Tips for requesting information</a>.
         </li>
       </ul>
@@ -416,7 +416,7 @@
         the process is very similar, although there are differences around time
         limits for compliance.
         See the
-        <a href="http://www.itspublicknowledge.info/YourRights/YourRights.aspx">
+        <a href="https://www.foi.scot/your-rights">
         Scottish Information Commissioner&rsquo;s guidance</a> for details.
       </p>
     </dd>

--- a/lib/views/help/unhappy.html.erb
+++ b/lib/views/help/unhappy.html.erb
@@ -119,7 +119,7 @@
     Information Commissioner's advice for those with concerns about accessing
     information</a>, which links to their form. If you requested information
     from a Scottish authority, then you should contact
-    <a href="https://www.itspublicknowledge.info/appeal">the
+    <a href="https://www.foi.scot/appeal">the
     Scottish Information Commissioner</a> instead.
   </p>
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1886

## What does this do?

This updates the links in guidance, referring to the Scottish Information Commissioner, from `itspublicknowledge.info`, to `foi.scot`.

As the change was in a related place, I've also updated the ICO link for s37 of FoIA (a80173d1fbaf052a7e1b033dce2d2ef4b6cd2b54).

## Why was this needed?

Scottish Information Commissioner has changed their domain.

## Implementation notes

Nothing of note

## Screenshots

We don't render the bare links themselves - so  I won't waste pixels here.

## Notes to reviewer
