### PR TITLE
[#1951] Update ICO advice links in refusal advice section 12 costs

### DIFF
--- a/config/refusal_advice/section_12_actions.yml.erb
+++ b/config/refusal_advice/section_12_actions.yml.erb
@@ -7,7 +7,7 @@ foi:
       - { id: s12-q1y1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Ask for an internal review. Inform the authority that this should not be part of the calculation, linking to <a href="https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf">ICO advice</a>.
+          Ask for an internal review. Inform the authority that this should not be part of the calculation, linking to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-12-requests-where-the-cost-of-compliance-exceeds-the-appropriate-limit/">ICO advice</a>.
 
     - id: s12-a4
       show_if:
@@ -30,7 +30,7 @@ foi:
         html: >
           Authorities are advised that requests may only be aggregated if they relate “to any extent” to the same or similar information. This is a wide description which you may be able to argue against.
 
-          Ask for an internal review, linking to <a href="https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf">ICO advice</a>.
+          Ask for an internal review, linking to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-12-requests-where-the-cost-of-compliance-exceeds-the-appropriate-limit/">ICO advice</a>.
 
     - id: s12-a10
       show_if:
@@ -39,7 +39,7 @@ foi:
         html: >
           You may be able to argue against aggregation on the basis that by law, authorities must respond to requests within 20 working days. The ICO allow "the aggregation period to only run up to 20 days ‘forward’ from the date of any single request under consideration" and "up to 60 days ‘backwards’ from the date of any single request under consideration" and "the total aggregation period (running either forwards or backwards or a combination of both) from the date of any single request must not exceed 60 working days".
 
-          Ask for an internal review, linking to <a href="https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf">ICO advice</a>.
+          Ask for an internal review, linking to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-12-requests-where-the-cost-of-compliance-exceeds-the-appropriate-limit/">ICO advice</a>.
 
     - id: s12-a11
       show_if:
@@ -53,7 +53,7 @@ foi:
       - { id: s12-q4y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Ask for an internal review, linking to <a href="https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf">ICO advice</a> which states that requests may not be aggregated if they were made more than 60 working days apart.
+          Ask for an internal review, linking to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-12-requests-where-the-cost-of-compliance-exceeds-the-appropriate-limit/">ICO advice</a> which states that requests may not be aggregated if they were made more than 60 working days apart.
 
   - id: clarification
     suggestions:
@@ -103,7 +103,7 @@ foi:
       - { id: s12-q5y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Ask for the information you prefer, linking to <a href="https://ico.org.uk/media/for-organisations/documents/1199/costs_of_compliance_exceeds_appropriate_limit.pdf">ICO advice</a>.
+          Ask for the information you prefer, linking to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-12-requests-where-the-cost-of-compliance-exceeds-the-appropriate-limit/">ICO advice</a>.
 
   - id: new_request
     suggestions:


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1951

## What does this do?

Corrects link to cost of compliance guidance.

## Why was this needed?

The ICO have re-organised their website.

## Implementation notes

Nothing to note, a mere swap-out of links.

## Screenshots

N/A

## Notes to reviewer

Nothing specific; but worth noting this had possibly been broken for a little while. Implementing #1714 would help improve this.
