### PR TITLE
Add foi@cheshireeast.gov.uk to no-reply email list

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -200,6 +200,7 @@ Rails.configuration.to_prepare do
     no-reply@oxford.ecase.co.uk
     noreply.digitalservices@emails.lisburncastlereagh.gov.uk
     noreply@ams-sar.com
+    foi@cheshireeast.gov.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1925

## What does this do?

This PR updates the no-reply email list to include the old FOI mailbox for Cheshire East Council.

## Why was this needed?

Cheshire East are discontinuing their old mailbox; so this will ensure that follow-up emails from old requests are directed to the correct address.

## Implementation notes

Nothing to note

## Screenshots

N/A

## Notes to reviewer

N/A
