### PR TITLE
Fixes broken ico links on welsh/english requesting help page

### DIFF
--- a/lib/views/help/requesting.cy.html.erb
+++ b/lib/views/help/requesting.cy.html.erb
@@ -105,7 +105,7 @@
         negeseuon yn dweud y "gallent" godi ffi. Anwybyddwch rybuddion o’r fath. Ni 
         fyddant bron byth mewn gwirionedd yn codi ffi. Os byddant yn codi ffi, dim ond 
         os ydych wedi cytuno’n benodol ymlaen llaw i dalu y gallant godi tâl arnoch. 
-        <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#15">
+        <a href="https://ico.org.uk/for-organisations/foi/guide-to-managing-an-foi-request/what-makes-a-valid-request/">
         Rhagor o fanylion</a>gan y Comisiynydd Gwybodaeth.
       </p>
       <p>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -301,7 +301,7 @@
         can charge for don’t apply to requests made via WhatDoTheyKnow. You will hardly 
         ever be asked for money. If you are, you would always have the chance to say no. 
         A public body can only charge you if you have agreed in advance to pay. See 
-        <a href="https://ico.org.uk/for-organisations/guide-to-freedom-of-information/receiving-a-request/#15">more details</a>
+        <a href="https://ico.org.uk/for-organisations/foi/guide-to-managing-an-foi-request/what-makes-a-valid-request/">more details</a>
         from the ICO.
       </p>
       <p>
@@ -431,7 +431,7 @@
       </p>
       <p>
         We don't allow subject access requests to be made using WhatDoTheyKnow.
-        <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">
+        <a href="https://ico.org.uk/for-the-public/getting-copies-of-your-information-subject-access-request/">
         The Information Commissioner’s website</a> provides advice on how to make a
         Subject Access request.
       </p>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2047 
## What does this do?
Fixes the broken links
## Why was this needed?
The ICO doesn't add redirects and has reorganised things again.
## Implementation notes
n/a
## Screenshots
n/a
## Notes to reviewer
Links as in issue, aside from .cy version that subbed out a deadlink noted in the english.