### PR TITLE
Add search engines help page to sidebar

### DIFF
--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -117,6 +117,10 @@
       <li>
         <%= link_to_unless_current 'Your privacy', help_privacy_path %>
       </li>
+
+      <li>
+        <%= link_to_unless_current 'Search engines', help_search_engines_path %>
+      </li>
     </ul>
 
     <h2>Information Officers</h2>


### PR DESCRIPTION
We mostly link to this from templates, but is useful enough to include in the sidebar.

Added in https://github.com/mysociety/whatdotheyknow-theme/pull/1715.
