### PR TITLE
Add link to ONS explore local statistics pages

### DIFF
--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -14,6 +14,13 @@
   <%= link_to _('Disclosure log'), public_body.disclosure_log %><br>
 <% end %>
 
+<% if public_body.has_tag?('statistical_geography') %>
+  <% public_body.get_tag_values('statistical_geography').each do |tag_value| %>
+      <%= link_to _('Explore local statistics'),
+                    "https://explore-local-statistics.beta.ons.gov.uk/areas/#{ tag_value }" %><br>
+  <% end %>
+<% end %>
+
 <% twfy_utm_params = { utm_source: 'whatdotheyknow.com',
                        utm_medium: 'link',
                        utm_campaign: 'body_page_more_info' } %>

--- a/lib/views/public_body/_more_info.html.erb
+++ b/lib/views/public_body/_more_info.html.erb
@@ -14,10 +14,18 @@
   <%= link_to _('Disclosure log'), public_body.disclosure_log %><br>
 <% end %>
 
+<% ons_statistics_tags = [] %>
 <% if public_body.has_tag?('statistical_geography') %>
-  <% public_body.get_tag_values('statistical_geography').each do |tag_value| %>
-      <%= link_to _('Explore local statistics'),
-                    "https://explore-local-statistics.beta.ons.gov.uk/areas/#{ tag_value }" %><br>
+  <% ons_statistics_tags += public_body.get_tag_values('statistical_geography') %>
+<% end %>
+<% if public_body.has_tag?('gss') %>
+  <% ons_statistics_tags += public_body.get_tag_values('gss') %>
+<% end %>
+
+<% unless ons_statistics_tags.empty? %>
+  <% ons_statistics_tags.each do |tag_value| %>
+    <%= link_to _('Explore local statistics'),
+          "https://www.ons.gov.uk/explore-local-statistics/areas/#{ ERB::Util.url_encode(tag_value) }" %><br>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1982 
## What does this do?
Adds a link to the ons local stats page
## Why was this needed?
We didn't link to is
## Implementation notes
n/a
## Screenshots
<img width="1021" alt="Screenshot 2025-04-05 at 15 42 14" src="https://github.com/user-attachments/assets/258a0576-1c94-48af-82d7-963bd0081e78" />
## Notes to reviewer
I popped it above mentions in parliament, as it seemed more relevant, but can be relegated if that doesn't make sense.