### PR TITLE
Restrict `@nhs.net` from web responses

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -131,6 +131,10 @@ Rails.configuration.to_prepare do
     yahoo.co.uk
   ]
 
+  PublicBody.excluded_foi_officer_access_domains += %w[
+    nhs.net
+  ]
+
   PublicBody.class_eval do
     # Return the domain part of an email address, canonicalised and with common
     # extra UK Government server name parts removed.


### PR DESCRIPTION
This is a very wide-ranging domain where we've had a recent example of a user mistaking how this works.

Related to https://github.com/mysociety/alaveteli/pull/8842 & https://github.com/mysociety/alaveteli/issues/427.