### PR TITLE
Scrappy A/B test of donation landing pages

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -19,6 +19,13 @@ Rails.configuration.to_prepare do
       AlaveteliSpamTermChecker::DEFAULT_SPAM_TERMS + custom_terms
   end
 
+  AlaveteliConfiguration.instance_eval do
+    def donation_url
+      ['https://www.mysociety.org/donate/support-whatdotheyknow-and-mysociety/',
+       'https://www.mysociety.org/donate/'].sample
+    end
+  end
+
   ContactValidator.class_eval do
     attr_accessor :understand
 

--- a/spec/donation_helper_spec.rb
+++ b/spec/donation_helper_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe DonationHelper, type: :helper do
     subject { show_donation_button? }
 
     context 'without donation URL' do
+      before do
+        allow(AlaveteliConfiguration).to receive(:donation_url).and_return('')
+      end
+
       it { is_expected.to eq false }
     end
 


### PR DESCRIPTION
Temporary override to the configuration variable to A/B test conversion of the service-specific donation page and the general organisation one.

This won't necessarily be a true 50:50 split (since `sample` is random and the various caching layers may have an impact, etc) but its the landing:conversion rate we're mostly interesting.