### PR TITLE
[#2055] Clearer link to privacy policy on signup

### DIFF
--- a/lib/views/user/_signup.html.erb
+++ b/lib/views/user/_signup.html.erb
@@ -67,11 +67,13 @@
     </div>
 
     <div class="form_item_note">
-      <%= _('By signing up you agree to our ' \
-            '<a href="{{house_rules_url}}">house rules</a>. Commercial and ' \
-            'for-profit use requires a ' \
+      <%= _('By signing up, you agree to our ' \
+            '<a href="{{house_rules_url}}">house rules</a> and confirm ' \
+            'you’ve read our <a href="{{privacy_policy_url}}">privacy policy</a>. ' \
+            'Commercial and for-profit use requires a ' \
             '<a href="{{pro_url}}">WhatDoTheyKnow Pro</a> subscription.',
             house_rules_url: help_house_rules_path,
+            privacy_policy_url: help_privacy_path,
             pro_url: account_request_index_path) %>
     </div>
   <% end %>


### PR DESCRIPTION
We do link to it via the email form note, but that's in reference to sharing your email instead of our general policy. Adding it to the wider small print helps make it super clear.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/2055.

<img width="599" height="124" alt="Screenshot 2025-09-22 at 16 11 38" src="https://github.com/user-attachments/assets/50cc645d-65fe-45ab-a707-30eb3b2e7174" />
