### PR TITLE
Fixing broken ICO links in EIR pages

### DIFF
--- a/lib/views/help/environmental_information.html.erb
+++ b/lib/views/help/environmental_information.html.erb
@@ -94,26 +94,26 @@
   <p>If a public authority does not hold the requested information at the time they received your request, they do 
   not have to provide you with it.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(a)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/#holding">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(a)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/#holding">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(a)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/InformationNotHeldEIRs%20(1).pdf">OSIC guidance</a></li>
   </ul>
   <strong>✋ Manifestly unreasonable requests</strong>
   <p>Public authorities may refuse to disclose information if the amount of information that you have asked for is 
   excessively large or deemed unreasonable.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(b)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/manifestly-unreasonable-requests-regulation-12-4-b-environmental-information-regulations/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(b)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-4-b-manifestly-unreasonable-requests/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(b)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingRegulation104bManifestlyUnreasonableRequests.pdf">OSIC guidance</a></li>
   </ul>
   <strong>😕 Formulated in too general a manner</strong>
   <p>An authority is not required to release information if the request is not specific or clear enough.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(c)</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1619/requests_formulated_in_too_general_a_manner_eir_guidance.pdf">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(c)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-4-c-requests-formulated-in-too-general-a-manner/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(c)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation104cRequestswhicharetoogeneral.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🚧 Unfinished Material</strong>
   <p>An authority is not required to release information that it is still working on/is unfinished.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(d)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-124d-eir/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(d)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-124d-eir/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(d)</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🤫 Confidentiality of proceedings</strong>
@@ -121,57 +121,57 @@
   of proceedings, where such confidentiality is protected by law. This exception typically applies to information 
   exchanged during legal proceedings, such as court hearings or tribunal proceedings.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(d)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-d-confidentiality-of-proceedings-environmental-information-regulations/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(d)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-5-d-confidentiality-of-proceedings/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(d)</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
   </ul>
   <strong>📧 Internal communications</strong>
   <p>Public authorities may refuse to disclose internal communications, such as draft documents or internal discussions.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(e)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-4-e-internal-communications/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(4)(e)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-4-e-internal-communications/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(4)(e)</a> - <a href="https://www.foi.scot/sites/default/files/2023-03/EIRsGuidanceRegulation104eInternalCommunications.pdf">OSIC guidance</a></li>
   </ul>
   <strong>📄 Intellectual property rights</strong>
   <p>If disclosing the information would infringe on intellectual property rights, such as copyrights or trademarks, 
   the public authority may refuse the request.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(c)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-c-intellectual-property-rights/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(c)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-5-c-intellectual-property-rights">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(c)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105cIntellectualpropertyrights.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🏭 Confidentiality of commercial or industrial information</strong>
   <p>Public authorities may refuse to disclose information if it would adversely affect the confidentiality of commercial 
   or industrial information, where such confidentiality is protected by law to safeguard a legitimate economic interest.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(e)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/commercial-or-industrial-information-regulation-12-5-e/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(e)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-5-e-commercial-or-industrial-information/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(e)</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/EIRBriefingsExceptions.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🤝 Interests of the person who provided the information</strong>
   <p>If the information requested was provided voluntarily and the person who supplied it has not consented to its disclosure, the public authority may refuse the request. This exception applies only if the person who supplied the information was not legally required to do so, and if the public authority can guarantee that the information will remain confidential.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(f)</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1638/eir_voluntary_supply_of_information_regulation.pdf">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(f)</a> - <a href="https://ico.org.uk/media2/gx5juslt/eir_voluntary_supply_of_information_regulation.pdf">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(f)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105fThirdpartyinterests.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🐻 Protection of the environment</strong>
   <p>Public authorities may refuse to disclose information if it would adversely affect the protection of the environment to which the information relates.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(g)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-g-protection-of-the-environment/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(g)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-5-g-protection-of-the-environment/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(g)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105gProtectionoftheEnvironment.pdf">OSIC guidance</a></li>
   </ul>
   <strong>🙋 Personal data</strong>
   <p>If the requested information includes personal data, the public authority may refuse to disclose it if doing so would breach data protection law.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/13/made">Regulation 13</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2619056/s40-personal-information-section-40-regulation-13.pdf">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/13/made">Regulation 13</a> - <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/11/made">Regulation 11</a> - <a href="https://www.foi.scot/sites/default/files/2023-08/EIRsGuidanceRegulation11Personaldata.pdf">OSIC guidance</a></li>
   </ul>
   <strong>💣 International relations, defence, and security</strong>
   <p>Authorities may refuse to provide information if doing so would harm international relations, defence, national security, or public safety.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(a)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-a-international-relations-defence-national-security-or-public-safety/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(a)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-5-a-international-relations-defence-national-security-or-public-safety/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(a)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105aInternationalRelations.pdf">OSIC guidance</a></li>
   </ul>
   <strong>⚖️ Justice and fair trials</strong>
   <p>If sharing the information would negatively affect the course of justice, a person's ability to receive a fair trial, or an authority's ability to conduct a criminal or disciplinary inquiry.</p>
   <ul>
-    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(b)</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/regulation-12-5-b-the-course-of-justice-and-inquiries-exception/">ICO guidance</a></li>
+    <li>EIR: <a href="https://www.legislation.gov.uk/uksi/2004/3391/regulation/12/made">Regulation 12(5)(b)</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/regulation-12-5-b-the-course-of-justice-and-inquiries-exception/">ICO guidance</a></li>
     <li>EISR: <a href="https://www.legislation.gov.uk/ssi/2004/520/regulation/10/made">Regulation 10(5)(b)</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/EIRsGuidanceRegulation105bCourseofJustice.pdf">OSIC guidance</a></li>
   </ul>
   <p>All of the exceptions to EIR are subject to the public interest test, which means that the public 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2048 
## What does this do?
Fixes the links
## Why was this needed?
The ICO reorganised without creating redirects
## Implementation notes
n/a
## Screenshots
n/a
## Notes to reviewer
Claude did this one :)