### PR TITLE
Fixing broken links to ICO guidance in privacy.html.erb

### DIFF
--- a/lib/views/help/privacy.html.erb
+++ b/lib/views/help/privacy.html.erb
@@ -207,7 +207,7 @@
       </em>
     </li>
     <li>
-     The Information Commissioner’s <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#1">
+     The Information Commissioner’s <a href="https://ico.org.uk/for-organisations/foi/guide-to-managing-an-foi-request/">
       guidance for organisations</a> says <em>“A request must ...
       include an address for correspondence. This need not be the person’s
       residential or work address - it can be <strong>any address at which
@@ -215,7 +215,7 @@
       <strong>email address</strong>;”</em>
     </li>
     <li>
-      Paragraph 107 of the <a href="https://ico.org.uk/media/for-organisations/documents/1164/recognising-a-request-made-under-the-foia.pdf#page=22"
+      The <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/recognising-a-request-made-under-the-freedom-of-information-act-section-8/#dowehave"
       title="Recognising a request made under the FOIA">Information
       Commissioner’s Guidance on recognising a request</a> under the Freedom
       of Information Act now contains a section specifically on
@@ -453,7 +453,7 @@
   <p>
     Technically, you must use your real name for your request to be a valid
     Freedom of Information request in law. See this <a
-    href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/consideration-of-the-applicant-s-identity-or-motives/">
+    href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/consideration-of-the-applicant-s-identity-or-motives/">
     guidance from the Information Commissioner</a>
     (November 2016). However, the same guidance also
     says it is good practice for the public authority to still consider a
@@ -799,7 +799,7 @@
   <p>
     We will consider any such notice, and balance it against
     <a href="/help/privacy#legal_basis">our legitimate interests in processing
-    the material</a>. There is some <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/right-to-erasure/">guidance about this on the ICO’s website</a>.
+    the material</a>. There is some <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/individual-rights/individual-rights/right-to-erasure/">guidance about this on the ICO’s website</a>.
   </p>
 
   <p>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2049 
## What does this do?
Updates the links to those in the issue
## Why was this needed?
The ICO never adds redirects (I really wish they would).
## Implementation notes
N/A
## Screenshots
N/A (doesn't show the underlying link text)
## Notes to reviewer
These are as on the issue.