### PR TITLE
Fixing broken ICO links in refusal_advice

### DIFF
--- a/config/refusal_advice/section_11.yml.erb
+++ b/config/refusal_advice/section_11.yml.erb
@@ -28,7 +28,7 @@ foi:
         Would the information that you requested meet the definition of 'a dataset'?
     hint:
       html: >
-        There is <a href="https://ico.org.uk/media/for-organisations/documents/1151/datasets-foi-guidance.pdf">ICO guidance</a> specifically about datasets. This defines a dataset as "a collection of factual information in electronic form to do with the services and functions of the authority that is neither the product of analysis or interpretation, nor an official statistic and has not been materially altered."
+        There is <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/datasets-sections-11-19-45/">ICO guidance</a> specifically about datasets. This defines a dataset as "a collection of factual information in electronic form to do with the services and functions of the authority that is neither the product of analysis or interpretation, nor an official statistic and has not been materially altered."
 
   - id: s11-q3y1
     show_if:
@@ -60,7 +60,7 @@ foi:
         Has the authority stated that it would not be reasonably practicable to convert it into a reusable data format?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1151/datasets-foi-guidance.pdf">ICO guidance</a> says that time, cost, scope and technical issues can all be considerations. However "What is reasonably practicable is a decision for the public authority to make, taking account of all the circumstances of the case, including the purpose of the legislation, which is to promote open data. If the public authority decides that it is not reasonably practicable to provide the information in a re-usable form, the requester can ask the authority to review its decision and then, if they are not satisfied with the authority’s review, complain to the Information Commissioner."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/datasets-sections-11-19-45/">ICO guidance</a> says that time, cost, scope and technical issues can all be considerations. However "What is reasonably practicable is a decision for the public authority to make, taking account of all the circumstances of the case, including the purpose of the legislation, which is to promote open data. If the public authority decides that it is not reasonably practicable to provide the information in a re-usable form, the requester can ask the authority to review its decision and then, if they are not satisfied with the authority’s review, complain to the Information Commissioner."
 
   - id: s11-q4
     show_if: *section-11
@@ -78,7 +78,7 @@ foi:
         Have they provided a reason for this judgement?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> says "the relevant circumstances could include, but are not limited to "the cost of supplying the information in the format requested; how the information is held; the available resources of the authority, and "issues such as security restrictions or difficulties of physical access to records stores".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> says "the relevant circumstances could include, but are not limited to "the cost of supplying the information in the format requested; how the information is held; the available resources of the authority, and "issues such as security restrictions or difficulties of physical access to records stores".
 
   - id: s11-q4y1y1
     show_if:
@@ -122,7 +122,7 @@ foi:
         Has the authority cited copyright or confidentiality as the reason that it is not reasonably practicable for them to provide the requested information in your preferred format?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> states: "Arguments that providing information in the preferred form would allow unauthorised copying,and hence infringement of copyright, are not relevant to whether it is reasonably practicable to comply with the requester’s preference."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> states: "Arguments that providing information in the preferred form would allow unauthorised copying,and hence infringement of copyright, are not relevant to whether it is reasonably practicable to comply with the requester’s preference."
 
   - id: s11-q6
     show_if: *section-11
@@ -132,7 +132,7 @@ foi:
         Did you request to inspect the information in person?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> states that some instances where it is not 'reasonably practicable' for an authority to provide information for inspection include where the original documents are fragile; where redaction is needed.
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> states that some instances where it is not 'reasonably practicable' for an authority to provide information for inspection include where the original documents are fragile; where redaction is needed.
 
   - id: s11-q6y1
     show_if:
@@ -159,7 +159,7 @@ foi:
         Is this method reasonable in the circumstances?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> says that the authority may communicate the information "by any means which are reasonable in the circumstances".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> says that the authority may communicate the information "by any means which are reasonable in the circumstances".
 
   - id: s11-q7
     show_if: *section-11
@@ -187,7 +187,7 @@ foi:
         Does the authority say that all the information in such a summary is exempt?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> states that an authority is not obliged to create a new summary of information, but may do so at their discretion. The summary may sometimes be created by extracting parts of existing information.  If it is not 'reasonably practicable' to extract the required parts, the authority may decide to provide all the information instead.
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> states that an authority is not obliged to create a new summary of information, but may do so at their discretion. The summary may sometimes be created by extracting parts of existing information.  If it is not 'reasonably practicable' to extract the required parts, the authority may decide to provide all the information instead.
 
   - id: s11-q8
     show_if: *section-11
@@ -212,7 +212,7 @@ foi:
         Does the fee also cover staff time spent in photocopying, printing or saving the information to your preferred media?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> states that the authority must not include costs relating to staff time spent in providing the information in your preferred format. Costs other than this are covered by exemption 13 (see our advice on that exemption here).
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> states that the authority must not include costs relating to staff time spent in providing the information in your preferred format. Costs other than this are covered by exemption 13 (see our advice on that exemption here).
 
   - id: s11-q9
     show_if: *section-11

--- a/config/refusal_advice/section_11_actions.yml.erb
+++ b/config/refusal_advice/section_11_actions.yml.erb
@@ -16,14 +16,14 @@ foi:
         plain: >
           The authority must provide the reason for not acquiescing with your request for the format or means of access to the information.
 
-          Ask for an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> on Section 11(3), and stating that the authority must provide the reasoning behind this decision.
+          Ask for an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> on Section 11(3), and stating that the authority must provide the reasoning behind this decision.
 
     - id: s11-a6
       show_if:
       - { id: s11-q4y1y1n1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider asking for an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a>.
+          Consider asking for an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a>.
 
     - id: s11-a8
       show_if:
@@ -32,7 +32,7 @@ foi:
         plain: >
           Not being able to provide the information in your preferred format does not exempt the authority from providing it at all. The ICO states that "the authority may provide the information by any other means that are reasonable in the circumstances" and "if [...] unable to provide the information by the preferred means, we consider that it would be good practice for the public authority to discuss with the requester whether they can provide the information in another form that would be acceptable".
 
-          Check that this is the only reason given for not providing the information,and if so, request an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a>.
+          Check that this is the only reason given for not providing the information,and if so, request an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a>.
 
     - id: s11-a9
       show_if:
@@ -46,7 +46,7 @@ foi:
       - { id: s11-q6y1, operator: is, value: 'no' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> says that the authority must provide the reasons.
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> says that the authority must provide the reasons.
 
           Ask for an internal review, citing this guidance.
 
@@ -55,7 +55,7 @@ foi:
       - { id: s11-q6y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a> says, "If it is not reasonably practicable to allow inspection, then the public authority must still communicate the information to the requester by other means."
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a> says, "If it is not reasonably practicable to allow inspection, then the public authority must still communicate the information to the requester by other means."
 
           Request an internal review, citing this guidance.
 
@@ -149,4 +149,4 @@ foi:
       - { id: s11-q9y1, operator: is, value: 'yes' }
       advice:
         html: >
-          According to <a href="https://ico.org.uk/media/for-organisations/documents/1163/means-of-communicating-information-foia-guidance.pdf">ICO guidance</a>, the authority is within its rights not to provide the information in your preferred format, and Section 21 may apply.
+          According to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/means-of-communicating-information-section-11/">ICO guidance</a>, the authority is within its rights not to provide the information in your preferred format, and Section 21 may apply.

--- a/config/refusal_advice/section_14_actions.yml.erb
+++ b/config/refusal_advice/section_14_actions.yml.erb
@@ -23,14 +23,14 @@ foi:
         html: >
           A <a href="http://www.bailii.org/ew/cases/EWCA/Civ/2015/454.html">Court of Appeal case</a> stated that a request may not be vexatious if "the information sought would be of value to the requester or to the public or any section of the public".
 
-          Consider requesting an internal review, citing the <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a> and stating the value this information would have if released.
+          Consider requesting an internal review, citing the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-14-dealing-with-vexatious-requests/">ICO guidance</a> and stating the value this information would have if released.
 
     - id: s14-a13
       show_if:
       - { id: s14-q6, operator: is, value: 'yes' }
       advice:
         html: >
-          Consider requesting an internal review. The <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a> states that an FOI service must be 'applicant blind'. Exemption 14(1) can only be applied to the request itself, and not the individual who submits it.
+          Consider requesting an internal review. The <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-14-dealing-with-vexatious-requests/">ICO guidance</a> states that an FOI service must be 'applicant blind'. Exemption 14(1) can only be applied to the request itself, and not the individual who submits it.
 
     - id: s14-a15
       show_if:
@@ -44,7 +44,7 @@ foi:
       - { id: s14-q8, operator: is, value: 'yes' }
       advice:
         html: >
-          Request an internal review, citing the <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a>. Round robin requests can be a legitimate way to get a wider picture or consistent data from a range of authorities. Also, authorities may only consider the burden on themselves, not that which your other requests may place on other authorities.
+          Request an internal review, citing the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-14-dealing-with-vexatious-requests/">ICO guidance</a>. Round robin requests can be a legitimate way to get a wider picture or consistent data from a range of authorities. Also, authorities may only consider the burden on themselves, not that which your other requests may place on other authorities.
 
     - id: s14-a18
       show_if:
@@ -95,7 +95,7 @@ foi:
       - { id: s14-q4y1y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Reply, citing <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/dealing-with-vexatious-requests-section-14/">ICO guidance</a> and asking for such suggestions.
+          Reply, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-14-dealing-with-vexatious-requests/">ICO guidance</a> and asking for such suggestions.
 
     - id: s14-a17
       show_if:

--- a/config/refusal_advice/section_21.yml.erb
+++ b/config/refusal_advice/section_21.yml.erb
@@ -11,7 +11,7 @@ foi:
         Having stated that this exemption applies, has the authority pointed you precisely to where the information can be found?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> states that the authority should either "[know] that the applicant has already found the information; or [be] able to provide the applicant with precise directions to the information so that it can be found without difficulty".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> states that the authority should either "[know] that the applicant has already found the information; or [be] able to provide the applicant with precise directions to the information so that it can be found without difficulty".
 
   - id: s21-q1y1
     show_if:
@@ -38,7 +38,7 @@ foi:
         Are there specific or personal circumstances which prevent you from accessing this information?
     hint:
       html: >
-        This is one of the few exemptions where an authority may consider <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">your personal circumstances</a>, and there are many possible considerations. These may include: that you do not have free or easy access to the internet, when the information is accessible only online; not being able to access an address where the information is held because you live far away from it or have physical difficulty accessing it, or because your job does not allow you to visit during its opening hours.  The authority must also take into consideration their obligations under relevant legislation such as the Equalities Act and the Welsh Language Act.
+        This is one of the few exemptions where an authority may consider <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">your personal circumstances</a>, and there are many possible considerations. These may include: that you do not have free or easy access to the internet, when the information is accessible only online; not being able to access an address where the information is held because you live far away from it or have physical difficulty accessing it, or because your job does not allow you to visit during its opening hours.  The authority must also take into consideration their obligations under relevant legislation such as the Equalities Act and the Welsh Language Act.
 
   - id: s21-q1y1y1n1y1
     show_if:
@@ -80,7 +80,7 @@ foi:
         Are there any restrictions to you as regards the use of the information once you have retrieved it from the other regime?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> states: "In order for section 21 to apply the applicant should be as free to use the information provided under any alternative access regime as they would be had it been disclosed under FOIA. This will include any conditions attached to further use that would apply when information is disclosed under FOIA, such as copyright restrictions".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> states: "In order for section 21 to apply the applicant should be as free to use the information provided under any alternative access regime as they would be had it been disclosed under FOIA. This will include any conditions attached to further use that would apply when information is disclosed under FOIA, such as copyright restrictions".
 
   - id: s21-q3
     show_if: *section-21
@@ -122,7 +122,7 @@ foi:
         Has the authority stated that the information is accessible via their own publication scheme?
     hint:
       html: >
-        A 'publication scheme' refers to an authority's practice of regularly publishing certain categories of data or information, usually on their website or via downloadable reports. Publication schemes must be ICO approved and adhere to the <a href="https://ico.org.uk/media/for-organisations/documents/1153/model-publication-scheme.pdf">model publication scheme</a>.
+        A 'publication scheme' refers to an authority's practice of regularly publishing certain categories of data or information, usually on their website or via downloadable reports. Publication schemes must be ICO approved and adhere to the <a href="https://ico.org.uk/for-organisations/foi/publication-schemes-a-guide/">model publication scheme</a>.
 
   - id: s21-q4y1
     show_if:
@@ -133,7 +133,7 @@ foi:
         Is it clear how to access the information?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> says: "As long as an authority draws the attention of the applicant to the scheme such that it is clear how the requested information can be accessed, its obligations in this respect will generally be fulfilled."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> says: "As long as an authority draws the attention of the applicant to the scheme such that it is clear how the requested information can be accessed, its obligations in this respect will generally be fulfilled."
 
   - id: s21-q4y2
     show_if:
@@ -152,7 +152,7 @@ foi:
         Is access to this information only available in person?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> says: "One requirement of the model publication scheme is that “only in exceptional circumstances” will information in the scheme be made available only by viewing in person".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> says: "One requirement of the model publication scheme is that “only in exceptional circumstances” will information in the scheme be made available only by viewing in person".
 
   - id: s21-q4y3y1
     show_if:
@@ -173,7 +173,7 @@ foi:
         If you wish to access the information via the route the authority has indicated, is payment required?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> says: "Section 21(2)(a) states that information may be regarded as reasonably accessible to the applicant “even though it is accessible only on payment”."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> says: "Section 21(2)(a) states that information may be regarded as reasonably accessible to the applicant “even though it is accessible only on payment”."
 
         WhatDoTheyKnow's opinion? We don't approve of this loophole, as in practice it means that if authorities wish to refuse access to information, they can apply a price to it! However, it is part of the Act.
 
@@ -202,4 +202,4 @@ foi:
     options: *yes-no
     label:
       html: >
-        Has the authority <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">confirmed or denied</a> whether they hold the information you have requested, or does the rest of their response make it clear whether they do or do not hold the information?
+        Has the authority <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">confirmed or denied</a> whether they hold the information you have requested, or does the rest of their response make it clear whether they do or do not hold the information?

--- a/config/refusal_advice/section_21_actions.yml.erb
+++ b/config/refusal_advice/section_21_actions.yml.erb
@@ -7,7 +7,7 @@ foi:
       - { id: s21-q1y1y1n1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Ask for an internal review, repeating the circumstances that mean the information is not accessible to you, and citing <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> as well as any relevant legislation.
+          Ask for an internal review, repeating the circumstances that mean the information is not accessible to you, and citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> as well as any relevant legislation.
 
     - id: s21-a9
       show_if:
@@ -21,7 +21,7 @@ foi:
       - { id: s21-q3y1y, operator: is, value: 'yes' }
       advice:
         html: >
-          When Exemption 22(2)(b) is applied, <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> states that the information 'cannot automatically' be considered as reasonably accessible. However, it also says that "information that is only available for inspection can still be considered to be reasonably accessible to the applicant under other parts of section 21". It is worth reading this guidance in full to see whether it is relevant to your case.
+          When Exemption 22(2)(b) is applied, <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> states that the information 'cannot automatically' be considered as reasonably accessible. However, it also says that "information that is only available for inspection can still be considered to be reasonably accessible to the applicant under other parts of section 21". It is worth reading this guidance in full to see whether it is relevant to your case.
 
           If exemption 21(2)(b) has been applied, read the ICO guidance and consider requesting an internal review if you can make a good case for disclosure.
 
@@ -57,7 +57,7 @@ foi:
 
           If they wish to withhold some of the information due to another exemption, they need to state why that exemption applies and apply their reasoning in full, including a consideration of the public interest where that applies. Section 21 doesn’t apply to that part of the information.
 
-          <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> states “If only part of the requested information is in the public domain, section 21 can only apply to that part of the request", and “If the information is held but is covered by another exemption [...], section 21 cannot apply because, for that very reason, the information is not, in fact, reasonably accessible to the requester".
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> states “If only part of the requested information is in the public domain, section 21 can only apply to that part of the request", and “If the information is held but is covered by another exemption [...], section 21 cannot apply because, for that very reason, the information is not, in fact, reasonably accessible to the requester".
 
   - id: clarification
     suggestions:
@@ -87,14 +87,14 @@ foi:
       - { id: s21-q2y1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider responding to the authority to ask for clarification. <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> states: "The authority should ensure that the applicant is familiar with the details of the regime and how it operates".
+          Consider responding to the authority to ask for clarification. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> states: "The authority should ensure that the applicant is familiar with the details of the regime and how it operates".
 
     - id: s21-a7
       show_if:
       - { id: s21-q2y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider responding to the authority to ask for clarification. <a href="https://ico.org.uk/media/for-organisations/documents/1203/information-reasonably-accessible-to-the-applicant-by-other-means-sec21.pdf">ICO guidance</a> gives the example of health records which are available only to relatives of a deceased person: the authority can demonstrate that these are available to the requester, if the requester is a relative. We also often see requests for service records — <a href="https://www.gov.uk/government/collections/requests-for-personal-data-and-service-records">see more information on that here</a>.
+          Consider responding to the authority to ask for clarification. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-21-information-accessible-to-the-applicant-by-other-means/">ICO guidance</a> gives the example of health records which are available only to relatives of a deceased person: the authority can demonstrate that these are available to the requester, if the requester is a relative. We also often see requests for service records — <a href="https://www.gov.uk/government/collections/requests-for-personal-data-and-service-records">see more information on that here</a>.
 
     - id: s21-a10
       show_if:
@@ -161,7 +161,7 @@ foi:
       - { id: s21-q4y2, operator: is, value: 'yes' }
       advice:
         html: >
-          Consider investigating whether the authority's publication scheme adheres to the <a href="https://ico.org.uk/media/for-organisations/documents/1153/model-publication-scheme.pdf">ICO model publication scheme</a>.
+          Consider investigating whether the authority's publication scheme adheres to the <a href="https://ico.org.uk/for-organisations/foi/publication-schemes-a-guide/">ICO model publication scheme</a>.
 
     - id: s21-a16
       show_if:

--- a/config/refusal_advice/section_30.yml.erb
+++ b/config/refusal_advice/section_30.yml.erb
@@ -22,7 +22,7 @@ foi:
          Has the authority carried out a public interest test?
     hint:
       html: >
-        Some exemptions, including this one, require the authority to conduct a <a href="https://ico.org.uk/media/for-organisations/documents/1183/the_public_interest_test.pdf">public interest test</a>. Note that 'interest' here does not refer to whether the information would be interesting to the public. This requirement says that the authority must weigh up whether there is more 'public good' in disclosing the information than the harm that disclosure would cause (in this case, by prejudicing the prosecution or investigation, or compromising a confidential source). <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">The ICO says</a>, "Where there would be no harm in releasing the information, or the public interest arguments in favour of disclosure outweigh those in favour of maintaining the exemption, it will need to be disclosed."
+        Some exemptions, including this one, require the authority to conduct a <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/the-public-interest-test/">public interest test</a>. Note that 'interest' here does not refer to whether the information would be interesting to the public. This requirement says that the authority must weigh up whether there is more 'public good' in disclosing the information than the harm that disclosure would cause (in this case, by prejudicing the prosecution or investigation, or compromising a confidential source). <a href="https://ico.org.uk/media2/raajgqfq/investigations-and-proceedings-foi-section-30.pdf">The ICO says</a>, "Where there would be no harm in releasing the information, or the public interest arguments in favour of disclosure outweigh those in favour of maintaining the exemption, it will need to be disclosed."
 
   - id: s30-q1y1y1
     show_if:
@@ -45,7 +45,7 @@ foi:
       html: >
         A Section 30 exemption can only be applied by authorities that "have a duty to investigate whether someone should be charged with an offence, or the power to conduct such investigations and/or institute criminal proceedings".
 
-        <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf>The ICO says</a>, "When citing section 30(1)(a) public authorities need to explain not only how the duty to investigate arises but also which offence or offences, usually defined in common law or statute, are relevant in the particular circumstances [...]. Although the police are the most obvious users of section 30(1)(a), there may be other public authorities who have a duty to investigate offences which may lead to a suspect being charged."
+        <a href="https://ico.org.uk/media2/raajgqfq/investigations-and-proceedings-foi-section-30.pdf>The ICO says</a>, "When citing section 30(1)(a) public authorities need to explain not only how the duty to investigate arises but also which offence or offences, usually defined in common law or statute, are relevant in the particular circumstances [...]. Although the police are the most obvious users of section 30(1)(a), there may be other public authorities who have a duty to investigate offences which may lead to a suspect being charged."
 
   - id: s30-q2y1
     show_if:
@@ -71,7 +71,7 @@ foi:
          Is the information you have requested a 'historical record'?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">The ICO says</a>: "Under section 63 of FOIA information contained in a historical record cannot be exempt under section 30(1)"
+        <a href="https://ico.org.uk/media2/raajgqfq/investigations-and-proceedings-foi-section-30.pdf">The ICO says</a>: "Under section 63 of FOIA information contained in a historical record cannot be exempt under section 30(1)"
 
         It defines historical records: "Originally, a historical record was one over 30 years old, or if forming part of a file, the last entry on that file must be over 30 years old. However, this has now been amended to 20 years by the Constitutional Reform and Governance Act 2010. This reduction is being phased in gradually over 10 years. In effect, from the end of 2013, the time limit is 29 years. It will reduce by another year, every year, until it reaches 20 years at the end of 2022".
 

--- a/config/refusal_advice/section_30_actions.yml.erb
+++ b/config/refusal_advice/section_30_actions.yml.erb
@@ -14,21 +14,21 @@ foi:
       - { id: s30-q1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Ask for an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a> and asking the authority to provide evidence that the public interest test was conducted in this case.
+          Ask for an internal review, citing <a href="https://ico.org.uk/media2/raajgqfq/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a> and asking the authority to provide evidence that the public interest test was conducted in this case.
 
     - id: s30-a3
       show_if:
       - { id: s30-q1y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider asking for an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a>.
+          Consider asking for an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>.
 
     - id: s30-a4
       show_if:
       - { id: s30-q1y1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a>, says, for example, says, for example, that "in a democratic society it is important that offences can be effectively investigated and prosecuted. However, the public needs to have confidence in the ability of the responsible public authorities to uphold the law and the public interest will be served by disclosures which serve that purpose". These considerations would be set against the effect upon the investigation or criminal proceedings; or against the potential effects on a confidential source, including the possibility that future confidential sources may be deterred from coming forward. If you think you may be able to make a good case for public interest based on one of these premises, read the ICO guidance linked above, and consider requesting an internal review.
+          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, says, for example, that "in a democratic society it is important that offences can be effectively investigated and prosecuted. However, the public needs to have confidence in the ability of the responsible public authorities to uphold the law and the public interest will be served by disclosures which serve that purpose". These considerations would be set against the effect upon the investigation or criminal proceedings; or against the potential effects on a confidential source, including the possibility that future confidential sources may be deterred from coming forward. If you think you may be able to make a good case for public interest based on one of these premises, read the ICO guidance linked above, and consider requesting an internal review.
 
     - id: s30-a6
       show_if:
@@ -46,7 +46,7 @@ foi:
 
           Confidential sources are very well protected by FOI, in recognition of the danger they may face if their confidentiality is compromised.
 
-          However, the existence of a confidential source will not necessarily mean that other pieces of information cannot be released, if doing so will have no effect on that source. Consider the authority's response carefully, read the <a href="https://ico.org.uk/media/for-organisations/documents/1205/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a>, and if you think you can argue convincingly that the confidential source is not a relevant factor to the matter (for example, if the release of information will not impact the source negatively), there may be grounds for requesting an internal review.
+          However, the existence of a confidential source will not necessarily mean that other pieces of information cannot be released, if doing so will have no effect on that source. Consider the authority's response carefully, read the <a href="https://ico.org.uk/media2/raajgqfq/investigations-and-proceedings-foi-section-30.pdf">ICO guidance</a>, and if you think you can argue convincingly that the confidential source is not a relevant factor to the matter (for example, if the release of information will not impact the source negatively), there may be grounds for requesting an internal review.
 
     - id: s30-a8
       show_if:
@@ -62,7 +62,7 @@ foi:
       - { id: s30-q4n1, operator: is, value: 'no' }
       advice:
         html: >
-          You may wish to ask for an internal review, asking the authority to confirm or deny whether they hold the information.There is more information about confirming or denying in this <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">ICO guidance</a>.
+          You may wish to ask for an internal review, asking the authority to confirm or deny whether they hold the information.There is more information about confirming or denying in this <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">ICO guidance</a>.
 
     - id: s30-a11
       show_if:
@@ -76,7 +76,7 @@ foi:
       - { id: s30-q4n1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/media/for-organisations/documents/1178/commercial-interests-section-43-foia-guidance.pdf">ICO guidance</a>, says, for example, that "in a democratic society it is important that offences can be effectively investigated and prosecuted. However, the public needs to have confidence in the ability of the responsible public authorities to uphold the law and the public interest will be served by disclosures which serve that purpose".
+          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, that "in a democratic society it is important that offences can be effectively investigated and prosecuted. However, the public needs to have confidence in the ability of the responsible public authorities to uphold the law and the public interest will be served by disclosures which serve that purpose".
 
           These considerations would, however, be set against the effect upon the investigation or criminal proceedings; or against the potential effects on a confidential source, including the possibility that future confidential sources may be deterred from coming forward. If you think you may be able to make a good case for public interest based on one of these premises, read the ICO guidance and consider requesting an internal review.
 

--- a/config/refusal_advice/section_31.yml.erb
+++ b/config/refusal_advice/section_31.yml.erb
@@ -11,7 +11,7 @@ foi:
         Has the authority conducted a prejudice test?
     hint:
       html: >
-        A prejudice test requires the authority to demonstrate that there would be a "causal link" between the release of the requested information, and prejudice (ie harm) to one of the interests (such as law enforcement or justice) listed in this exemption. <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/31">See Sections 1 and 2 of exemption 31</a> for a full list of these interests. The authority must then go on to determine the likelihood of this prejudice arising were the information released.  You can find more information about prejudice tests in <a href="https://ico.org.uk/media/for-organisations/documents/1214/the_prejudice_test.pdf">this ICO guidance</a>.
+        A prejudice test requires the authority to demonstrate that there would be a "causal link" between the release of the requested information, and prejudice (ie harm) to one of the interests (such as law enforcement or justice) listed in this exemption. <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/31">See Sections 1 and 2 of exemption 31</a> for a full list of these interests. The authority must then go on to determine the likelihood of this prejudice arising were the information released.  You can find more information about prejudice tests in <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/the-prejudice-test/">this ICO guidance</a>.
 
   - id: s31-q1y1
     show_if:
@@ -43,7 +43,7 @@ foi:
     options: *yes-no
     label:
       html: >
-        Has the authority conducted a <a href="https://ico.org.uk/media/for-organisations/documents/1183/the_public_interest_test.pdf">public interest test</a>?
+        Has the authority conducted a <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/the-public-interest-test/">public interest test</a>?
     hint:
       plain: >
         The authority is obliged to consider whether the 'public good' that would arise from the release of the information would outweigh the identified prejudice (or harm) to the identified law enforcement interest.
@@ -71,7 +71,7 @@ foi:
         Does the response identify which public authority's activities would be subject to prejudice through the release of this information, and give supporting evidence for this conclusion?
     hint:
       html: >
-        According to <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a>, the authority must "identify the public authority that has been entrusted with a function to fulfil one of the purposes listed in subsection (2); confirm that the function has been specifically designed to fulfil that purpose, and explain how the disclosure would prejudice that function."
+        According to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a>, the authority must "identify the public authority that has been entrusted with a function to fulfil one of the purposes listed in subsection (2); confirm that the function has been specifically designed to fulfil that purpose, and explain how the disclosure would prejudice that function."
 
   - id: s31-q3y1y1
     show_if:
@@ -90,7 +90,7 @@ foi:
         Has the responding authority consulted the other authority before coming to its conclusion?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> states that "Where one public authority claims that a disclosure would prejudice the functions of another the Information Commissioner would expect that public authority to have obtained evidence from the public authority affected by the disclosure."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> states that "Where one public authority claims that a disclosure would prejudice the functions of another the Information Commissioner would expect that public authority to have obtained evidence from the public authority affected by the disclosure."
 
   - id: s31-q3
     show_if: *section-31

--- a/config/refusal_advice/section_31_actions.yml.erb
+++ b/config/refusal_advice/section_31_actions.yml.erb
@@ -7,30 +7,30 @@ foi:
       - { id: s31-q1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider requesting an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> that this exemption requires a prejudice test to be conducted.
+          Consider requesting an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> that this exemption requires a prejudice test to be conducted.
 
     - id: s31-a2
       show_if:
       - { id: s31-q1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider requesting an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> that the authority must state the interest they believe will be prejudiced.
+          Consider requesting an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> that the authority must state the interest they believe will be prejudiced.
 
     - id: s31-a3
       show_if:
       - { id: s31-q1y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          The authority is required to demonstrate the harm that would potentially be caused by release of the information, and how the release would cause such harm. <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> says that if 'the harm is only trivial, the exemption would not be engaged'. However, it also refers to the 'mosaic effect', the concept that the information released may be put together with other information already in the public domain, which would then satisfy the conditions of prejudice. Additionally, the authority is allowed to consider the 'precedent effect' where 'complying with one request would make it more difficult to refuse requests for similar information in the future'.
+          The authority is required to demonstrate the harm that would potentially be caused by release of the information, and how the release would cause such harm. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> says that if 'the harm is only trivial, the exemption would not be engaged'. However, it also refers to the 'mosaic effect', the concept that the information released may be put together with other information already in the public domain, which would then satisfy the conditions of prejudice. Additionally, the authority is allowed to consider the 'precedent effect' where 'complying with one request would make it more difficult to refuse requests for similar information in the future'.
 
-          Consider requesting an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> and asking the authority to provide information about the perceived prejudice and the causal link to the release of information.
+          Consider requesting an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> and asking the authority to provide information about the perceived prejudice and the causal link to the release of information.
 
     - id: s31-a4
       show_if:
       - { id: s31-q1y1y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> states: "Deciding whether the prejudice would occur or is only likely to occur is important. In this context the term “would prejudice” means that it has to be <i>more probable than not</i> that the prejudice would occur." [italics ours]
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> states: "Deciding whether the prejudice would occur or is only likely to occur is important. In this context the term “would prejudice” means that it has to be <i>more probable than not</i> that the prejudice would occur." [italics ours]
 
           Consider requesting an internal review, citing this guidance.
 
@@ -50,7 +50,7 @@ foi:
 
           It adds, "Public authorities cannot take account of either crimes or the consequences of those crimes which are too speculative or fanciful", but also that "each case needs to be considered on its own merits taking account of the actual harm that would be caused by disclosure together with all the circumstances of the case."
 
-          If you can argue plausibly that the public interest test should have come to the opposite conclusion, read the <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> on this section and then consider requesting an internal review, citing your reasons.
+          If you can argue plausibly that the public interest test should have come to the opposite conclusion, read the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> on this section and then consider requesting an internal review, citing your reasons.
 
     - id: s31-a7
       show_if:
@@ -71,7 +71,7 @@ foi:
       - { id: s31-q3n1, operator: is, value: 'yes' }
       advice:
         html: >
-          You may wish to read the section on confirming or denying in the <a href="https://ico.org.uk/media/for-organisations/documents/1207/law-enforcement-foi-section-31.pdf">ICO guidance</a> and see whether you agree with this decision.
+          You may wish to read the section on confirming or denying in the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-31-law-enforcement/">ICO guidance</a> and see whether you agree with this decision.
 
     - id: s31-a12
       show_if:

--- a/config/refusal_advice/section_35.yml.erb
+++ b/config/refusal_advice/section_35.yml.erb
@@ -11,7 +11,7 @@ foi:
         Did you request information from a department of the UK, Wales or Northern Ireland central Governments?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> states that this exemption may only be applied to "information held by central government departments or the Welsh Assembly Government [...which includes any] Northern Ireland department, the Northern Ireland Court Service, and any other body or authority exercising statutory functions on behalf of the Crown (not including Scottish bodies or the security services)."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> states that this exemption may only be applied to "information held by central government departments or the Welsh Assembly Government [...which includes any] Northern Ireland department, the Northern Ireland Court Service, and any other body or authority exercising statutory functions on behalf of the Crown (not including Scottish bodies or the security services)."
 
   - id: s35-q1y1
     show_if:
@@ -60,7 +60,7 @@ foi:
         Has the authority conducted a public interest test on the matter of whether to confirm or deny?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> says "Departments can only NCND if the public interest in concealing whether information is held outweighs the public interest in knowing whether information is held", and "a department must be able to explain in the public interest test exactly what a hypothetical confirmation or a hypothetical denial would reveal in the context of the particular request, and why at least one of these responses would be harmful to good government."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> says "Departments can only NCND if the public interest in concealing whether information is held outweighs the public interest in knowing whether information is held", and "a department must be able to explain in the public interest test exactly what a hypothetical confirmation or a hypothetical denial would reveal in the context of the particular request, and why at least one of these responses would be harmful to good government."
 
   - id: s35-q2
     show_if: *section-35
@@ -80,7 +80,7 @@ foi:
         Has the authority also applied Section 36?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> says "if any part of section 35 is engaged, section 36 cannot apply".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> says "if any part of section 35 is engaged, section 36 cannot apply".
 
   - id: s35-q4
     show_if: *section-35
@@ -98,7 +98,7 @@ foi:
         Did you request statistical information?
     hint:
       html: >
-        There is more information about what counts as statistical information in sections 162-168 of this <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a>.
+        There is more information about what counts as statistical information in sections 162-168 of this <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a>.
 
   - id: s35-q4y1y1
     show_if:
@@ -125,7 +125,7 @@ foi:
         Did you request information relating to the internal management of the department?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> says, "Departmental policies relating to the internal management and administration of individual departments (eg HR, information security, management structure, or administrative processes) are not government policy. All public and indeed private sector organisations need these sorts of policies in place. They are about managing the organisation, rather than governing the wider world.".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> says, "Departmental policies relating to the internal management and administration of individual departments (eg HR, information security, management structure, or administrative processes) are not government policy. All public and indeed private sector organisations need these sorts of policies in place. They are about managing the organisation, rather than governing the wider world.".
 
   - id: s35-q4n1n1
     show_if:
@@ -136,7 +136,7 @@ foi:
         Does the information you requested apply to the <i>formulation</i> of policy?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> states: "To be exempt, the information must relate to the formulation or development of government policy. The Commissioner understands these terms to broadly refer to the design of new policy, and the process of reviewing or improving existing policy. [...] However, the exemption will not cover information relating purely to the <i>application or implementation of established policy</i>." [italics ours].
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> states: "To be exempt, the information must relate to the formulation or development of government policy. The Commissioner understands these terms to broadly refer to the design of new policy, and the process of reviewing or improving existing policy. [...] However, the exemption will not cover information relating purely to the <i>application or implementation of established policy</i>." [italics ours].
 
         It continues, "The Commissioner considers that the following factors will be key indicators of the formulation or development of government policy: the final decision will be made either by the Cabinetor the relevant minister; the government intends to achieve a particular outcome or change in the real world; and the consequences of the decision will be wide-ranging".
 
@@ -148,7 +148,7 @@ foi:
         Has the policy now been implemented?
     advice:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> suggests that policy may be considered to have moved from formulation to implementation when it becomes legislation, when it is publicly announced, or when it is rolled out.
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> suggests that policy may be considered to have moved from formulation to implementation when it becomes legislation, when it is publicly announced, or when it is rolled out.
 
   - id: s35-q5
     show_if: *section-35
@@ -158,7 +158,7 @@ foi:
         Did you request information relating to a decision made by a Minister?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> suggests that only Ministers have the final say on government policy, and "any decisions or adjustments made by someone else must therefore be implementation or management decisions, rather than policy development".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> suggests that only Ministers have the final say on government policy, and "any decisions or adjustments made by someone else must therefore be implementation or management decisions, rather than policy development".
 
   - id: s35-q5y1
     show_if:
@@ -176,7 +176,7 @@ foi:
         Has the authority applied Section 35(1)(b) (information relating to 'ministerial communications')?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> says, "The purpose of section 35(1)(b) is to protect the operation of government at ministerial level. It prevents disclosures which would significantly undermine ministerial unity and effectiveness or result in less robust, well-considered or effective ministerial debates and decisions. However, it should not be used simply to protect ministers from embarrassment,or from being held accountable for their decisions".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> says, "The purpose of section 35(1)(b) is to protect the operation of government at ministerial level. It prevents disclosures which would significantly undermine ministerial unity and effectiveness or result in less robust, well-considered or effective ministerial debates and decisions. However, it should not be used simply to protect ministers from embarrassment,or from being held accountable for their decisions".
 
   - id: s35-q6y1
     show_if:
@@ -187,7 +187,7 @@ foi:
         Did you request statistical information?
     hint:
       html: >
-        There is more information about what counts as statistical information in sections 162-168 of this <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a>.
+        There is more information about what counts as statistical information in sections 162-168 of this <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a>.
 
   - id: s35-q6y1y1
     show_if:
@@ -239,7 +239,7 @@ foi:
         Has the authority applied Section 35(1)(d) (information relating to 'the operation of any Ministerial private offices'?).
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> says that this exemption is rarely applied: "it is limited to information about routine administrative and management processes [and is]  likely to cover information such as routine emails, circulation lists, procedures for handling ministerial papers or prioritising issues, travel expenses, information about staffing, the minister’s diary, and any purely internal documents or discussions which have not been circulated outside the private office [...] However, the exemption will not automatically cover the content of a document just because it originated in or passed through the ministerial private office. In particular, it will not automatically cover the content of all ministerial papers, or details of ministerial meetings with third parties".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> says that this exemption is rarely applied: "it is limited to information about routine administrative and management processes [and is]  likely to cover information such as routine emails, circulation lists, procedures for handling ministerial papers or prioritising issues, travel expenses, information about staffing, the minister’s diary, and any purely internal documents or discussions which have not been circulated outside the private office [...] However, the exemption will not automatically cover the content of a document just because it originated in or passed through the ministerial private office. In particular, it will not automatically cover the content of all ministerial papers, or details of ministerial meetings with third parties".
 
   - id: s35-q8y1
     show_if:
@@ -250,4 +250,4 @@ foi:
         Has a public interest test been conducted?
     hint:
       html: >
-        You can find more information about this exemption and the public interest test in sections 152-160 of the <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a>, which says "The key public interest argument for this exemption is likely to relate to preserving a ‘safe space’ for the private office to focus on managing the minister’s work efficiently without external interference and distraction".
+        You can find more information about this exemption and the public interest test in sections 152-160 of the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a>, which says "The key public interest argument for this exemption is likely to relate to preserving a ‘safe space’ for the private office to focus on managing the minister’s work efficiently without external interference and distraction".

--- a/config/refusal_advice/section_35_actions.yml.erb
+++ b/config/refusal_advice/section_35_actions.yml.erb
@@ -25,7 +25,7 @@ foi:
       - { id: s35-q1n1, operator: is, value: 'no' }
       advice:
         html: >
-          Request an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> and pointing out that the authority is obliged to conduct a public interest test when applying this exemption.
+          Request an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> and pointing out that the authority is obliged to conduct a public interest test when applying this exemption.
 
     - id: s35-a4
       show_if:
@@ -39,7 +39,7 @@ foi:
       - { id: s35-q1n1y1n1, operator: is, value: 'no' }
       advice:
         html: >
-          Request an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> and pointing out that the authority is obliged to provide details of the public interest test and how the final decision was reached.
+          Request an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> and pointing out that the authority is obliged to provide details of the public interest test and how the final decision was reached.
 
     - id: s35-a6
       show_if:
@@ -60,7 +60,7 @@ foi:
       - { id: s35-q2, operator: is, value: 'yes' }
       advice:
         html: >
-          Request an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> and explaining that the exemption cannot be applied to historical records.
+          Request an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> and explaining that the exemption cannot be applied to historical records.
 
     - id: s35-a9
       show_if:
@@ -74,7 +74,7 @@ foi:
       - { id: s35-q4y1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> states: "Once a policy decision has been made, the exemption cannot apply to any background statistical information".
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> states: "Once a policy decision has been made, the exemption cannot apply to any background statistical information".
 
           Read the guidance in detail and then decide whether to go ahead and request an internal review.
 
@@ -83,7 +83,7 @@ foi:
       - { id: s35-q4y1y1n1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> contains detailed consideration of what constitutes 'policy making'.
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> contains detailed consideration of what constitutes 'policy making'.
 
           If you are unsure whether this exemption should have been applied to your request, you may wish to read it in more detail to see whether you can make a valid argument that you are not requesting information relating to the formulation or development of government policy.
 
@@ -120,16 +120,16 @@ foi:
       - { id: s35-q5y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> sections 73-92 explain more about the public interest test when Section 35(1)(a) is applied. Among other advice, it notes "Arguments about other issues (eg the personal impact on individuals, or the commercial interests of stakeholders) are not relevant", and "arguments that ‘routine’ disclosure of a particular type of information would not be in the public interest are misconceived". There are also arguments about when the ideas of a 'safe space' or the 'chilling effect' can and cannot reasonably be applied.
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> sections 73-92 explain more about the public interest test when Section 35(1)(a) is applied. Among other advice, it notes "Arguments about other issues (eg the personal impact on individuals, or the commercial interests of stakeholders) are not relevant", and "arguments that ‘routine’ disclosure of a particular type of information would not be in the public interest are misconceived". There are also arguments about when the ideas of a 'safe space' or the 'chilling effect' can and cannot reasonably be applied.
 
-          Read <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, and, if so, consider requesting an internal review, laying out this argument.
+          Read <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, and, if so, consider requesting an internal review, laying out this argument.
 
     - id: s35-a17
       show_if:
       - { id: s35-q6y1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> states: "Once a policy decision has been made, the exemption cannot apply to any background statistical information,even if it is contained in a ministerial communication".
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> states: "Once a policy decision has been made, the exemption cannot apply to any background statistical information,even if it is contained in a ministerial communication".
 
           Read the guidance in detail and then decide whether to go ahead and request an internal review.
 
@@ -138,25 +138,25 @@ foi:
       - { id: s35-q6y2y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> sections 108-117 explain more about the public interest test when Section 35(1)(b) is applied. Among other advice, it notes that "the relevance and weight of the public interest arguments will depend entirely on the content and sensitivity of the particular information in question and the effect its release would have in all the circumstances of the case".
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> sections 108-117 explain more about the public interest test when Section 35(1)(b) is applied. Among other advice, it notes that "the relevance and weight of the public interest arguments will depend entirely on the content and sensitivity of the particular information in question and the effect its release would have in all the circumstances of the case".
 
-          Read <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, and, if so, consider requesting an internal review, laying out this argument.
+          Read <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, and, if so, consider requesting an internal review, laying out this argument.
 
     - id: s35-a19
       show_if:
       - { id: s35-q7y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">ICO guidance</a> sections 132-141 explain more about the public interest test when Section 35(1)(c) is applied. Among other advice, it notes that 'Public interest arguments under section 35(1)(c) should focus on harm to government decision making processes. This reflects the underlying purpose of the exemption. Arguments about other issues will not be relevant."
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">ICO guidance</a> sections 132-141 explain more about the public interest test when Section 35(1)(c) is applied. Among other advice, it notes that 'Public interest arguments under section 35(1)(c) should focus on harm to government decision making processes. This reflects the underlying purpose of the exemption. Arguments about other issues will not be relevant."
 
-          Read <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, or that it focuses on issues other than harm to government decision-making processes and, if so, consider requesting an internal review, laying out this argument.
+          Read <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, or that it focuses on issues other than harm to government decision-making processes and, if so, consider requesting an internal review, laying out this argument.
 
     - id: s35-a20
       show_if:
       - { id: s35-q8y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Read <a href="https://ico.org.uk/media/for-organisations/documents/1200/government-policy-foi-section-35-guidance.pdf">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, and, if so, consider requesting an internal review, laying out this argument.
+          Read <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-35-government-policy/">the guidance</a> carefully to see if you might be able to make a strong argument that the public interest test has arrived at the wrong decision, and, if so, consider requesting an internal review, laying out this argument.
 
     - id: s35-a21
       show_if:

--- a/config/refusal_advice/section_38.yml.erb
+++ b/config/refusal_advice/section_38.yml.erb
@@ -8,7 +8,7 @@ foi:
     - { label: "<%= 'No' %>", value: "no" }
     label:
       html: >
-        Has the authority performed a <a href="https://ico.org.uk/media/for-organisations/documents/1214/the_prejudice_test.pdf">prejudice test</a>?
+        Has the authority performed a <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/the-prejudice-test/">prejudice test</a>?
     hint:
       plain: >
         A prejudice test is required for this exemption. The authority must assess whether a causal link exists between disclosure of the information you have requested, and (in the case of Section 38) the likelihood of harm befalling an individual.

--- a/config/refusal_advice/section_40.yml.erb
+++ b/config/refusal_advice/section_40.yml.erb
@@ -78,7 +78,7 @@ foi:
         Has the individual whose data it is given 'explicit consent' for its release, or already clearly made the data public?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/2614720/personal-information-section-40-and-regulation-13-version-21.pdf"">ICO guidance</a> states that for explicit consent, the authority "must have a record that shows that each of the individuals concerned has explicitly and specifically consented to their data being disclosed to the world in response to an FOI or EIR request"; and "there may be situations in which the individual has deliberately done something which has put their special category personal data into the public domain. An obvious example of this would be the political affiliations of a Member of Parliament."
+        <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/"">ICO guidance</a> states that for explicit consent, the authority "must have a record that shows that each of the individuals concerned has explicitly and specifically consented to their data being disclosed to the world in response to an FOI or EIR request"; and "there may be situations in which the individual has deliberately done something which has put their special category personal data into the public domain. An obvious example of this would be the political affiliations of a Member of Parliament."
 
   - id: s40-q1n1y2y1y1
     show_if:
@@ -95,10 +95,10 @@ foi:
     options: *yes-no
     label:
       html: >
-        Has the authority performed a '<a href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/legitimate-interests/">legitimate interests</a>' test?
+        Has the authority performed a '<a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/legitimate-interests/">legitimate interests</a>' test?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/2614720/personal-information-section-40-and-regulation-13-version-21.pdf">ICO guidance</a> says that an authority may consider the wider public good (or "pressing social need") to be gained from the release of information, against the rights and freedoms of the person whose information is being requested, "particularly their right to privacy and family life under the Human Rights Act 1998".
+        <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/">ICO guidance</a> says that an authority may consider the wider public good (or "pressing social need") to be gained from the release of information, against the rights and freedoms of the person whose information is being requested, "particularly their right to privacy and family life under the Human Rights Act 1998".
 
   - id: s40-q1n1y3y1
     show_if:
@@ -117,7 +117,7 @@ foi:
         Has the authority confirmed or denied whether they hold the information?
     hint:
       html: >
-        There is more about confirming or denying in relation to personal data in this <a href="https://ico.org.uk/media/for-organisations/documents/2614719/neither-confirm-nor-deny-in-relation-to-personal-data-section-40-5-and-regulation-13-5-v20.pdf">ICO guidance</a>.
+        There is more about confirming or denying in relation to personal data in this <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/part-two-can-you-confirm-or-deny-holding-the-requested-information/">ICO guidance</a>.
 
   - id: s40-q1n1y4n1
     show_if:

--- a/config/refusal_advice/section_40_actions.yml.erb
+++ b/config/refusal_advice/section_40_actions.yml.erb
@@ -7,7 +7,7 @@ foi:
       - { id: s40-q1n1, operator: is, value: 'no' }
       advice:
         html: >
-          This exemption only applies to <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/what-is-personal-data/">personal data</a> (your own or someone else's). If the information you have requested is not personal data, this exemption has not been applied correctly.
+          This exemption only applies to <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/personal-information-what-is-it/what-is-personal-data/what-is-personal-data/">personal data</a> (your own or someone else's). If the information you have requested is not personal data, this exemption has not been applied correctly.
 
           Ask for an internal review.
 
@@ -34,21 +34,21 @@ foi:
       - { id: s40-q1n1y2y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider requesting an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/2614720/personal-information-section-40-and-regulation-13-version-21.pdf">ICO guidance</a>.
+          Consider requesting an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/">ICO guidance</a>.
 
     - id: s40-a9
       show_if:
       - { id: s40-q1n1y3y1, operator: is, value: 'no' }
       advice:
         html: >
-          Deciding upon the 'necessity' of release as part of a legitimate interests test is always going to rely, to some extent, on personal opinion. So you may consider requesting an internal review, if you think that you can argue persuasively that disclosure is necessary due to legitimate interests. <a href="https://ico.org.uk/media/for-organisations/documents/2614720/personal-information-section-40-and-regulation-13-version-21.pdf">Read the portion of this ICO guidance on legitimate interests first</a>.
+          Deciding upon the 'necessity' of release as part of a legitimate interests test is always going to rely, to some extent, on personal opinion. So you may consider requesting an internal review, if you think that you can argue persuasively that disclosure is necessary due to legitimate interests. <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/">Read the portion of this ICO guidance on legitimate interests first</a>.
 
     - id: s40-a11
       show_if:
       - { id: s40-q1n1y4n1, operator: is, value: 'no' }
       advice:
         html: >
-          Read this <a href="https://ico.org.uk/media/for-organisations/documents/2614719/neither-confirm-nor-deny-in-relation-to-personal-data-section-40-5-and-regulation-13-5-v20.pdf">ICO guidance</a>, and if you consider that the act of confirming or denying would not release personal data, consider requesting an internal review.
+          Read this <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/part-two-can-you-confirm-or-deny-holding-the-requested-information/">ICO guidance</a>, and if you consider that the act of confirming or denying would not release personal data, consider requesting an internal review.
 
     - id: s40-a14
       show_if:
@@ -82,7 +82,7 @@ foi:
       - { id: s40-q1n1y4n1y1, operator: is, value: 'no' }
       advice:
         html: >
-          Read this <a href="https://ico.org.uk/media/for-organisations/documents/2614719/neither-confirm-nor-deny-in-relation-to-personal-data-section-40-5-and-regulation-13-5-v20.pdf">ICO guidance</a> and consider responding to ask for clarification on this point.
+          Read this <a href="https://ico.org.uk/for-organisations/foi/section-40-and-regulation-13-personal-information/part-two-can-you-confirm-or-deny-holding-the-requested-information/">ICO guidance</a> and consider responding to ask for clarification on this point.
 
   - id: new_request
     suggestions:
@@ -94,7 +94,7 @@ foi:
       - { id: s40-q1, operator: is, value: 'yes' }
       advice:
         html: >
-          Freedom of Information is not the correct channel for this type of request: you should have made a Subject Access Request (SAR) directly to the authority. <a href="https://ico.org.uk/your-data-matters/your-right-to-get-copies-of-your-data/">You can see more information about this here</a>.
+          Freedom of Information is not the correct channel for this type of request: you should have made a Subject Access Request (SAR) directly to the authority. <a href="https://ico.org.uk/for-the-public/getting-copies-of-your-information-subject-access-request/">You can see more information about this here</a>.
 
     - id: s40-a6
       show_if:

--- a/config/refusal_advice/section_41.yml.erb
+++ b/config/refusal_advice/section_41.yml.erb
@@ -74,7 +74,7 @@ foi:
         Has the authority cited Section 41 as the reason for not confirming or denying?
     hint:
       html: >
-        Under Section 41 of the FOI Act authorities are permitted not to <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">confirm or deny</a> whether they hold information, IF doing so would result in an 'actionable brief of confidence' (ie a breach that would stand up in court).
+        Under Section 41 of the FOI Act authorities are permitted not to <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">confirm or deny</a> whether they hold information, IF doing so would result in an 'actionable brief of confidence' (ie a breach that would stand up in court).
 
   - id: s41-q2n1y1
     show_if:
@@ -85,7 +85,7 @@ foi:
         Have they performed a public interest test on the matter of whether to confirm or deny?
     hint:
       html: >
-        Where an authority uses Section 41 as a reason not to confirm or deny whether they hold information, they must also perform a public interest test on this matter. The ICO <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">provides guidance to authorities about confirming or denying here</a>.
+        Where an authority uses Section 41 as a reason not to confirm or deny whether they hold information, they must also perform a public interest test on this matter. The ICO <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">provides guidance to authorities about confirming or denying here</a>.
 
   - id: s41-q3
     show_if: *section-41
@@ -95,7 +95,7 @@ foi:
         Has the authority demonstrated that this information has "the necessary quality of confidence"?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a> says that the authority should be able to demonstrate that the "someone has a genuine interest in the contents remaining confidential". This may take into account the right to privacy as enshrined in the Human Rights Act (if disclosure of the information would impinge on this in the case of the identified person).
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a> says that the authority should be able to demonstrate that the "someone has a genuine interest in the contents remaining confidential". This may take into account the right to privacy as enshrined in the Human Rights Act (if disclosure of the information would impinge on this in the case of the identified person).
 
   - id: s41-q3y1
     show_if:
@@ -106,7 +106,7 @@ foi:
         Would disclosure bring new information into the public domain?
     hint:
       html: >
-        The authority should consider whether the same or similar information is already in the public domain. <a href="https://ico.org.uk/media/for-organisations/documents/1204/information-in-the-public-domain-foi-eir-guidance.pdf">The ICO gives guidance about this point here</a>.
+        The authority should consider whether the same or similar information is already in the public domain. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/information-in-the-public-domain/">The ICO gives guidance about this point here</a>.
 
         An example would be where the request is for a testimony which contains facts that have already been published elsewhere. While the testimony may not have previously been disclosed, the information within it is already accessible.
 
@@ -119,7 +119,7 @@ foi:
         Could the authority release some of the information without breaching confidence?
     hint:
       html: >
-        The authority should only apply this exemption to information which breaches confidence. Read <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">the ICO guidance</a> to understand this point in more detail.
+        The authority should only apply this exemption to information which breaches confidence. Read <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">the ICO guidance</a> to understand this point in more detail.
 
   - id: s41-q3y1y1n1
     show_if:
@@ -130,7 +130,7 @@ foi:
         Has the authority demonstrated that the breach in confidence would be actionable, and likely to succeed, in a court of law?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a> explains that one of the ways to ascertain whether release of information would constitute a breach of confidence is to consider whether it would be actionable, and then, whether such an action would be likely to succeed. The authority needs to demonstrate its thinking on this point, which will also involve a version of the public interest test in which they will balance the public good of any disclosure against the breach of confidence: "This is because case law on the common law of confidence suggests that a breach of confidence won’t succeed, and therefore won’t be actionable, in circumstances where a public authority can rely on a public interest defence".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a> explains that one of the ways to ascertain whether release of information would constitute a breach of confidence is to consider whether it would be actionable, and then, whether such an action would be likely to succeed. The authority needs to demonstrate its thinking on this point, which will also involve a version of the public interest test in which they will balance the public good of any disclosure against the breach of confidence: "This is because case law on the common law of confidence suggests that a breach of confidence won’t succeed, and therefore won’t be actionable, in circumstances where a public authority can rely on a public interest defence".
 
   - id: s41-q4
     show_if: *section-41
@@ -148,7 +148,7 @@ foi:
         Is the information you requested a contract?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a> says that this exemption does not generally apply to contracts, although if 'technical information' or the contractor's 'pre-contractual negotiating position' has been included in a contract, there may be a case for redacting these parts.
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a> says that this exemption does not generally apply to contracts, although if 'technical information' or the contractor's 'pre-contractual negotiating position' has been included in a contract, there may be a case for redacting these parts.
 
   - id: s41-q4y1n1
     show_if:
@@ -159,7 +159,7 @@ foi:
         Has the authority demonstrated that a breach of confidence would be detrimental towards the person, company or authority that provided the information?
     hint:
       html: >
-        <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a> states, "If the requested information is commercial in nature then the disclosure will only constitute a breach of confidence if it would have a detrimental impact on the confider."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a> states, "If the requested information is commercial in nature then the disclosure will only constitute a breach of confidence if it would have a detrimental impact on the confider."
 
   - id: s41-q5
     show_if: *section-41

--- a/config/refusal_advice/section_41_actions.yml.erb
+++ b/config/refusal_advice/section_41_actions.yml.erb
@@ -9,7 +9,7 @@ foi:
         html: >
           This exemption appears to have been incorrectly applied.
 
-          Consider asking for an internal review, citing <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a>.
+          Consider asking for an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a>.
 
     - id: s41-a2
       show_if:
@@ -23,7 +23,7 @@ foi:
       - { id: s41-q1y1y1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a> refers to <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/81">Section 81(2)(b) of the FOI Act</a>, and states; "In cases where the authority and confider are both government departments (or two Northern Ireland departments), the confider would not be able to rely upon this exemption."
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a> refers to <a href="https://www.legislation.gov.uk/ukpga/2000/36/section/81">Section 81(2)(b) of the FOI Act</a>, and states; "In cases where the authority and confider are both government departments (or two Northern Ireland departments), the confider would not be able to rely upon this exemption."
 
           Read the guidance and consider requesting an internal review.
 
@@ -48,7 +48,7 @@ foi:
       - { id: s41-q3y1, operator: is, value: 'no' }
       advice:
         html: >
-          If you can argue the case convincingly that the information is already in the public domain, consider requesting an internal review. You may wish to cite Judge Megarry in Coco v A N Clark (Engineers) Limited [1968] FSR 415 (see point 35 of <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">the ICO guidance</a>).
+          If you can argue the case convincingly that the information is already in the public domain, consider requesting an internal review. You may wish to cite Judge Megarry in Coco v A N Clark (Engineers) Limited [1968] FSR 415 (see point 35 of <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">the ICO guidance</a>).
 
     - id: s41-a10
       show_if:
@@ -62,14 +62,14 @@ foi:
       - { id: s41-q3y1y1n1, operator: is, value: 'yes' }
       advice:
         html: >
-          The authority appears to have acted correctly on this point. However, if you think that you can argue convincingly that "there is a public interest in disclosure which overrides the competing public interest in maintaining the duty of confidence", you may like to request an internal review, stating your point. Read the <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a> to understand this point in more detail.
+          The authority appears to have acted correctly on this point. However, if you think that you can argue convincingly that "there is a public interest in disclosure which overrides the competing public interest in maintaining the duty of confidence", you may like to request an internal review, stating your point. Read the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a> to understand this point in more detail.
 
     - id: s41-a12
       show_if:
       - { id: s41-q3y1y1n1, operator: is, value: 'no' }
       advice:
         html: >
-          Read the <a href="https://ico.org.uk/media/for-organisations/documents/1432163/information-provided-in-confidence-section-41.pdf">ICO guidance</a> to understand this point in more detail. If you can argue the case that the release of the information would not be actionable, you may consider requesting an internal review, questioning this point.
+          Read the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/">ICO guidance</a> to understand this point in more detail. If you can argue the case that the release of the information would not be actionable, you may consider requesting an internal review, questioning this point.
 
     - id: s41-a13
       show_if:
@@ -90,7 +90,7 @@ foi:
       - { id: s41-q5, operator: is, value: 'no' }
       advice:
         html: >
-          You may wish to read the <a href="https://ico.org.uk/media/for-organisations/documents/1202/information-about-the-deceased-foi-eir.pdf">ICO guidance relating to deceased people and Section 41 exemptions</a>. If, after doing so, you consider that the exemption has been incorrectly applied, you could request an internal review and cite this guidance.
+          You may wish to read the <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-41-information-provided-in-confidence/how-does-section-41-apply-to-requests-for-information-about-deceased-people/">ICO guidance relating to deceased people and Section 41 exemptions</a>. If, after doing so, you consider that the exemption has been incorrectly applied, you could request an internal review and cite this guidance.
 
   - id: clarification
     suggestions:

--- a/config/refusal_advice/section_43.yml.erb
+++ b/config/refusal_advice/section_43.yml.erb
@@ -11,7 +11,7 @@ foi:
         Has the authority demonstrated that the disclosure of the information you have requested would prejudice commercial interests?
     hint:
       html: >
-        <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> states that an authority "must show that because [the information] is commercially sensitive, disclosure would be, or would be likely to be, prejudicial to the commercial activities of a person (an individual, a company, the public authority itself or any other legal entity)".
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> states that an authority "must show that because [the information] is commercially sensitive, disclosure would be, or would be likely to be, prejudicial to the commercial activities of a person (an individual, a company, the public authority itself or any other legal entity)".
 
   - id: s43-q1y1
     show_if:
@@ -30,7 +30,7 @@ foi:
         Has the authority conducted a prejudice test?
     hint:
       html: >
-        <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says: "In order to apply section 43(2), the public authority must satisfy itself that disclosure of the information would, or would be likely to, prejudice or harm the commercial interests of any person (this can include the public authority holding it)."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says: "In order to apply section 43(2), the public authority must satisfy itself that disclosure of the information would, or would be likely to, prejudice or harm the commercial interests of any person (this can include the public authority holding it)."
 
   - id: s43-q1y1y1y1
     show_if:
@@ -41,7 +41,7 @@ foi:
         Has the authority decided the likelihood of prejudice occurring?
     hint:
       html: >
-        The ICO also states that 'would' means that there is a more than 50% chance of harm occurring, while 'would be likely to' indicates a lower, but 'real and significant' risk. <a href="https://ico.org.uk/media/for-organisations/documents/1214/the_prejudice_test.pdf">There is more guidance on the prejudice test here</a>.
+        The ICO also states that 'would' means that there is a more than 50% chance of harm occurring, while 'would be likely to' indicates a lower, but 'real and significant' risk. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/the-prejudice-test/">There is more guidance on the prejudice test here</a>.
 
   - id: s43-q1y1n1
     show_if:
@@ -52,7 +52,7 @@ foi:
         Has the authority sought the views of the third party whose commercial interests they are citing?
     hint:
       html: >
-        <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says: "if you propose to withhold information because the disclosure would, or would be likely to, prejudice a third party’s commercial interests, you must have evidence that this accurately reflects the third party’s concerns. It is not sufficient for you to simply speculate about the prejudice which might be caused to the third party’s commercial interests. You need to consult them for their exact views in all but the most exceptional circumstances."
+        <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says: "if you propose to withhold information because the disclosure would, or would be likely to, prejudice a third party’s commercial interests, you must have evidence that this accurately reflects the third party’s concerns. It is not sufficient for you to simply speculate about the prejudice which might be caused to the third party’s commercial interests. You need to consult them for their exact views in all but the most exceptional circumstances."
 
   - id: s43-q1y1n1n1
     show_if:
@@ -99,7 +99,7 @@ foi:
         Has the authority carried out a public interest test?
     hint:
       html: >
-        Some exemptions, including this one, require the authority to conduct a <a href="https://ico.org.uk/media/for-organisations/documents/1183/the_public_interest_test.pdf">public interest test</a>. Note that 'interest' here does not refer to whether the information would be interesting to the public. This requirement says that the authority must weigh up whether there is more 'public good' in disclosing the information than there is a benefit to commercial interests in withholding it.
+        Some exemptions, including this one, require the authority to conduct a <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/the-public-interest-test/">public interest test</a>. Note that 'interest' here does not refer to whether the information would be interesting to the public. This requirement says that the authority must weigh up whether there is more 'public good' in disclosing the information than there is a benefit to commercial interests in withholding it.
 
   - id: s43-q3y1
     show_if:

--- a/config/refusal_advice/section_43_actions.yml.erb
+++ b/config/refusal_advice/section_43_actions.yml.erb
@@ -49,7 +49,7 @@ foi:
       - { id: s43-q2y1, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says that this argument can only be applied if future transactions are likely to have a 'degree of similarity' with the one you are asking about.
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says that this argument can only be applied if future transactions are likely to have a 'degree of similarity' with the one you are asking about.
 
           Consider whether this is the case - you may have grounds to request an internal review if it is not.
 
@@ -58,7 +58,7 @@ foi:
       - { id: s43-q2y2, operator: is, value: 'no' }
       advice:
         html: >
-          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> states that: "It is [...] important for a public authority to consider each clause within a contract, rather than view the contract as a whole. Arguments about the burden this may create are not relevant under section 43".
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> states that: "It is [...] important for a public authority to consider each clause within a contract, rather than view the contract as a whole. Arguments about the burden this may create are not relevant under section 43".
 
           You may have grounds for requesting an internal review. Cite the ICO guidance and ask for the other parts of the contract to be released.
 
@@ -67,21 +67,21 @@ foi:
       - { id: s43-q3, operator: is, value: 'no' }
       advice:
         html: >
-          Ask for an internal review, citing <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> and asking the authority to provide evidence that the public interest test was conducted in this case.
+          Ask for an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> and asking the authority to provide evidence that the public interest test was conducted in this case.
 
     - id: s43-a11
       show_if:
       - { id: s43-q3y1, operator: is, value: 'no' }
       advice:
         html: >
-          Consider asking for an internal review, citing <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>.
+          Consider asking for an internal review, citing <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>.
 
     - id: s43-a12
       show_if:
       - { id: s43-q3y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
+          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
 
           These would, however, be set against the commercial interests of, for example, competition, reputation, ability to generate income and impact on other negotiations.
 
@@ -92,7 +92,7 @@ foi:
       - { id: s43-q4n1, operator: is, value: 'no' }
       advice:
         html: >
-          You may wish to ask for an internal review, asking the authority to confirm or deny whether they hold the information.There is more information about confirming or denying in this <a href="https://ico.org.uk/media/for-organisations/documents/1166/when_to_refuse_to_confirm_or_deny_section_1_foia.pdf">ICO guidance</a>.
+          You may wish to ask for an internal review, asking the authority to confirm or deny whether they hold the information.There is more information about confirming or denying in this <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/when-to-refuse-to-confirm-or-deny-holding-information/">ICO guidance</a>.
 
     - id: s43-a15
       show_if:
@@ -106,7 +106,7 @@ foi:
       - { id: s43-q4n1y1, operator: is, value: 'yes' }
       advice:
         html: >
-          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
+          Of necessity, the Public Interest test will reflect the thought processes of the member of staff conducting it, and there may well be room for making a good case against them. <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a>, says, for example, that authorities should bear in mind that there is a "strong case for openness and transparency"; for "accountability for the spending of public money", for "promoting competition in procurement via transparency" and for "protect[ing] the public from unsafe products or dubious practices".
 
           These would, however, be set against the commercial interests of, for example, competition, reputation, ability to generate income and impact on other negotiations.
 
@@ -126,7 +126,7 @@ foi:
       - { id: s43-q1y1y1y1, operator: is, value: 'no' }
       advice:
         html: >
-          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">The ICO says</a>: "The public authority must decide the likelihood of prejudice arising on the facts of each case".
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">The ICO says</a>: "The public authority must decide the likelihood of prejudice arising on the facts of each case".
 
           Consider asking for clarification, citing this guidance and requesting that the authority provide more details about their calculations in applying the prejudice test.
 
@@ -137,7 +137,7 @@ foi:
       - { id: s43-q6, operator: is, value: 'yes' }
       advice:
         html: >
-          <a href="https://ico.org.uk/for-organisations/guidance-index/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says, "The public authority must apply an exemption based on the circumstances that exist at the time the request is made. However information submitted during a tendering process is more likely to be commercially sensitive while the tendering process is ongoing, compared to once the contract has been awarded", although it does also note that some information will remain sensitive, for example if it reveals an approach to business which if known to the public could be commercially damaging.
+          <a href="https://ico.org.uk/for-organisations/foi/freedom-of-information-and-environmental-information-regulations/section-43-commercial-interests/">ICO guidance</a> says, "The public authority must apply an exemption based on the circumstances that exist at the time the request is made. However information submitted during a tendering process is more likely to be commercially sensitive while the tendering process is ongoing, compared to once the contract has been awarded", although it does also note that some information will remain sensitive, for example if it reveals an approach to business which if known to the public could be commercially damaging.
 
           You may wish to consider resubmitting your request once some time has passed.
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes #2083
## What does this do?
Fixes broken links to ICO guidance that has been moved without a redirect.
## Why was this needed?
It was pointing to the wrong place
## Implementation notes
n/a
## Screenshots
n/a
## Notes to reviewer
I got a 5 agent swarm to do this. Have manually reviewed the changes and checked all new links return 200. Most guidance says "you must" when we quote "the authority must" but other than that, the quotes still make sense.