### PR TITLE
Update RawEmail patch

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -128,7 +128,7 @@ Rails.configuration.to_prepare do
     alias original_data data
 
     def data
-      original_data.sub(/
+      original_data&.sub(/
         ^(Date: [^\n]+\n)
         \s+(To: [^\n]+\n)
         \s+(From: [^\n]+)


### PR DESCRIPTION
In development occasionally see errors where the original data isn't present, normally when my local ActiveStorage store has been cleared.

We can return nil here and some dev operations (EG. indexing) will then succeed.
