### PR TITLE
Drop sleep between batch info request sends

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -83,6 +83,20 @@ Rails.configuration.to_prepare do
     end
   end
 
+  InfoRequestBatch.class_eval do
+    # Override to remove the `sleep 60` between requests present in core.
+    def create_batch!
+      requestable_public_bodies.each do |public_body|
+        info_request = transaction do
+          create_request!(public_body)
+        end
+
+        send_request(info_request)
+      end
+      reload
+    end
+  end
+
   Legislation.refusals = {
     foi: [
       's 11', 's 12', 's 14', 's 21', 's 22', 's 30', 's 31', 's 35', 's 38',


### PR DESCRIPTION
Core sleeps 60 seconds between each request in a batch to avoid a torrent of auto-replies overloading the server.

This shouldn't be necessary anymore given mail is now being received via Action Mailbox.

Override `create_batch!` in the theme to remove this delay, eventually this will make into core after the next release when we remove the old `script/mailin`.

