### PR TITLE
Social share buttons request sent

### DIFF
--- a/lib/views/request/_request_sent.html.erb
+++ b/lib/views/request/_request_sent.html.erb
@@ -1,3 +1,7 @@
+<% content_for :javascript_head do %>
+  <%= javascript_importmap_tags("public") %>
+<% end %>
+
 <div id="content">
   <div class="request-sent-message" id="notice">
     <h1>
@@ -14,38 +18,16 @@
                 :late_number_of_days => AlaveteliConfiguration.reply_late_after_days) %>
         </p>
 
-        <h2><%= _("Share your request") %></h2>
-
-        <%= link_to image_tag("next-step-twitter.png",
-                              :alt => _("Share on X"),
-                              :width => "120",
-                              :height => "37"),
-                              "https://twitter.com/intent/post?" << {
-                                :url => request.url,
-                                :via => AlaveteliConfiguration.twitter_username,
-                                :text => "'#{ @info_request.title }'",
-                                :related => _('mySociety:Helping people set ' \
-                                                'up sites like {{site_name}} ' \
-                                                'all over the world',
-                                              :site_name => site_name),
-                              }.to_query, :class => 'share-link',
-                                          :onclick => track_analytics_event(
-                                            AnalyticsEvent::Category::OUTBOUND,
-                                            AnalyticsEvent::Action::TWITTER_EXIT,
-                                            :label => "Share Request") %>
-
-
-        <%= link_to image_tag("next-step-facebook.png",
-                              :alt => _("Share on Facebook"),
-                              :width => "120",
-                              :height => "37"),
-                              "https://www.facebook.com/sharer/sharer.php?" << {
-                                :u => request.url
-                              }.to_query, :class => 'share-link',
-                                          :onclick => track_analytics_event(
-                                            AnalyticsEvent::Category::OUTBOUND,
-                                            AnalyticsEvent::Action::FACEBOOK_EXIT,
-                                            :label => "Share Request") %>
+        <a href="<%= request.url %>"
+          class="button button-share js-share-request"
+          role="button"
+          data-share-title="<%= @info_request.title %>"
+          data-share-url="<%= request.url %>"
+          data-clipboard-text="<%= request.url %>"
+          data-clipboard-success="<%= _('Link copied!') %>">
+          <%= File.read(Rails.root.join("app/assets/images/share-icon.svg")).html_safe %>
+          <span><%= _("Share this request") %></span>
+        </a>
 
         <h2><%= _("Keep your request up to date") %></h2>
 

--- a/lib/views/request/describe_notices/_successful.html.erb
+++ b/lib/views/request/describe_notices/_successful.html.erb
@@ -13,37 +13,17 @@
       <%= _("We're glad you got all the information that you wanted.") %>
     </p>
     <% end %>
-    <%= link_to image_tag("next-step-twitter.png",
-                          :alt => _("Share on X"),
-                          :width => "120",
-                          :height => "37"),
-                          "https://twitter.com/intent/post?" << {
-                            :url => request.url,
-                            :via => AlaveteliConfiguration.twitter_username,
-                            :text => "'#{ info_request.title }'",
-                            :related => _('mySociety:Helping people set ' \
-                                            'up sites like {{site_name}} ' \
-                                            'all over the world',
-                                          :site_name => site_name),
-                          }.to_query, :class => 'share-link',
-                                      :onclick => track_analytics_event(
-                                        AnalyticsEvent::Category::OUTBOUND,
-                                        AnalyticsEvent::Action::TWITTER_EXIT,
-                                        :label => "Share Request") %>
 
-
-    <%= link_to image_tag("next-step-facebook.png",
-                          :alt => _("Share on Facebook"),
-                          :width => "120",
-                          :height => "37"),
-                          "https://www.facebook.com/sharer/sharer.php?" << {
-                            :u => request.url
-                          }.to_query, :class => 'share-link',
-                                      :onclick => track_analytics_event(
-                                        AnalyticsEvent::Category::OUTBOUND,
-                                        AnalyticsEvent::Action::FACEBOOK_EXIT,
-                                        :label => "Share Request") %>
-
+    <a href="<%= request.url %>"
+      class="button button-share js-share-request"
+      role="button"
+      data-share-title="<%= @info_request.title %>"
+      data-share-url="<%= request.url %>"
+      data-clipboard-text="<%= request.url %>"
+      data-clipboard-success="<%= _('Link copied!') %>">
+      <%= File.read(Rails.root.join("app/assets/images/share-icon.svg")).html_safe %>
+      <span><%= _("Share this request") %></span>
+    </a>
   </div>
   <div class="request-sent-message__column-2">
     <% if show_donation_button? %>


### PR DESCRIPTION
## Relevant issue(s)
Fixes part of: https://github.com/mysociety/alaveteli/issues/9165
Fixes part of: https://github.com/mysociety/whatdotheyknow-theme/issues/2091

## What does this do?

Replaces Twitter and Facebook share buttons in `request-sent-message` and `succesful.html.erb` with web share API

## Why was this needed?

## Implementation notes

## Screenshots

https://github.com/user-attachments/assets/410f00c5-a33b-490b-a81e-14d713370f47


https://github.com/user-attachments/assets/54b3b7e5-bc3f-4dd7-a4a0-f86cebdd3528


https://github.com/user-attachments/assets/eaffeca4-9684-4cdb-af0b-d70bfd82f084



## Notes to reviewer

⚠️ **IMPORTANT:** This PR needs this [other Alaveteli PR ](https://github.com/mysociety/alaveteli/pull/9238) in order to work. So it should only be merged when the Alaveteli one has been already merged.
