### PR TITLE
[#1969] Add new no-reply address for CaseTracker

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -202,7 +202,8 @@ Rails.configuration.to_prepare do
     account-security-noreply@accountprotection.microsoft.com
     msonlineservicesteam@microsoftonline.com
     DataRightsDONOTREPLY@met.police.uk
-    no.reply@met.police.uk 
+    no.reply@met.police.uk
+    noreply@casetracker.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1969

## What does this do?

Adds a new no-reply email to the list in `model_patches.rb`, for Govmetric CaseTracker, used by LB Havering.

## Why was this needed?

Some messages are being issued from a no-reply address, and Alaveteli should be able to recognise this.

## Implementation notes

Nothing to note

## Screenshots

N/A

## Notes to reviewer

N/A
