### PR TITLE
Fix welcome page POST to include CSRF token

### DIFF
--- a/lib/views/rules/welcome.html.erb
+++ b/lib/views/rules/welcome.html.erb
@@ -31,7 +31,7 @@
   </div>
 
   <p class="card card-red" style="width:fit-content"><strong>Important:</strong> Please read the house rules before continuing.</p>
-  <%= link_to 'Continue to WhatDoTheyKnow', welcome_path, data: { method: :post }, class: 'link_button_green js-read-container-continue-button' %>
+  <%= button_to 'Continue to WhatDoTheyKnow', welcome_path, class: 'link_button_green js-read-container-continue-button' %>
 </div>
 
 <style>


### PR DESCRIPTION
The continue link uses `link_to` with `data-method: :post`, which relies on Rails UJS to create a dynamic form. The app starting to switch to use Turbo, not UJS, so this only worked because CSRF verification was skipped for anonymous users.

Switching to button_to generates a real form with a hidden `authenticity_token` field, making the POST work regardless.

