### PR TITLE
[#2040] Update Stripe processing details

### DIFF
--- a/lib/views/alaveteli_pro/pages/_legal.html.erb
+++ b/lib/views/alaveteli_pro/pages/_legal.html.erb
@@ -248,9 +248,15 @@
   </p>
 
   <p>
-    We use Stripe for processing payments. You can read about Stripe’s usage
-    terms and privacy policy here: <a
-    href="https://stripe.com/gb/privacy">https://stripe.com/gb/privacy</a>.
+    If you register as a paying customer, your name, contact details, payment
+    and security details are held by the payment processor Stripe, whose usage
+    terms and privacy policy can be seen here:
+    <a href="https://stripe.com/gb/privacy">stripe.com/gb/privacy</a>.
+    Your name, email address, the billing address of your card and the last few
+    digits of your card or bank account number are made available to us along
+    with your purchase history. We use these to manage your subscription, issue
+    invoices and send you important information about changes or updates to the
+    service.
   </p>
 
   <p>The legal basis for the processing of your payment information is Contract


### PR DESCRIPTION
Update in line with other mySociety services.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/2040.

Appears on `/pro/pages/legal`. Not added to `/help/privacy` as not relevant unless you're a Pro subscriber.

<img width="908" height="480" alt="Screenshot 2025-09-16 at 14 38 36" src="https://github.com/user-attachments/assets/57019d69-2132-4f7d-8889-7ba9d70a6efa" />
