### PR TITLE
[#1971] GitHub actions: Ubuntu 20.04 depreciation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         sudo apt-get -y update
         sudo apt-get -y install exim4-daemon-light
-        sudo apt-get -y install `cut -d " " -f 1 config/packages.ubuntu-focal | egrep -v "(^#|wkhtml|bundler|^ruby|^rake)"`
+        sudo apt-get -y install `cut -d " " -f 1 config/packages | egrep -v "(^#|wkhtml|bundler|^ruby|^rake)"`
       working-directory: core
 
     - name: Install Ruby ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   rspec:
     name: Ruby ${{ matrix.ruby }} / PostgreSQL ${{ matrix.postgres }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         fi
 
     - name: Checkout Alaveteli
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: mysociety/alaveteli
         ref: ${{ env.PR_ALAVETELI_BRANCH }}
@@ -73,7 +73,7 @@ jobs:
         mkdir alaveteli-themes
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: alaveteli-themes/whatdotheyknow-theme
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,10 +8,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout Alaveteli
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: mysociety/alaveteli
         ref: develop
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: lib/themes/whatdotheyknow-theme
 
@@ -30,7 +30,7 @@ jobs:
         bundler-cache: true
 
     - name: Run RuboCop linter
-      uses: reviewdog/action-rubocop@v1
+      uses: reviewdog/action-rubocop@v2
       with:
         github_token: ${{ secrets.github_token }}
         rubocop_flags: -DES lib/themes/whatdotheyknow-theme


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1971

## What does this do?

Changes the CI, and Rubocop, workflows from `ubuntu-20.04`, to `ubuntu-latest`.

## Why was this needed?

GitHub have depreciated support for runners using `ubuntu-20.04`, and are [removing support on 2025-04-01](https://github.com/actions/runner-images/issues/11101).

## Implementation notes

This is a straight swap from `ubuntu-20.04`, to `ubuntu-latest`. A couple of the other actions have also been updated (`action-rubocop`, and `checkout`)

## Screenshots

N/A

## Notes to reviewer

Based on the runners in the Alaveteli repo, `ubuntu-latest` should work here.  I did notice that there is a hardcoded dependency to `ubuntu-focal` packages, which doesn't seem to be in the [Alaveteli CI](https://github.com/mysociety/alaveteli/blob/develop/.github/workflows/ci.yml) - I will add a suggested change for review.