### PR TITLE
Update officers.html.erb

### DIFF
--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -169,10 +169,8 @@
         href="https://www.mysociety.org/2016/07/29/the-small-symbol-that-tells-you-all-is-well/?utm_source=whatdotheyknow.com&utm_medium=link">
         small green tick</a> by those which have certifiably
         been received by the authority’s mail servers, and any delivery failure
-        messages will automatically appear on the site. You can check the
-        address we’re using with the “View FOI email address” link which appears
-        on the page for the authority. <a href="/help/contact">Contact us</a> if
-        there is a better address we can use.
+        messages will automatically appear on the site. Please <a href="/help/contact">contact us</a> if
+        there is a better address that we can use.
       </p>
       <p>
         Requests are sometimes not delivered because they are removed by “spam


### PR DESCRIPTION
removing reference to viewing email addresses

## Relevant issue(s)
fixes #1905 
## What does this do?
Removes the reference to viewing emails because you can't do that anymore
## Why was this needed?
see above
## Implementation notes
none
## Screenshots
n/a
## Notes to reviewer
n/a