### PR TITLE
Add Public Body name to analyzer report

### DIFF
--- a/lib/views/excel_analyzer/notifier_mailer/report.text.erb
+++ b/lib/views/excel_analyzer/notifier_mailer/report.text.erb
@@ -1,6 +1,7 @@
 ExcelAnalyzer has flagged and automatically set hidden prominence of a received
 spreadsheet due to the detection of potentially suspect hidden data.
 
+Requested from: <%= @incoming_message.info_request.public_body.name %>
 Admin request URL: <%= admin_request_url(@incoming_message.info_request_id) %>
 Admin attachment URL: <%= edit_admin_foi_attachment_url(@foi_attachment) %>
 


### PR DESCRIPTION
It's useful to know which authority the request was sent to as this gives a lot of context to the data that the file may contain.
