### PR TITLE
[#1840] Donation link

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
   get '/help/report-a-data-breach/thank-you' => 'help#report_a_data_breach_thank_you',
       as: :help_report_a_data_breach_thank_you
 
+  get "/donate" => redirect("https://www.mysociety.org/donate/support-whatdotheyknow-and-mysociety"),
+      as: :donate_to_mysociety   
+
   get "/help/ico-guidance-for-authorities" => redirect("https://ico.org.uk/media/for-organisations/documents/2021/2618998/how-to-disclose-information-safely-20201224.pdf"),
       as: :ico_guidance
 

--- a/lib/views/general/_default_footer.text.erb
+++ b/lib/views/general/_default_footer.text.erb
@@ -3,8 +3,8 @@
 WhatDoTheyKnow is a project of mySociety run by a small team of staff and
 dedicated volunteers.
 
-You can help to make information accessible to all by donating today.
-Your donations, however small, really help:
+mySociety is a charity that believes that information should be accessible to everyone.
+If this is important to you, please consider donating to help us do more:
 <%= donate_to_mysociety_url %>
 
 Find out more about how we handle your data at:

--- a/lib/views/general/_default_footer.text.erb
+++ b/lib/views/general/_default_footer.text.erb
@@ -3,11 +3,12 @@
 WhatDoTheyKnow is a project of mySociety run by a small team of staff and
 dedicated volunteers.
 
-Support WhatDoTheyKnow and mySociety. Your donations, however small, really help:
-https://www.mysociety.org/donate/support-whatdotheyknow-and-mysociety
+You can help to make information accessible to all by donating today.
+Your donations, however small, really help:
+<%= donate_to_mysociety_url %>
 
 Find out more about how we handle your data at:
 <%= help_privacy_url %>
 
-mySociety is a registered charity in England and Wales (1076346) and a limited
+mySociety is a registered charity in England and Wales (1076346), and a limited
 company (03277032)


### PR DESCRIPTION
## Relevant issue(s)

#1840

## What does this do?

This adds a new route, `/donate`, which points toward the WDTK specific donation page.

It also adds the enhanced "please donate" wording, from https://github.com/mysociety/whatdotheyknow-theme/issues/1840#issuecomment-2023092325

## Why was this needed?

Current mailbox signature has a rather cumbersome link, this enables a neater solution.

Additionally, the enhanced "ask" is hopefully more eye catching, within the limit that plaintext email has.

## Implementation notes

Nothing new here, it's just enhancing what is already in the code.

## Screenshots

## Notes to reviewer

I'm not sure if this closes #1840 completely, or not, so haven't marked it as such.
