### PR TITLE
Remove mentions of user messaging system

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -126,11 +126,7 @@
     made a particularly interesting request, as we like to write about these on
     the mySociety blog.
   </p>
-  <p>
-    Secondly, if you send a message to another user on the site, your email
-    address is shared with them. You’ll see an alert to warn you of this before
-    you submit your message.
-  </p>
+
   <p>
     We will not disclose your email address to anyone else unless we are obliged
     to by law, or you ask us to.
@@ -145,13 +141,6 @@
     or for other reasons that you specifically authorise. We will never give or
     sell your email addresses to anyone else, unless we are obliged to by law,
     or you ask us to.
-  </p>
-  <p>
-    In theory, spam could be received via the ‘send this user an email’
-    function. Abuse of this service is not common and you can report any
-    messages which you consider inappropriate to us via the
-    <a href="https://www.whatdotheyknow.com/help/contact">Contact Us</a> form.
-    Upon consideration, we may suspend users who have abused this service.
   </p>
 
   <h3 id="request">
@@ -573,10 +562,6 @@
           A list of the requests and annotations you have made
         </li>
       </ul>
-      <p>
-        The page does not display your email address, but does allow others to
-        get in touch with you via a messaging system.
-      </p>
       <p>
         The page does not display details of alerts you have subscribed to,
         although these are visible to you (and only you) when you are logged in.


### PR DESCRIPTION
This has been disabled on WhatDoTheyKnow.

