### PR TITLE
[2086] Add 'forthcoming' and 'defunct' to excluded tags

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -129,6 +129,8 @@ Rails.configuration.to_prepare do
   PublicBody.batch_excluded_tags += %w[
     engrsl
     signpost
+    forthcoming
+    defunct
     unit
   ]
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #2086 

## What does this do?

This adds the `forthcoming`, and `defunct`, tags to the list that should be excluded from batches.

## Why was this needed?

Per linked issue, these tags should never be included in the batch picker, as they are effectively unusable due to the fact that they do not link back to a "live" public body.

## Implementation notes

Nothing to note.

## Screenshots

## Notes to reviewer

`signpost` was in the issue, but this is already covered in `PublicBody.batch_excluded_tags` - can you validate the logic is doing what is intended?