### PR TITLE
Update PublicBody missing email auto tagging

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -160,6 +160,18 @@ Rails.configuration.to_prepare do
     end
   end
 
+  PublicBody.instance_eval do
+    module SignpostMissingEmail
+      def update_missing_email_tag
+        return remove_tag('missing_email') if has_tag?('signpost')
+
+        super
+      end
+    end
+
+    prepend SignpostMissingEmail
+  end
+
   RawEmail.class_eval do
     alias original_data data
 

--- a/spec/model_patches_spec.rb
+++ b/spec/model_patches_spec.rb
@@ -134,6 +134,20 @@ RSpec.describe PublicBody do
 
   end
 
+  describe '#update_missing_email_tag' do
+
+    it 'removed missing_email tag if public body is a signpost' do
+      public_body = FactoryBot.create(:blank_email_public_body)
+      expect(public_body.has_tag?('missing_email')).to eq(true)
+
+      public_body.add_tag_if_not_already_present('signpost')
+      public_body.save
+
+      expect(public_body.has_tag?('missing_email')).to eq(false)
+    end
+
+  end
+
 end
 
 RSpec.describe User::EmailAlerts do


### PR DESCRIPTION
## What does this do?

Don't add the `missing_email` tag if the public body is a signpost.

## Why was this needed?

This was causing todo items in the admin general index.
