### PR TITLE
Add translation disclaimer

### DIFF
--- a/lib/views/help/_translation_disclaimer.html.erb
+++ b/lib/views/help/_translation_disclaimer.html.erb
@@ -1,0 +1,3 @@
+<div class="changes">
+  For your convenience, we have provided a translation of this page. This translation is for informational purposes only, and the definitive version of this page is the <a href="?locale=en">English version</a>. Os hoffech chi, gallwch weld cyfieithiad awtomataidd, drwy ddefnyddio <a href="https://www-whatdotheyknow-com.translate.goog<%= request.path %>?_x_tr_sl=auto&_x_tr_tl=cy&_x_tr_hl=en&_x_tr_pto=wapp">Google Translate</a>.
+</div>

--- a/lib/views/help/about.cy.html.erb
+++ b/lib/views/help/about.cy.html.erb
@@ -1,6 +1,8 @@
 <% @title = "Cyflwyniad" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
+  <%= render partial: 'translation_disclaimer' %>
+
   <h1 id="introduction"><%= @title %> <a href="#introduction">#</a> </h1>
   <dl>
     <dt id="purpose">

--- a/lib/views/help/house_rules.cy.html.erb
+++ b/lib/views/help/house_rules.cy.html.erb
@@ -1,6 +1,8 @@
 <% @title = "Rheolau tŷ" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
+  <%= render partial: 'translation_disclaimer' %>
+
   <h1><%=@title %></h1>
   <h2>
     Sut rydym yn disgwyl i bobl ddefnyddio’r wefan ac ymddwyn wrth wneud hynny

--- a/lib/views/help/officers.cy.html.erb
+++ b/lib/views/help/officers.cy.html.erb
@@ -1,6 +1,8 @@
 ﻿﻿<% @title = "Cwestiynau Swyddog Rhyddid Gwybodaeth" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
+  <%= render partial: 'translation_disclaimer' %>
+
   <h1 id="officers"><%= @title %> <a href="#officers">#</a></h1>
   <dl>
     <dt id="top">

--- a/lib/views/help/privacy.cy.html.erb
+++ b/lib/views/help/privacy.cy.html.erb
@@ -1,22 +1,11 @@
 <% @title = "Eich preifatrwydd" %>
 <%= render :partial => 'sidebar' %>
+
 <div id="left_column_flip" class="left_column_flip">
+  <%= render partial: 'translation_disclaimer' %>
+
   <h1 id="privacy"><%= @title %> <a href="#privacy">#</a> </h1>
   <dl>
-    <div class="changes">
-      <span style="font-size:16px">
-      <p>
-        <strong>Pennau i fyny!</strong> Rydym yn gwybod nad yw'r dudalen hon mor gyfoes ag y dymunwn. 
-        Rydyn ni'n ceisio datrys hyn; ond os na allwch ddod o hyd i'r hyn sydd ei angen arnoch yma, 
-        rhowch gynnig ar ein prif <a href="/help/privacy">Hysbysiad Preifatrwydd</a>, sydd yn Saesneg.
-      </p>
-      <p>
-        Os hoffech chi, gallwch weld cyfieithiad awtomataidd, drwy ddefnyddio
-        <a href="https://www-whatdotheyknow-com.translate.goog/help/privacy?_x_tr_sl=auto&_x_tr_tl=cy&_x_tr_hl=en&_x_tr_pto=wapp">
-        Google Translate</a>.
-      </p>
-      </span>
-    </div>
     <dd>
       <p>
         Mae WhatDoTheyKnow yn cael ei redeg gan yr elusen mySociety.

--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -1,6 +1,8 @@
 <% @title = "Gwneud ceisiadau" %>
 <%= render :partial => 'sidebar' %>
 <div id="left_column_flip" class="left_column_flip">
+  <%= render partial: 'translation_disclaimer' %>
+
   <h1 id="making_requests"><%= @title %> <a href="#making_requests">#</a> </h1>
   <dl>
     <dt id="which_authority">


### PR DESCRIPTION
We don't have the resources to keep translations in sync, so these often go out of date. In some cases it's quite important that the reader knows that the English version is the definitive one.

Fixes https://github.com/mysociety/whatdotheyknow-private/issues/417.

- [ ] Would be good to translate the actual disclaimer to Welsh.

Have added this to all non-default locale help pages, other than the contact form which is a bit of a different case as it's not really "help" content as such.

<img width="1040" height="311" alt="Screenshot 2025-09-26 at 12 23 09" src="https://github.com/user-attachments/assets/fbf9619c-bea9-4ffa-a494-16515e6a41cc" />

