### PR TITLE
[#1776] Fix styling of data breach form labels

### DIFF
--- a/lib/views/help/report_a_data_breach.html.erb
+++ b/lib/views/help/report_a_data_breach.html.erb
@@ -14,7 +14,7 @@
     <%= foi_error_messages_for :report %>
 
     <p>
-      <%= f.label :url, "Please provide a link to the request or attachment containing the data breach." %>
+      <%= f.label :url, "Please provide a link to the request or attachment containing the data breach.", class: 'form_label' %>
       <span class="form_item_note">
         Alternatively you can provide the request's email address, if known.
         <br>
@@ -24,7 +24,7 @@
     </p>
 
     <p>
-      <%= f.label :message, "Please provide details about this data breach" %>
+      <%= f.label :message, "Please provide details about this data breach", class: 'form_label' %>
       <%= f.text_area :message, rows: 3 %>
     </p>
 
@@ -36,12 +36,12 @@
     </p>
 
     <p>
-      <%= f.label :dpo_contact_email, "Please provide the email address for the Data Protection Officer (if known):" %>
+      <%= f.label :dpo_contact_email, "Please provide the email address for the Data Protection Officer (if known):", class: 'form_label' %>
       <%= f.email_field :dpo_contact_email %>
     </p>
 
     <p>
-        <label>Are you reporting on behalf of the public body responsible for the data breach?</label>
+        <label class="form_label">Are you reporting on behalf of the public body responsible for the data breach?</label>
         <%= f.label :is_public_body_yes, class: 'form_inline' do %>
           <%= f.radio_button :is_public_body, true %>
           Yes
@@ -54,7 +54,7 @@
 
     <% unless @user %>
       <p>
-        <%= f.label :contact_email, 'My email:' %>
+        <%= f.label :contact_email, 'My email:', class: 'form_label' %>
         <%= f.email_field :contact_email, required: true %>
         (or <%= link_to 'sign in', signin_url(r: request.fullpath) %>)
       </p>


### PR DESCRIPTION
Make consistent use of the `form_label` class.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/1776

**BEFORE**

<img width="753" height="974" alt="Screenshot 2025-09-19 at 14 26 21" src="https://github.com/user-attachments/assets/6d65c1ac-c065-4838-8ced-f22e7f72e265" />

**AFTER**

<img width="747" height="1009" alt="Screenshot 2025-09-19 at 14 26 11" src="https://github.com/user-attachments/assets/d5102a4d-9248-4679-9082-e7908457349b" />
