### PR TITLE
WIP Fix PII badger background job

### DIFF
--- a/lib/excel_analyzer/jobs/pii_badger_job.rb
+++ b/lib/excel_analyzer/jobs/pii_badger_job.rb
@@ -9,8 +9,14 @@ module ExcelAnalyzer
   class PIIBadgerJob < ApplicationJob
     queue_as :excel_analyzer
 
+    attr_reader :attachment_blob, :foi_attachment
+
     def perform(attachment_blob)
-      attachment_blob.open(tmpdir: ENV['EXCEL_ANALYZER_TMP_DIR']) do |file|
+      @attachment_blob = attachment_blob
+      @foi_attachment = FoiAttachment.joins(:file_blob).
+        find_by(active_storage_blobs: { id: attachment_blob })
+
+      begin
         cmd = [
           ENV['EXCEL_ANALYZER_PII_BADGER_COMMAND'], '--file', file.path
         ].join(' ')
@@ -20,9 +26,49 @@ module ExcelAnalyzer
         attachment_blob.update(metadata: attachment_blob.metadata.merge(
           pii_badger: pii_badger_metadata
         ))
+      ensure
+        file.close!
       end
 
       ExcelAnalyzer::RepublishOrReportJob.perform_later(attachment_blob)
+    end
+
+    private
+
+    def name
+      [
+        "ActiveStorage-#{attachment_blob.id}-",
+        attachment_blob.filename.extension_with_delimiter
+      ]
+    end
+
+    def file
+      @file ||= (
+        file = Tempfile.open(name, ENV['EXCEL_ANALYZER_TMP_DIR'])
+        file.binmode
+        file.write(foi_attachment.unmasked_body)
+        file.flush
+        file.rewind
+        file
+      )
+    end
+  end
+end
+
+module ActiveStorage
+  class Service::MirrorService
+    def download(key)
+      primary.download(key)
+    rescue ActiveStorage::FileNotFoundError => primary_error
+      mirrors.each_with_index do |mirror, index|
+        begin
+          data = mirror.download(key)
+          return data
+        rescue ActiveStorage::FileNotFoundError => mirror_error
+          next
+        end
+      end
+      raise primary_error
     end
   end
 end


### PR DESCRIPTION
Sometimes this is breaking for files which have redactions/masks.

In the case of some XLSX files text masking of email addresses in the underlying ZIP format meant the Python Excel Analyzer code couldn't decompress the file and analyse the file contents.

The patch for the ActiveStorage mirror service is needed for our server deployment as these jobs run on a secondary application instance which doesn't have the raw email on disk, so we have to rely on fetching the S3 mirrored version. This patch should probably be moved elsewhere.
