### PR TITLE
Fix ProAccountBans module

### DIFF
--- a/lib/pro_account_bans.rb
+++ b/lib/pro_account_bans.rb
@@ -2,7 +2,9 @@ module ProAccountBans
   module ModelMethods
     PRO_ACCOUNT_BANS_CONFIG = Rails.root.join('config/pro_account_bans.yml')
 
-    def update_source
+    def update_stripe_customer
+      return unless feature_enabled?(:pro_pricing)
+      return super unless @token
       return super unless pro_account_banned?
 
       sleep (4...10).to_a.sample unless Rails.env.test? # simulate random delay

--- a/spec/pro_account_bans_spec.rb
+++ b/spec/pro_account_bans_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProAccountBans, feature: :pro_pricing do
     let(:card_params) { { number: '4242424242424242', address_zip: 'AB1 1AB' } }
 
     let(:pro_account) { FactoryBot.build(:pro_account, token: stripe_token) }
-    let(:customer) { Stripe::Customer.new(id: 'test_cus_123') }
+    let(:customer) { Stripe::Customer.create(id: 'test_cus_123') }
 
     let(:stripe_token) do
       token_id = stripe_helper.generate_card_token(card_params)
@@ -21,13 +21,13 @@ RSpec.describe ProAccountBans, feature: :pro_pricing do
     before do
       allow(pro_account).to receive(:bans_config).and_return(bans_config)
       allow(pro_account).to receive(:stripe_customer).and_return(customer)
-      allow(customer).to receive(:save)
+      allow(Stripe::Customer).to receive(:update).and_return(customer)
     end
 
     context 'with a valid token' do
       it 'updates the Stripe customer successfully' do
         expect(pro_account.update_stripe_customer).to be_truthy
-        expect(customer).to have_received(:save)
+        expect(Stripe::Customer).to have_received(:update)
       end
     end
 


### PR DESCRIPTION
Since Stripe API version upgrade [1] in core this hasn't worked as expected.

This is because of changes to ProAccount#update_stripe_customer required to support the newer API and changes to prevent deprecation warnings.

[1] https://github.com/mysociety/alaveteli/pull/8405
