### PR TITLE
Fix broken donation spec

### DIFF
--- a/spec/donation_helper_spec.rb
+++ b/spec/donation_helper_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe DonationHelper, type: :helper do
       context 'with pro enabled' do
         before(:each) do
           allow(AlaveteliFeatures.backend).
+            to receive(:enabled?).and_call_original
+          allow(AlaveteliFeatures.backend).
             to receive(:enabled?).with(:alaveteli_pro).and_return(true)
         end
 


### PR DESCRIPTION
Dur to changes in core we're checking if more than one feature is enabled. This means the `allow/with` wasn't matching and it raise an exception.
