### PR TITLE
Remove redundant flash from data breach form

### DIFF
--- a/lib/data_breach.rb
+++ b/lib/data_breach.rb
@@ -30,7 +30,6 @@ module DataBreach
         ContactMailer.data_breach(@report, current_user).deliver_now
 
         # Redirect to a thank you page
-        flash[:notice] = _('Thank you for reporting a data breach. We will review your report and get back to you if we need any more information.')
         redirect_to help_report_a_data_breach_thank_you_path
       else
         render :report_a_data_breach

--- a/lib/views/help/report_a_data_breach_thank_you.html.erb
+++ b/lib/views/help/report_a_data_breach_thank_you.html.erb
@@ -7,4 +7,6 @@
   <h1>Thank you for reporting a data breach</h1>
 
   <p>We will review your report and take appropriate action.</p>
+
+  <p>We will get back to you if we need any more information.</p>
 </div>


### PR DESCRIPTION
We received an issue report of the flash message persisting across pages when submitting the form as a non-logged-in user.

We redirect to a thank you page after successful submission, which duplicates the flash message content, so this commit just removes the redundant flash.

Fixes https://github.com/mysociety/whatdotheyknow-theme/issues/2110

<img width="1105" height="428" alt="Screenshot 2026-05-11 at 17 25 14" src="https://github.com/user-attachments/assets/95d44a9f-353b-49a6-94d9-cecb3cba2565" />
