### PR TITLE
Use AlaveteliSpamTermChecker for spam term detection

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -105,21 +105,7 @@ Rails.configuration.to_prepare do
     end
 
     def spammer?(text)
-      return false unless spam_terms.any?
-      # https://stackoverflow.com/a/43278823/387558
-      # String#match? is Ruby 2.4.0 only so need to tweak
-      # Need to make a case-insensitive regexp for each term then join them all
-      # together
-      text =~ Regexp.union(spam_terms.map { |t| Regexp.new(/#{t}/i) })
-    end
-
-    def spam_terms
-      config = Rails.root + 'tmp/spam_terms.txt'
-      if File.exist?(config)
-        File.read(config).split("\n")
-      else
-        []
-      end
+      AlaveteliSpamTermChecker.new.spam?(text)
     end
   end
 

--- a/spec/integration/spam_terms_integration_spec.rb
+++ b/spec/integration/spam_terms_integration_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'creating a request with spam terms' do
   let(:spammy_message) { 'potato is a lower case spam term' }
 
   before do
-    File.write(Rails.root + 'tmp/spam_terms.txt', "Potato\n")
+    allow_any_instance_of(AlaveteliSpamTermChecker).
+      to receive(:spam?).and_return(true)
     stub_request(:get, /research\.mysociety\.org/)
   end
 


### PR DESCRIPTION
Requires https://github.com/mysociety/alaveteli/pull/9293 to remove some possibly legitimate terms that we wouldn't want to instantly ban on

The initial implementation was a quick hack and since then we've introduced the `AlaveteliSpamTermChecker`.

We set custom terms for this [1] in `config/spam_terms.txt` and have that set up to persist across deployments, which `tmp/spam_terms.txt` is not, so makes sense to move to this.

[1] https://github.com/mysociety/whatdotheyknow-theme/pull/1592

