### PR TITLE
Exclude certain types of authorities from batch category picker

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -76,7 +76,46 @@ Rails.configuration.to_prepare do
     prepend ProAccountBans::ModelMethods
   end
 
-  PublicBody.batch_excluded_tags += %w[school]
+  # Educational institutions
+  PublicBody.batch_excluded_tags += %w[
+    academies
+    fei
+    school
+  ]
+
+  # Independent Monitoring Boards for prisons etc
+  PublicBody.batch_excluded_tags += %w[
+    hmp_imb
+    irc_imb
+    special_imb
+    sthf_imb
+    yoi_imb
+  ]
+
+  # Local government — lowest tier
+  PublicBody.batch_excluded_tags += %w[
+    city_parish_council
+    community_council
+    town_council
+    parish_council
+    parish_meeting
+  ]
+
+  # Healthcare — smaller healthcare providers only subject to FOI in respect of
+  # specific functions
+  PublicBody.batch_excluded_tags += %w[
+    dentist
+    optician
+    pharmacy
+    surgery
+  ]
+
+  # Other
+  PublicBody.batch_excluded_tags += %w[
+    engrsl
+    signpost
+    unit
+  ]
 
   PublicBody.excluded_calculated_home_page_domains += %w[
     aol.co.uk


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1851

## What does this do?
Excludes certain types of authorities from batch category picker. 

## Why was this needed?
There are different reasons for different types of authorities. These are summarised below. 

### Academies
This category can include primary schools as as well as secondary schools. In most cases, it would not make sense to make a batch request to both. Batch requests could also result in an unreasonable burden on primary schools that are relatively small public authorities. This is consistent with the decision taken previously for the 'school' tag.

Relevant tags: academies

### Further education institutions
Due to the number of further education institutions and their size it was felt that it would not be proportionate to allow batch requests to these institutions because it could result in an unreasonable burden on their resources. This is aligned with the decision taken previously for the 'school' tag. At the Community and Activism call on 5 December 2024, it was decided not to prevent batch requests to universities because in general they are larger institutions that have the resources to respond to such request.

Relevant tags: fei

### Independent Monitoring Boards
We understand that the Independent Monitoring Boards Secretariat is a centralised team so it won't normally make sense to submit a batch because it would mean the Secretariat receiving a large number of very similar emails. These IMBs are also very small public authorities with a substantial dependency on unpaid volunteers so we want to minimise the work for them where it is practical and reasonable to do so.

Relevant tags: hmp_imb,  irc_imb, special_imb, sthf_imb and yoi_imb

### Lowest level of local government
In England, Parish councils and parish meetings are very small public authorities with limited resources. Councils that are called 'town councils' are legally no different from those named parish councils — this is just a naming difference.  There are also some called 'city councils' that are also the same as the parish councils from a legal standpoint. Parish meetings can take decisions in areas of England where no parish council has been established.  In Scotland and Wales, the term community council is used for bodies that are similar to the authorities named parish council in England. All of these authorities are relatively small and it was felt that it would not be proportionate to allow batch requests to these institutions because it could result in an unreasonable burden on their resources. 

Relevant tags: parish_council, town_council, parish_meeting, community_council

### Registered Social Landlords in England

In general, RSLs in England are not subject to FOI which limits the scope for a successful batch request. We also struggle to keep the database fully up to date for these RSLs and so a batch request could result in a lot of work for our admin team which includes the WhatDoTheyKnow volunteers. The position in Scotland is different because in Scotland RSLs generally are subject to FOI. RSLs in Wales and Northern Ireland are generally not subject to FOI but the number of RSLs is in each case significantly lower than for England and it was decided that there was no need to remove these from the batch category picker.

### Smaller healthcare providers that are only subject to FOI for specific purposes
Some smaller healthcare providers are only subject to FOI for specific purposes meaning that there is limited scope for making useful batch request. In addition, we struggle to keep the database fully up to date for these smaller authorities so a batch request could result in a lot of work for our admin team which includes the WhatDoTheyKnow volunteers.

Relevant tags: dentist, optician, pharmacy, surgery

### Signpost authorities and units
Signpost authorities exist to point users to authorities they may be looking for. For example, the Economic and Cyber Crime Academy signpost page directs users to City of London Police because the Academy is not a legal entity in its own right. In most cases, there won't be an email address in the system for signpost authorities so no requests can be made to them. For this reason, it is proposed to exclude them from the batch category picker. Similarly, authorities tagged 'unit' usually exist to point users to other authorities and it is proposed to exclude these also.

Relevant tags: signpost and unit

## Implementation notes
N/A

## Screenshots
N/A

## Notes to reviewer
N/A