### PR TITLE
fixing brokem ICO links

### DIFF
--- a/lib/views/help/exemptions.html.erb
+++ b/lib/views/help/exemptions.html.erb
@@ -15,7 +15,7 @@
     out a public authority’s commitment to make some types of information routinely available on request.
   </p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/21">Section 21</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/21">Section 21</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/25">Section 25</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection25InformationOtherwiseAccessible_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
@@ -26,7 +26,7 @@
   <p>Information relating to MI5, MI6, GCHQ and certain other bodies. The public interest test only needs to be carried out when
   someone has asked for very old records.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/23">Section 23</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-23-security-bodies/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/23">Section 23</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-23-security-bodies/">ICO guidance</a></li>
     <li>FOISA: No exact equivalent</li>
     <li>Public Interest Test: Sometimes</li>
   </ul>
@@ -38,7 +38,7 @@
   a court case. There are separate access regimes for getting access to these. Information relating to court building and facilities will
   not normally be covered by this exemption.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/32">Section 32</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619028/s32-court-inquiry-and-arbitration-records.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/32">Section 32</a> - <a href="https://ico.org.uk/media2/migrated/2619028/s32-court-inquiry-and-arbitration-records.pdf">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/37">Section 37</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection37CourtRecords_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
@@ -50,7 +50,7 @@
   House of Commons and the House of Lords, so they can do their jobs without any external interference. Ultimately, the Speaker of
     the House of Commons and the Lord Speaker decide what information is or isn’t privileged.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/34">Section 34</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1161/section_34_parliamentary_privilege.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/34">Section 34</a> - <a href="https://ico.org.uk/media2/jkanzzvq/section_34_parliamentary_privilege.pdf">ICO guidance</a></li>
     <li>FOISA: No equivalent</li>
     <li>Public Interest Test: No</li>
   </ul>
@@ -63,7 +63,7 @@
   likely to succeed. There is a public interest defence to breach of confidence claims, so you can ask the authority to assess the
   public interest on that basis.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/41">Section 41</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/41">Section 41</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(2)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection36Confidentiality_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
@@ -74,7 +74,7 @@
   <p>Information where disclosure is prohibited by law or would result in contempt of court. Contempt of court refers to a situation
   where someone’s actions risk unfairly influencing a court case. This could include disobeying a court order.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/44">Section 44</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619033/s44-prohibitions-on-disclosure.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/44">Section 44</a> - <a href="https://ico.org.uk/media2/cj1jyi3j/s44-prohibitions-on-disclosure.pdf">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/26">Section 26</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection26ProhibitionsOnDisclosure_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: No</li>
   </ul>
@@ -87,7 +87,7 @@
   publish the information at a later date. For Scottish public authorities, the planned publication must be within 12 weeks of the
   request date. For all other public authorities in the UK, this exemption applies even if no publication date has been set.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22">Section 22</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1172/information-intended-for-future-publication-and-research-information-sections-22-and-22a-foi.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22">Section 22</a> - <a href="https://ico.org.uk/media2/xnkbxjwg/s22-and-22a-info-intended-for-future-publication-v-1-2.pdf">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/27">Section 27</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection27InformationIntendedforFuturePublication_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -99,7 +99,7 @@
   impact on institutions or people who are involved in the research. The exemption only applies if the research programme is still
   continuing and if there is an intention to publish the research.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22A">Section 22A</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1172/information-intended-for-future-publication-and-research-information-sections-22-and-22a-foi.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/22A">Section 22A</a> - <a href="https://ico.org.uk/media2/xnkbxjwg/s22-and-22a-info-intended-for-future-publication-v-1-2.pdf">ICO guidance</a></li>
     <li>FOISA: No equivalent</li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -110,7 +110,7 @@
   <p>Information relating to the security of the United Kingdom. This can include information relating to the security of
   Government buildings and the prevention of terrorism.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/24">Section 24</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-24-safeguarding-national-security/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/24">Section 24</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-24-safeguarding-national-security/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection31NationalSecurityandDefence_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -121,7 +121,7 @@
   <p>Information relating to the defence of the UK and the Channel Islands and the effectiveness of the UK armed forces.
   This can also include information about the armed forces of the UK’s allies.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/26">Section 26</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-26-defence/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/26">Section 26</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-26-defence/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/31">Section 31(4)</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection31NationalSecurityandDefence_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -132,7 +132,7 @@
   <p>Communications with other countries, such as correspondence between diplomats, and other information that an authority thinks
   would harm relations between the UK and other countries if it was released.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/27">Section 27</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-27-international-relations/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/27">Section 27</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-27-international-relations/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/32">Section 32</a> - <a href="https://www.foi.scot/sites/default/files/2023-05/BriefingSection32InternationalRelations_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -142,7 +142,7 @@
   </h2>
   <p>Communications between the UK Government and the devolved administrations in Wales, Scotland, and Northern Ireland.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/28">Section 28</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-28-relations-within-the-uk/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/28">Section 28</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-28-relations-within-the-uk/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/28">Section 28</a> - <a href="hhttps://www.foi.scot/sites/default/files/2023-05/BriefingSection28RelationswithintheUnitedKingdom_25.5.23.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -154,7 +154,7 @@
   if released. This covers information that would have a negative impact on the finances of the UK Government or any of the devolved
     administrations. This exemption can be used in cases where information could result in volatility in foreign exchange rates.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/29">Section 29</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2021/2619027/s29-the-economy.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/29">Section 29</a> - <a href="https://ico.org.uk/media2/vemgmhcu/s29-the-economy.pdf">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(2)</a> - <a href="https://www.foi.scot/sites/default/files/2023-06/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -167,7 +167,7 @@
   and prosecuting people who are suspected to have committed crimes. In addition, this also covers immigration controls, the
   collection of taxes, the prison system, and certain types of civil proceedings.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/31">Section 31</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/31">Section 31</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/35">Section 35</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection35LawEnforcement.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -179,7 +179,7 @@
   with a crime or whether or not a person is guilty of a crime. This can apply to information about investigations that have already
   finished as well as current investigations.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/30">Section 30</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/30">Section 30</a> - <a href="https://ico.org.uk/media2/raajgqfq/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/34">Section 34</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection34InvestigationsbyScottishPublicAuthoritiesandProceedings_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -190,7 +190,7 @@
   <p>Any information that could harm a public authority’s ability to carry out an effective audit of another public authority.
   This covers formal ‘value for money’ reviews as well as the auditing of accounts.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/33">Section 33</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1210/public-audit-functions-s33-foi-guidance.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/33">Section 33</a> - <a href="https://ico.org.uk/media2/dppbbtmu/public-audit-functions-s33-foi-guidance.pdf">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/40">Section 40</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/Briefing_Section40AuditFunctions2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -202,7 +202,7 @@
   to the UK Government and to the devolved administrations. The exemptions also cover information about the operation of private
   ministerial offices and advice from the government’s senior legal advisers who are known as the Law Officers.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/35">Section 35</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/35">Section 35</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/29">Section 29</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection29FormulationofScottishAdministrationPolicy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -212,7 +212,7 @@
   </h2>
   <p>Information that, if released, could put someone’s health or safety at risk. This includes risks to both physical and mental health.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/38">Section 38</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/38">Section 38</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-38-health-and-safety/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection39HealthSafetyandtheEnvironment_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -224,7 +224,7 @@
   Environmental Information (Scotland) Regulations (EISR). This means it is exempt under FOI. This is good news for requesters
   because your rights under EIR and EISR are much stronger.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/39">Section 39</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1043419/exemption-for-environmental-information-section-39.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/39">Section 39</a> - <a href="https://ico.org.uk/media2/migrated/1043419/exemption-for-environmental-information-section-39.pdf">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/39">Section 39(2)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection39HealthSafetyandtheEnvironment_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -236,7 +236,7 @@
   lawyers. This also covers certain types of internal discussion that are closely linked to legal proceedings. This exemption
   exists so that people are able to talk openly with their lawyers and receive appropriate legal advice.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/42">Section 42</a> - <a href="https://ico.org.uk/media/for-organisations/documents/1208/legal_professional_privilege_exemption_s42.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/42">Section 42</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-42-legal-professional-privilege/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/36">Section 36(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-07/BriefingSection36Confidentiality_2023.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -246,7 +246,7 @@
   </h2>
   <p>Information on trade secrets (such as secret recipes) or information that could harm the commercial interests of any company or other business. The authority must show that the release of the information would directly cause the harm being claimed.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/43">Section 43</a> - <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/43">Section 43</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/33">Section 33(1)</a> - <a href="https://www.foi.scot/sites/default/files/2023-06/BriefingSection33CommercialInterestsandtheEconomy.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Yes</li>
   </ul>
@@ -271,7 +271,7 @@
   people who are still alive at the time the request is made. This exemption exists to protect people’s right to privacy. The law
   on how personal data can be used and stored in the UK is set out in a law called UK GDPR.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/40">Section 40</a> - <a href="https://ico.org.uk/media/for-organisations/documents/2619056/s40-personal-information-section-40-regulation-13.pdf">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/40">Section 40</a> - <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/38">Section 38</a> - <a href="https://www.foi.scot/sites/default/files/2022-04/BriefingSection38PersonalInformationGDPR.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Sometimes</li>
   </ul>
@@ -284,7 +284,7 @@
   Scotland, an authority can’t use this exemption unless the qualified person says it is OK to do so. The qualified person
     is usually a minister or chief executive. If this is used against you, it’s quite hard to overturn.</p>
   <ul>
-    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/36">Section 36</a> - <a href="https://ico.org.uk/for-organisations/foi-eir-and-access-to-information/freedom-of-information-and-environmental-information-regulations/section-36-prejudice-to-the-effective-conduct-of-public-affairs/">ICO guidance</a></li>
+    <li>FOIA: <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/36">Section 36</a> - <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-36-prejudice-to-the-effective-conduct-of-public-affairs/">ICO guidance</a></li>
     <li>FOISA: <a href="https://www.legislation.gov.uk/asp/2002/13/section/30">Section 30</a> - <a href="https://www.foi.scot/sites/default/files/2022-03/FeesandExcessiveCostofComplianceBriefing.pdf">OSIC guidance</a></li>
     <li>Public Interest Test: Sometimes</li>
   </ul>


### PR DESCRIPTION
## Relevant issue(s)
fixes #2033 
## What does this do?
fixes the broken links on the exemptions page
## Why was this needed?
The ICO moved things with no redirects
## Implementation notes
n/a
## Screenshots
n/a
## Notes to reviewer
As on the ICO website. They don't seem to have finished updating their guidance, so I expect some of these will move again when they do. 