### PR TITLE
Require two factor authentication for admins

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -26,6 +26,9 @@ Rails.configuration.to_prepare do
     end
   end
 
+  # Require administrators to have authenticator-app (TOTP) two factor enabled.
+  AdminController.require_two_factor_auth = true
+
   HelpController.class_eval do
     prepend VolunteerContactForm::ControllerMethods
     prepend DataBreach::ControllerMethods


### PR DESCRIPTION
Set `AdminController.require_two_factor_auth = true` so admins without authenticator-app (TOTP) two factor enabled are redirected to enable it before they can use the admin interface.

Relates to https://github.com/mysociety/alaveteli/pull/9317

Part of https://github.com/mysociety/alaveteli/issues/9241