### PR TITLE
Fixing tag ordering

### DIFF
--- a/lib/views/help/authority_performance_tracking.html.erb
+++ b/lib/views/help/authority_performance_tracking.html.erb
@@ -30,94 +30,93 @@
     <tbody>
       <tr>
         <td>Authority releases material via a link</td>
-        <td><b><a href="/body/list/response_link"><%= pluralize(PublicBody.visible.with_tag('response_link').size, 'Authority') %></b> tagged <code>response_link</code></td>
-            </a></td>
-            <td><b><a href="/search/tag:response_link/requests"><%= pluralize(InfoRequest.is_public.with_tag('response_link').size, 'Request') %></b> tagged <code>response_link</code></a></td></a></td>
+        <td><a href="/body/list/response_link"><b><%= pluralize(PublicBody.visible.with_tag('response_link').size, 'Authority') %></b> tagged <code>response_link</code></a></td>
+        <td><a href="/search/tag:response_link/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('response_link').size, 'Request') %></b> tagged <code>response_link</code></a></td>
       </tr>
       <tr>
         <td>Authority sends a misleading auto-response implying they won’t respond via email (but then do correspond via email)</td>
-        <td><b><a href="/body/list/implies_webform_required"><%= pluralize(PublicBody.visible.with_tag('implies_webform_required').size, 'Authority') %></b> tagged <code>implies_webform_required</code></a></td>
-        <td><b><a href="/search/tag:implies_webform_required/requests"><%= pluralize(InfoRequest.is_public.with_tag('implies_webform_required').size, 'Request') %></b> tagged <code>implies_webform_required</code></a></td>
+        <td><a href="/body/list/implies_webform_required"><b><%= pluralize(PublicBody.visible.with_tag('implies_webform_required').size, 'Authority') %></b> tagged <code>implies_webform_required</code></a></td>
+        <td><a href="/search/tag:implies_webform_required/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('implies_webform_required').size, 'Request') %></b> tagged <code>implies_webform_required</code></a></td>
       </tr>
       <tr>
         <td>Authority outright refuses to engage with requests not made on their web form</td>
-        <td><b><a href="/body/list/refuses_emailed_request"><%= pluralize(PublicBody.visible.with_tag('refuses_emailed_request').size, 'Authority') %></b> tagged <code>refuses_emailed_request</code></a></td>
-        <td><b><a href="/search/tag:refuses_emailed_request/requests"><%= pluralize(InfoRequest.is_public.with_tag('refuses_emailed_request').size, 'Request') %></b> tagged <code>refuses_emailed_request</code></a></td>
+        <td><a href="/body/list/refuses_emailed_request"><b><%= pluralize(PublicBody.visible.with_tag('refuses_emailed_request').size, 'Authority') %></b> tagged <code>refuses_emailed_request</code></a></td>
+        <td><a href="/search/tag:refuses_emailed_request/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('refuses_emailed_request').size, 'Request') %></b> tagged <code>refuses_emailed_request</code></a></td>
       </tr>
       <tr>
         <td>Authority denies being subject to <abbr>FOI</abbr></td>
-        <td><b><a href="/body/list/claims_not_apply"><%= pluralize(PublicBody.visible.with_tag('claims_not_apply').size, 'Authority') %></b> tagged <code>claims_not_apply</code></a></td>
-        <td><b><a href="/search/tag:claims_not_apply/requests"><%= pluralize(InfoRequest.is_public.with_tag('claims_not_apply').size, 'Request') %></b> tagged <code>claims_not_apply</code></a></td>
+        <td><a href="/body/list/claims_not_apply"><b><%= pluralize(PublicBody.visible.with_tag('claims_not_apply').size, 'Authority') %></b> tagged <code>claims_not_apply</code></a></td>
+        <td><a href="/search/tag:claims_not_apply/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('claims_not_apply').size, 'Request') %></b> tagged <code>claims_not_apply</code></a></td>
       </tr>
       <tr>
         <td>Authority denies being subject to <abbr title="Environmental Information Regulations">EIR</abbr></td>
-        <td><b><a href="/body/list/claims_eir_no"><%= pluralize(PublicBody.visible.with_tag('claims_eir_no').size, 'Authority') %></b> tagged <code>claims_eir_no</code></a></td>
-        <td><b><a href="/search/tag:claims_eir_no/requests"><%= pluralize(InfoRequest.is_public.with_tag('claims_eir_no').size, 'Request') %></b> tagged <code>claims_eir_no</code></a></td>
+        <td><a href="/body/list/claims_eir_no"><b><%= pluralize(PublicBody.visible.with_tag('claims_eir_no').size, 'Authority') %></b> tagged <code>claims_eir_no</code></a></td>
+        <td><a href="/search/tag:claims_eir_no/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('claims_eir_no').size, 'Request') %></b> tagged <code>claims_eir_no</code></a></td>
       </tr>
       <tr>
         <td>Authority isn’t subject to <abbr>FOI</abbr> due to minority non-public sector owner(s)/member(s)</td>
-        <td><b><a href="/body/list/poisoned"><%= pluralize(PublicBody.visible.with_tag('poisoned').size, 'Authority') %></b> tagged <code>poisoned</code></a></td>
-        <td><b><a href="/search/tag:poisoned/requests"><%= pluralize(InfoRequest.is_public.with_tag('poisoned').size, 'Request') %></b> tagged <code>poisoned</code></a></td>
+        <td><a href="/body/list/poisoned"><b><%= pluralize(PublicBody.visible.with_tag('poisoned').size, 'Authority') %></b> tagged <code>poisoned</code></a></td>
+        <td><a href="/search/tag:poisoned/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('poisoned').size, 'Request') %></b> tagged <code>poisoned</code></a></td>
       </tr>
       <tr>
         <td>Authority denies existing</td>
-        <td><b><a href="/body/list/denies_existing"><%= pluralize(PublicBody.visible.with_tag('denies_existing').size, 'Authority') %></b> tagged <code>denies_existing</code></a></td>
-        <td><b><a href="/search/tag:denies_existing/requests"><%= pluralize(InfoRequest.is_public.with_tag('denies_existing').size, 'Request') %></b> tagged <code>denies_existing</code></a></td>
+        <td><a href="/body/list/denies_existing"><b><%= pluralize(PublicBody.visible.with_tag('denies_existing').size, 'Authority') %></b> tagged <code>denies_existing</code></a></td>
+        <td><a href="/search/tag:denies_existing/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('denies_existing').size, 'Request') %></b> tagged <code>denies_existing</code></a></td>
       </tr>
       <tr>
         <td>Authority says it responded but we didn’t get a response</td>
-        <td><b><a href="/body/list/claims_to_have_responded"><%= pluralize(PublicBody.visible.with_tag('claims_to_have_responded').size, 'Authority') %></b> tagged <code>claims_to_have_responded</code></a></td>
-        <td><b><a href="/search/tag:claims_to_have_responded/requests"><%= pluralize(InfoRequest.is_public.with_tag('claims_to_have_responded').size, 'Request') %></b> tagged <code>claims_to_have_responded</code></a></td>
+        <td><a href="/body/list/claims_to_have_responded"><b><%= pluralize(PublicBody.visible.with_tag('claims_to_have_responded').size, 'Authority') %></b> tagged <code>claims_to_have_responded</code></a></td>
+        <td><a href="/search/tag:claims_to_have_responded/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('claims_to_have_responded').size, 'Request') %></b> tagged <code>claims_to_have_responded</code></a></td>
       </tr>
       <tr>
         <td>Authority says it hasn’t received request(s)</td>
-        <td><b><a href="/body/list/claims_not_received"><%= pluralize(PublicBody.visible.with_tag('claims_not_received').size, 'Authority') %></b> tagged <code>claims_not_received</code></a></td>
-        <td><b><a href="/search/tag:claims_not_received/requests"><%= pluralize(InfoRequest.is_public.with_tag('claims_not_received').size, 'Request') %></b> tagged <code>claims_not_received</code></a></td>
+        <td><a href="/body/list/claims_not_received"><b><%= pluralize(PublicBody.visible.with_tag('claims_not_received').size, 'Authority') %></b> tagged <code>claims_not_received</code></a></td>
+        <td><a href="/search/tag:claims_not_received/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('claims_not_received').size, 'Request') %></b> tagged <code>claims_not_received</code></a></td>
       </tr>
       <tr>
         <td>Authority repeatedly delays responding to a request to consider the public interest</td>
-        <td><b><a href="/body/list/pit_delay"><%= pluralize(PublicBody.visible.with_tag('pit_delay').size, 'Authority') %></b> tagged <code>pit_delay</code></a></td>
-        <td><b><a href="/search/tag:pit_delay/requests"><%= pluralize(InfoRequest.is_public.with_tag('pit_delay').size, 'Request') %></b> tagged <code>pit_delay</code></a></td>
+        <td><a href="/body/list/pit_delay"><b><%= pluralize(PublicBody.visible.with_tag('pit_delay').size, 'Authority') %></b> tagged <code>pit_delay</code></a></td>
+        <td><a href="/search/tag:pit_delay/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('pit_delay').size, 'Request') %></b> tagged <code>pit_delay</code></a></td>
       </tr>
       <tr>
         <td>Authority responds to personal email address</td>
-        <td><b><a href="/body/list/response_offsite"><%= pluralize(PublicBody.visible.with_tag('response_offsite').size, 'Authority') %></b> tagged <code>response_offsite</code></a></td>
-        <td><b><a href="/search/tag:response_offsite/requests"><%= pluralize(InfoRequest.is_public.with_tag('response_offsite').size, 'Request') %></b> tagged <code>response_offsite</code></a></td>
+        <td><a href="/body/list/response_offsite"><b><%= pluralize(PublicBody.visible.with_tag('response_offsite').size, 'Authority') %></b> tagged <code>response_offsite</code></a></td>
+        <td><a href="/search/tag:response_offsite/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('response_offsite').size, 'Request') %></b> tagged <code>response_offsite</code></a></td>
       </tr>
       <tr>
         <td>Authority inappropriately requests ID from requesters</td>
-        <td><b><a href="/body/list/requests_id"><%= pluralize(PublicBody.visible.with_tag('requests_id').size, 'Authority') %></b> tagged <code>requests_id</code></a></td>
-        <td><b><a href="/search/tag:requests_id/requests"><%= pluralize(InfoRequest.is_public.with_tag('requests_id').size, 'Request') %></b> tagged <code>requests_id</code></a></td>
+        <td><a href="/body/list/requests_id"><b><%= pluralize(PublicBody.visible.with_tag('requests_id').size, 'Authority') %></b> tagged <code>requests_id</code></a></td>
+        <td><a href="/search/tag:requests_id/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('requests_id').size, 'Request') %></b> tagged <code>requests_id</code></a></td>
       </tr>
       <tr>
         <td>Authority makes statements about fees and charges which could frighten requesters</td>
-        <td><b><a href="/body/list/fee_scare"><%= pluralize(PublicBody.visible.with_tag('fee_scare').size, 'Authority') %></b> tagged <code>fee_scare</code></a></td>
-        <td><b><a href="/search/tag:fee_scare/requests"><%= pluralize(InfoRequest.is_public.with_tag('fee_scare').size, 'Request') %></b> tagged <code>fee_scare</code></a></td>
+        <td><a href="/body/list/fee_scare"><b><%= pluralize(PublicBody.visible.with_tag('fee_scare').size, 'Authority') %></b> tagged <code>fee_scare</code></a></td>
+        <td><a href="/search/tag:fee_scare/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('fee_scare').size, 'Request') %></b> tagged <code>fee_scare</code></a></td>
       </tr>
       <tr>
         <td>Authority refuses to recognise valid <abbr>FOI</abbr> requests</td>
-        <td><b><a href="/body/list/foi_refuse"><%= pluralize(PublicBody.visible.with_tag('foi_refuse').size, 'Authority') %></b> tagged <code>foi_refuse</code></a></td>
-        <td><b><a href="/search/tag:foi_refuse/requests"><%= pluralize(InfoRequest.is_public.with_tag('foi_refuse').size, 'Request') %></b> tagged <code>foi_refuse</code></a></td>
+        <td><a href="/body/list/foi_refuse"><b><%= pluralize(PublicBody.visible.with_tag('foi_refuse').size, 'Authority') %></b> tagged <code>foi_refuse</code></a></td>
+        <td><a href="/search/tag:foi_refuse/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('foi_refuse').size, 'Request') %></b> tagged <code>foi_refuse</code></a></td>
       </tr>
       <tr>
         <td>Authority refuses to carry out an internal review</td>
-        <td><b><a href="/body/list/refuses_internal_review"><%= pluralize(PublicBody.visible.with_tag('refuses_internal_review').size, 'Authority') %></b> tagged <code>refuses_internal_review</code></a></td>
-        <td><b><a href="/search/tag:refuses_internal_review/requests"><%= pluralize(InfoRequest.is_public.with_tag('refuses_internal_review').size, 'Request') %></b> tagged <code>refuses_internal_review</code></a></td>
+        <td><a href="/body/list/refuses_internal_review"><b><%= pluralize(PublicBody.visible.with_tag('refuses_internal_review').size, 'Authority') %></b> tagged <code>refuses_internal_review</code></a></td>
+        <td><a href="/search/tag:refuses_internal_review/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('refuses_internal_review').size, 'Request') %></b> tagged <code>refuses_internal_review</code></a></td>
       </tr>
       <tr>
         <td>Authority wrongly rejects requests made on behalf of an organisation for want of a personal name</td>
-        <td><b><a href="/body/list/rejects_org_request"><%= pluralize(PublicBody.visible.with_tag('rejects_org_request').size, 'Authority') %></b> tagged <code>rejects_org_request</code></a></td>
-        <td><b><a href="/search/tag:rejects_org_request/requests"><%= pluralize(InfoRequest.is_public.with_tag('rejects_org_request').size, 'Request') %></b> tagged <code>rejects_org_request</code></a></td>
+        <td><a href="/body/list/rejects_org_request"><b><%= pluralize(PublicBody.visible.with_tag('rejects_org_request').size, 'Authority') %></b> tagged <code>rejects_org_request</code></a></td>
+        <td><a href="/search/tag:rejects_org_request/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('rejects_org_request').size, 'Request') %></b> tagged <code>rejects_org_request</code></a></td>
       </tr>
       <tr>
         <td>Authority requires requests be sent again, often with a specific subject line, to be considered</td>
-        <td><b><a href="/body/list/requires_resend"><%= pluralize(PublicBody.visible.with_tag('requires_resend').size, 'Authority') %></b> tagged <code>requires_resend</code></a></td>
-        <td><b><a href="/search/tag:requires_resend/requests"><%= pluralize(InfoRequest.is_public.with_tag('requires_resend').size, 'Request') %></b> tagged <code>requires_resend</code></a></td>
+        <td><a href="/body/list/requires_resend"><b><%= pluralize(PublicBody.visible.with_tag('requires_resend').size, 'Authority') %></b> tagged <code>requires_resend</code></a></td>
+        <td><a href="/search/tag:requires_resend/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('requires_resend').size, 'Request') %></b> tagged <code>requires_resend</code></a></td>
       </tr>
       <tr>
         <td>Authority charges for access to Environmental Information</td>
-        <td><b><a href="/body/list/eir_charges"><%= pluralize(PublicBody.visible.with_tag('eir_charges').size, 'Authority') %></b> tagged <code>eir_charges</code></a></td>
-        <td><b><a href="/search/tag:eir_charges/requests"><%= pluralize(InfoRequest.is_public.with_tag('eir_charges').size, 'Request') %></b> tagged <code>eir_charges</code></a></td>
+        <td><a href="/body/list/eir_charges"><b><%= pluralize(PublicBody.visible.with_tag('eir_charges').size, 'Authority') %></b> tagged <code>eir_charges</code></a></td>
+        <td><a href="/search/tag:eir_charges/requests"><b><%= pluralize(InfoRequest.is_public.with_tag('eir_charges').size, 'Request') %></b> tagged <code>eir_charges</code></a></td>
       </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## Relevant issue(s)
Fixes #1765
## What does this do?
Moves the bold tags to the right place
## Why was this needed?
They were in the wrong place
## Implementation notes
Went for fixing the existing table for simplicity
## Screenshots
<img width="1345" height="821" alt="Screenshot 2026-04-10 at 14 30 14" src="https://github.com/user-attachments/assets/61e02149-fca0-449c-85ad-b94e45d478a3" />

## Notes to reviewer
n/a