### PR TITLE
[WDTK] Popup black version

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -317,14 +317,14 @@ a.link_button_green_large {
 /* Popups */
 
 .popup {
-  background-color: $color_black;
+  background: linear-gradient(90deg, rgba(140, 210, 130, 1) 0%, rgba(192, 246, 185, 1) 100%);
   border: 0;
-  color: $color_white;
+  color: $color_black;
   a, a:hover, a:active, a:focus, a:visited,
   a:visited:hover,
   a:visited:active,
   a:visited:focus {
-    color: $color_white;
+    color: $color_black;
   }
 }
 

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -317,14 +317,14 @@ a.link_button_green_large {
 /* Popups */
 
 .popup {
-  background-color: $color_green;
+  background-color: $color_black;
   border: 0;
-  color: #fff;
+  color: $color_white;
   a, a:hover, a:active, a:focus, a:visited,
   a:visited:hover,
   a:visited:active,
   a:visited:focus {
-    color: #fff;
+    color: $color_white;
   }
 }
 

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1,5 +1,6 @@
 $color_orange: #f4a140;
 $color_blue: #2078C2;
+$color_blue_light: #A2D2FA;
 $color_green: #62b356;
 $color_yellow: #ffd836;
 $color_red: #e04b4b;
@@ -317,7 +318,7 @@ a.link_button_green_large {
 /* Popups */
 
 .popup {
-  background: linear-gradient(90deg, rgba(140, 210, 130, 1) 0%, rgba(192, 246, 185, 1) 100%);
+  background-color: $color_blue_light;
   border: 0;
   color: $color_black;
   a, a:hover, a:active, a:focus, a:visited,


### PR DESCRIPTION
## Relevant issue(s)
[Helen discovered ](https://github.com/mysociety/whatdotheyknow-theme/issues/1920)

## What does this do?
Improved contrast for the popup element so it passes contrast text

## Why was this needed?

## Implementation notes

## Screenshots

**Black version**
<img width="1915" alt="Screenshot 2024-09-23 at 07 44 07" src="https://github.com/user-attachments/assets/6020a1b6-2346-40f6-af13-21855c8b9f71">

**Green version**
I get why originally we are using the mySociety green.  but I think the problem with that it rarely looks nice inmediately right next to the other colours, they tend to clash with each other. Assuming using green is important I added a gradient that makes it readable, but probably my least favourite option. I tried a darker version so we can continue using white font text, but it didn't look very nice next to the navbar.
<img width="1915" alt="Screenshot 2024-09-23 at 07 59 32" src="https://github.com/user-attachments/assets/4af071bc-d3f3-4192-888e-e8d781a9271a">

**WDTK Variation**
I created a variation of WDTK primary colour, using the same HUE, unlike the green version I think this one looks more WDTK style. 
<img width="1915" alt="Screenshot 2024-09-23 at 08 14 20" src="https://github.com/user-attachments/assets/938d7c15-693b-4911-b146-8752794e432e">

Let me know if you have any preferences.

## Notes to reviewer
