### PR TITLE
Fix warning that constant is already defined

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -7,7 +7,7 @@
 #
 # Please arrange overridden classes alphabetically.
 Rails.configuration.to_prepare do
-  SPAM_TERMS_CONFIG = Rails.root + 'config/spam_terms.txt'
+  SPAM_TERMS_CONFIG ||= Rails.root + 'config/spam_terms.txt'
 
   if File.exist?(SPAM_TERMS_CONFIG)
     custom_terms =


### PR DESCRIPTION
Fixes:
```
  ./alaveteli/lib/themes/whatdotheyknow-theme/lib/model_patches.rb:10: warning: already initialized constant SPAM_TERMS_CONFIG
  ./alaveteli/lib/themes/whatdotheyknow-theme/lib/model_patches.rb:10: warning: previous definition of SPAM_TERMS_CONFIG was here
```