### PR TITLE
Prevent global censor rule creation

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -1,5 +1,15 @@
 # Please arrange overridden classes alphabetically.
 Rails.configuration.to_prepare do
+  AdminCensorRuleController.class_eval do
+    before_action :block_global_censor_rule_creation, only: [:create]
+
+    private
+
+    def block_global_censor_rule_creation
+      raise NotImplementedError if @censor_rule.is_global?
+    end
+  end
+
   HelpController.class_eval do
     prepend VolunteerContactForm::ControllerMethods
     prepend DataBreach::ControllerMethods


### PR DESCRIPTION
Censor rule creation results in expiry of all related content. On WhatDoTheyKnow this would cause a major problem. This hacks in a preventative measure. Admins who wish to create a global rule can seek developer assistance until a more robust solution is found.

Tested in browser:

![Screenshot 2024-11-29 at 17 03 19](https://github.com/user-attachments/assets/7ac0cb6a-939d-4499-a79d-0fa8a9f6c0b8)
