### PR TITLE
Reconcile with core

### DIFF
--- a/lib/views/user/_signup.html.erb
+++ b/lib/views/user/_signup.html.erb
@@ -61,9 +61,11 @@
       <%= hidden_field_tag 'token', params[:token], id: 'signup_token' %>
       <%= hidden_field_tag :modal, params[:modal], id: 'signup_modal' %>
 
-      <%= submit_tag _('Sign up'),
-                     tabindex: 50,
-                     data: { disable_with: _('Sending...') } %>
+      <p>
+        <%= submit_tag _('Sign up'),
+                       tabindex: 50,
+                       data: { disable_with: _('Sending...') } %>
+      </p>
     </div>
 
     <div class="form_item_note">


### PR DESCRIPTION
See https://github.com/mysociety/alaveteli/pull/8891. Fix issue with form_item_note being jammed up against the signup button.

**BEFORE**

<img width="607" height="217" alt="Screenshot 2025-09-22 at 16 08 15" src="https://github.com/user-attachments/assets/4ac7793f-b87d-4c37-a139-b0d88e85217b" />


**AFTER**

<img width="617" height="232" alt="Screenshot 2025-09-22 at 16 08 01" src="https://github.com/user-attachments/assets/b28b6897-a436-4710-b125-34fe60b56380" />
