### PR TITLE
Refactor UK-specific webmail providers

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -32,6 +32,24 @@ Rails.configuration.to_prepare do
                      "to government services.")
   end
 
+  # Add UK-specific domains and providers
+  Domains.webmail_providers += %w[
+    aol.co.uk
+    blueyonder.co.uk
+    btconnect.com
+    btinternet.com
+    btopenworld.com
+    hotmail.co.uk
+    live.co.uk
+    ntlworld.com
+    sky.com
+    talk21.com
+    talktalk.net
+    tiscali.co.uk
+    virginmedia.com
+    yahoo.co.uk
+  ]
+
   InfoRequest.class_eval do
     def email_subject_request(opts = {})
       html = opts.fetch(:html, true)
@@ -112,23 +130,6 @@ Rails.configuration.to_prepare do
     engrsl
     signpost
     unit
-  ]
-
-  PublicBody.excluded_calculated_home_page_domains += %w[
-    aol.co.uk
-    blueyonder.co.uk
-    btconnect.com
-    btinternet.com
-    btopenworld.com
-    hotmail.co.uk
-    live.co.uk
-    ntlworld.com
-    sky.com
-    talk21.com
-    talktalk.net
-    tiscali.co.uk
-    virginmedia.com
-    yahoo.co.uk
   ]
 
   PublicBody.excluded_foi_officer_access_domains += %w[


### PR DESCRIPTION
Depends on https://github.com/mysociety/alaveteli/pull/8889

We now have a global listing of webmail providers [1], which is used in various places where we use email address domains to do something.

We can now extract the UK-specific domains from
`PublicBody.excluded_calculated_home_page_domains` to this webmail providers list as they are all domains of that nature. The calculated home page domains list will inherit the customised webmail provider list.

[1] https://github.com/mysociety/alaveteli/commit/c0764b7

