### PR TITLE
Changes to volunteer contact form

### DIFF
--- a/lib/views/help/_contact_volunteer_form.html.erb
+++ b/lib/views/help/_contact_volunteer_form.html.erb
@@ -67,7 +67,7 @@
     <label class="form_label" for="contact_age">How old are you?<label>
 
     <span class="form_item_note">
-      We restrict some of our work to those aged 18 or over due to the fact it sometimes involves dealing with sensitive material, but we are still happy for people under 18 to help with some tasks.<br><br>
+      We restrict membership of our volunteer team to those aged 18 or over due to the fact it sometimes involves dealing with sensitive material.<br><br>
     </span>
 
     <%= f.label :age_under_18, class: 'form_inline' do %>

--- a/lib/views/help/contact.html.erb
+++ b/lib/views/help/contact.html.erb
@@ -116,7 +116,11 @@
         <ul>
             <li>
                 Please use this form if you are interested in volunteering for
-                WhatDoTheyKnow
+                WhatDoTheyKnow. Please note that this form is for informal, general 
+                offers of help only. We are a small team and may not always 
+                have volunteer roles available. We appreciate all offers of help, 
+                but unfortunately, we are not always able to respond to everyone 
+                individually.
             </li>
             <li>
                 If you would like more information on what volunteering

--- a/lib/views/help/volunteers.html.erb
+++ b/lib/views/help/volunteers.html.erb
@@ -56,7 +56,7 @@
 
   <p>
     As well as our traditional multidisciplinary volunteering opportunities,
-    we're trialled developing some structured roles for key activities:
+    we've trialled developing some structured roles for key activities:
   </p>
 
   <ul>

--- a/lib/views/help/volunteers.html.erb
+++ b/lib/views/help/volunteers.html.erb
@@ -56,7 +56,7 @@
 
   <p>
     As well as our traditional multidisciplinary volunteering opportunities,
-    we're currently developing some structured roles for key activities:
+    we're trialled developing some structured roles for key activities:
   </p>
 
   <ul>
@@ -103,6 +103,12 @@
     You can get in touch by using our
     <%= link_to "I'd like to volunteer contact form",
                 help_contact_path(anchor: 'wdtk-volunteer') %>.
+  </p>
+  <p>
+    Please note that the volunteer form is for informal, general offers of 
+    help only. We are a small team and may not always have volunteer 
+    roles available. We appreciate all offers of help, but unfortunately, 
+    we are not always able to respond to everyone individually.
   </p>
 
   <h2 id="general-tasks">


### PR DESCRIPTION
## Relevant issue(s)
Fixes [377](https://github.com/mysociety/whatdotheyknow-private/issues/377) 

## What does this do?
Tweaks wording around the purpose of the volunteer form and to clarify that you need to be 18 to join the core team.

## Why was this needed?
Reduce the likelihood of any confusion.

## Implementation notes
n/a
## Screenshots
<img width="828" alt="Screenshot 2025-03-24 at 16 11 21" src="https://github.com/user-attachments/assets/73cd1b55-7062-4657-965e-beeab3f2c241" />
<img width="914" alt="Screenshot 2025-03-24 at 16 05 32" src="https://github.com/user-attachments/assets/f3c217ec-4c0e-4e3a-bf6e-85b1b3901eca" />
<img width="1141" alt="Screenshot 2025-03-24 at 16 05 25" src="https://github.com/user-attachments/assets/6efe0a3d-8504-4989-b276-e36cfd5af49f" />

## Notes to reviewer
n/a