### PR TITLE
Update _more_info.html.erb to support UCAS links

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -74,6 +74,13 @@
   <% end %>
 <% end %>
 
+<% if public_body.has_tag?('ucas') %>
+  <% public_body.get_tag_values('ucas').each do |tag_value| %>
+      <%= link_to _('UCAS provider'),
+                    "https://www.ucas.com/explore/search/providers?query=#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <% if public_body.has_tag?('matuid') %>
   <% public_body.get_tag_values('matuid').each do |tag_value| %>
       <%= link_to _('Establishment group information'),


### PR DESCRIPTION
Add UCAS links on authority pages

## Relevant issue(s)
N/A

## What does this do?
Adds a link to UCAS website on each authority page for which there is an UCAS code.

## Why was this needed?
N/A

## Implementation notes
N/A

## Screenshots
N/A

## Notes to reviewer
Here is an example URL: https://www.ucas.com/explore/search/providers?query=A60