### PR TITLE
Remove now removed inbound_email argument

### DIFF
--- a/spec/authority_only_response_gatekeeper_spec.rb
+++ b/spec/authority_only_response_gatekeeper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AuthorityOnlyResponseGatekeeper do
   end
 
   def receive_from(from)
-    info_request.receive Mail.new(from: from), ''
+    info_request.receive Mail.new(from: from)
   end
 
   it 'allows responses from main request email and extra addresses' do


### PR DESCRIPTION
The second argument to `InfoRequest#receive` was removed in https://github.com/mysociety/alaveteli/commit/bd1d8ec5f46533b0704f5a6e5dcc3f3e8e0fd449

