### PR TITLE
[#2021] Add Midlothian Council no-reply

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -260,6 +260,8 @@ Rails.configuration.to_prepare do
     noreply@north-ayrshire.gov.uk
     noreply@corestream.co.uk
     NHSFife@axlr8.com
+    do-not-reply=midlothian.gov.uk@email.firmstep.com
+    do-not-reply@midlothian.gov.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2021 

## What does this do?

Adds no-reply email addresses for Midlothian Council to `model_patches.rb`

## Why was this needed?

Midlothian are sending out from Firmstep and this is configured to send from a no-reply address.

## Implementation notes

Nothing of note

## Screenshots

N/A

## Notes to reviewer

N/A