### PR TITLE
Added note about masked content to requester

### DIFF
--- a/app/assets/stylesheets/responsive/_mixins.scss
+++ b/app/assets/stylesheets/responsive/_mixins.scss
@@ -92,6 +92,23 @@
   }
 }
 
+@mixin button-green {
+  @include button-base;
+  background: $color_green_aa; // Adding a colour instead of transparent, that way we can use this button even in dark backgrounds
+  color: $color_white;
+  font-weight: normal;
+  border-color: $color_green_aa;
+  &:hover,
+  &:active,
+  &:visited:hover,
+  &:visited:active {
+    color: $color_green_aa;
+    // We are darkening the background and border for cases there is a default button and a tertiary button together. In this case when we are hovering over the tertiary one it won't look just like the default button next to it.
+    background: $color_white;
+    border-color: $color_green_aa;
+  }
+}
+
 @mixin button-disabled {
   opacity: 0.333;
   &:hover,

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -2,7 +2,9 @@ $color_orange: #f4a140;
 $color_blue: #2078C2;
 $color_blue_light: #A2D2FA;
 $color_green: #62b356;
+$color_green_aa: #39852e; // Pass AA test
 $color_yellow: #ffd836;
+$color_yellow_aa: #6b5a13; // Pass AA test
 $color_red: #e04b4b;
 $color_violet: #a94ca6;
 $color_purple: #5c377f;

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -2074,7 +2074,7 @@ dd {
 
 .donate-cta {
   padding: 1em 1.5em 1.5em;
-  background-color: lighten($color_red, 25%);
+  background-color: lighten($color_green, 25%);
   margin-top: 2em;
   border-radius: 0.3em;
 
@@ -2088,14 +2088,7 @@ dd {
   font-size: 1.125em;
 }
 
-a.donate-cta__button {
-  background-color: $color_red;
-  &:hover,
-  &:active,
-  &:focus {
-    background-color: darken($color_red, 10%);
-  }
-}
+a.donate-cta__button {@include button-green;}
 
 // blog
 #blog {

--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -966,6 +966,17 @@ div.correspondence {
   }
 }
 
+.correspondence_info {
+  font-size: 0.9rem;
+  padding: 0.75rem 1rem;
+  background-color: mix($color_yellow, $body-bg, 15%);
+  color: $color_yellow_aa;
+
+  :last-child {
+    margin-bottom: 0;
+  }
+}
+
 .js-loaded .js-collapsible {
   .correspondence__header {
     &.hover {

--- a/lib/views/request/_incoming_correspondence.html.erb
+++ b/lib/views/request/_incoming_correspondence.html.erb
@@ -1,0 +1,48 @@
+<div class="incoming correspondence <%= incoming_message.prominence %> js-collapsible" id="<%= dom_id(incoming_message) %>">
+  <div class="correspondence__header">
+    <span class="correspondence__header__author js-collapsible-trigger">
+      <% if incoming_message.specific_from_name? %>
+        <%= incoming_message.safe_from_name %>,
+      <% end %>
+      <% if incoming_message.from_public_body? %>
+        <%= @info_request.public_body.name %>
+      <% end %>
+    </span>
+
+    <%= link_to incoming_message_path(incoming_message, anchor_only: true), :class => 'correspondence__header__date' do %>
+      <%= simple_date(incoming_message.sent_at) %>
+    <% end %>
+  </div>
+
+  <%= render partial: 'request/prominence', locals: { prominenceable: incoming_message } %>
+
+  <%- if can?(:read, incoming_message) %>
+    <% if feature_enabled?(:refusal_identification) %>
+      <%= render partial: 'request/incoming_refusals',
+                 locals: { incoming_message: incoming_message } %>
+    <% end %>
+
+    <div class="correspondence_text">
+      <%= render partial: 'request/attachments',
+                 locals: { incoming_message: incoming_message } %>
+    </div>
+
+    <p class="event_actions">
+      <% if !@user.nil? && @user.admin_page_links? %>
+        <%= link_to "Admin", edit_admin_incoming_message_path(incoming_message.id) %>
+      <% end %>
+    </p>
+
+    <% if show_correspondence_footer %>
+      <% link_to_this_url = incoming_message_url(incoming_message) %>
+
+      <% report_path =
+           new_request_report_path(@info_request.url_title,
+                                   incoming_message_id: incoming_message.id) %>
+
+      <%= render partial: 'request/correspondence_footer',
+                 locals: { link_to_this_url: link_to_this_url,
+                           report_path: report_path } %>
+    <% end %>
+  <%- end %>
+</div>

--- a/lib/views/request/_incoming_correspondence.html.erb
+++ b/lib/views/request/_incoming_correspondence.html.erb
@@ -33,6 +33,13 @@
       <% end %>
     </p>
 
+    <% if @is_owning_user %>
+        <div class="correspondence_info">
+            <p>Email addresses and phone numbers may have been automatically redacted from this response and any attachments by WhatDoTheyKnow. <a href="https://www.whatdotheyknow.com/help/officers#mobiles">Find out why.</a>
+            </p>
+        </div>
+    <% end %>
+
     <% if show_correspondence_footer %>
       <% link_to_this_url = incoming_message_url(incoming_message) %>
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes: https://github.com/mysociety/whatdotheyknow-theme/issues/2015

## What does this do?
The message advices the requester that emails and phone numbers are automatically redacted from responses. This should help reducing the amount of emails that the authorities receive from requesters asking why those details have been redacted.

## Why was this needed?

## Implementation notes
@gbp 

- Initially I added this conditional`<% if @is_owning_user %>`, but I wonder if we also should include another argument that only display the message if there is a response.

- Ideally we don't want to display the "We work to defend the right to FOI for everyone" message at the same time as the warning message. I have included a conditional `<% if show_donation_button? && !flash[:request_sent] && !@is_owning_user %>`, but this conditional might change depending on the point above.

## Screenshots
<img width="765" alt="Screenshot 2025-07-03 at 13 46 36" src="https://github.com/user-attachments/assets/0f2a74a9-9f2d-49b6-802e-77f59a4276d8" />

## Notes to reviewer
