### PR TITLE
1975 changes to house rules around requesting email addresses

### DIFF
--- a/lib/views/help/house_rules.html.erb
+++ b/lib/views/help/house_rules.html.erb
@@ -24,6 +24,7 @@
     <li>Don't use WhatDoTheyKnow to ask for other people's personal information. Don't include this type of information in requests, comments or follow-ups, unless it's fair to do so.</li>
     <li>Don't try to get around the site limits or actions of site administrators. For example, don't make new accounts to avoid a ban or limits on how many requests you can make. Don't repost things you know moderators have removed.</li>
     <li>Commercial and for-profit use requires a <%= link_to 'WhatDoTheyKnow Pro', account_request_index_path %> subscription.</li>
+    <li>Don’t ask for email addresses in your requests. Email addresses are automatically redacted, and you will not be able to access them if they are provided in the response.</li>
   </ul>
   
   <p>If you break these rules, you could be banned from the site. We may also remove your requests or annotations. We'll usually contact you first to give advice on how to use the service better.</p>

--- a/lib/views/help/how.html.erb
+++ b/lib/views/help/how.html.erb
@@ -153,20 +153,14 @@
     <a href="#email_addresses">#</a>
   </h4>
   <p>
-    To guard all parties against spam, and to encourage keeping all
-    correspondence on WhatDoTheyKnow, we automatically remove most email
-    addresses and some mobile numbers from responses to requests. For technical
-    reasons we don’t always manage to remove them from attachments, such as
-    certain PDFs.
+    To guard all parties against spam, and to encourage keeping all correspondence 
+    on WhatDoTheyKnow, we automatically remove most email addresses and some mobile 
+    numbers from responses to requests. 
   </p>
   <p>
-    If you need to know an address that we've removed, please
-    <a href="<%=  help_contact_path %>">get in touch</a> with us. It's worth
-    noting though, that as our team is small, we've not got the capacity to
-    deal with a large number of these requests, so our service isn't well
-    suited to being used to gather email addresses.
-    Occasionally, an email address forms an important part of a response and if
-    we’re asked to reveal it we may post it in an annotation.
+    It is against our House Rules to request email addresses from an authority. Our 
+    support team will not provide the unredacted details to you, should you ignore 
+    this rule. 
   </p>
   <h4 id="send_errors">
     How do we deal with requests that are not sent successfully?


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1975 
## What does this do?
Changes the wording around asking for email addresses.
## Why was this needed?
Increasing admin burden of unredacting pro responses.
## Implementation notes
n/a
## Screenshots
<img width="809" alt="Screenshot 2025-03-13 at 13 58 50" src="https://github.com/user-attachments/assets/331929aa-5da8-477d-996a-a2481b4f51e1" />
<img width="788" alt="Screenshot 2025-03-13 at 13 58 39" src="https://github.com/user-attachments/assets/22d9d4dd-008a-4906-89a9-0c0475dab71e" />
## Notes to reviewer
n/a