### PR TITLE
[#1980] Add address for NHSWLT to no-reply list

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -204,6 +204,7 @@ Rails.configuration.to_prepare do
     DataRightsDONOTREPLY@met.police.uk
     no.reply@met.police.uk
     noreply@casetracker.uk
+    foi@westlondon.nhs.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1980

## What does this do?

Adds a new address, for NHS WLT (2422) to the list of "no reply" addresses.

## Why was this needed?

Recent change to NHSMail, messages to old address (in use until recently) are bouncing. This should stop IRs bouncing back.

## Implementation notes

N/A

## Screenshots

Nothing to note.

## Notes to reviewer

N/A