### PR TITLE
ExcelAnalyzer locking and rescan

### DIFF
--- a/lib/config/wdtk-routes.rb
+++ b/lib/config/wdtk-routes.rb
@@ -118,4 +118,9 @@ Rails.application.routes.draw do
       as: :welcome
 
   post '/welcome' => 'users/confirmations#force_confirm'
+
+  # Re-run ExcelAnalyzer analysis on an attachment from the admin UI
+  post '/admin/attachments/:foi_attachment_id/scan' =>
+         'excel_analyzer/scans#create',
+       as: :admin_foi_attachment_scan
 end

--- a/lib/excel_analyzer/controllers/scans_controller.rb
+++ b/lib/excel_analyzer/controllers/scans_controller.rb
@@ -1,0 +1,38 @@
+##
+# Allow admins to re-run the ExcelAnalyzer analysis on a FoiAttachment.
+#
+# Re-analysing the blob repopulates its :excel metadata and re-fires the
+# on_hidden_metadata flow (hide + PII Badger) for suspect files.
+#
+module ExcelAnalyzer
+  class ScansController < AdminController
+    before_action :set_foi_attachment, :set_incoming_message, :set_info_request
+    before_action :check_info_request
+
+    def create
+      @foi_attachment.file_blob.analyze_later
+      redirect_to edit_admin_foi_attachment_path(@foi_attachment),
+                  notice: 'Re-scan queued.'
+    end
+
+    private
+
+    def set_foi_attachment
+      @foi_attachment = FoiAttachment.find(params[:foi_attachment_id])
+    end
+
+    def set_incoming_message
+      @incoming_message = @foi_attachment&.incoming_message
+    end
+
+    def set_info_request
+      @info_request = @incoming_message&.info_request
+    end
+
+    def check_info_request
+      return if can? :admin, @info_request
+
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/lib/excel_analyzer/jobs/pii_badger_job.rb
+++ b/lib/excel_analyzer/jobs/pii_badger_job.rb
@@ -17,9 +17,14 @@ module ExcelAnalyzer
 
         pii_badger_metadata = IO.popen(cmd) { JSON.parse(_1.read) }
 
-        attachment_blob.update(metadata: attachment_blob.metadata.merge(
-          pii_badger: pii_badger_metadata
-        ))
+        # Lock and reload before merging so the analyzer's :excel metadata,
+        # which ActiveStorage persists concurrently, is not clobbered by a
+        # stale in-memory copy.
+        attachment_blob.with_lock do
+          attachment_blob.update(metadata: attachment_blob.metadata.merge(
+            pii_badger: pii_badger_metadata
+          ))
+        end
       end
 
       ExcelAnalyzer::RepublishOrReportJob.perform_later(attachment_blob)

--- a/lib/views/admin/foi_attachments/_intro.html.erb
+++ b/lib/views/admin/foi_attachments/_intro.html.erb
@@ -1,0 +1,19 @@
+<% @title = "Attachment #{foi_attachment.id} of FOI request '#{info_request.title}'" %>
+<h1>Attachment <%= foi_attachment.id %></h1>
+
+<ul class="breadcrumb">
+  <li>FOI request: <%= both_links(info_request) %> <span class="divider">/</span></li>
+  <li>Message: <%= both_links(incoming_message) %> <span class="divider">/</span></li>
+  <li class="active">Attachment: <%= both_links(foi_attachment) %></li>
+</ul>
+
+<% if ExcelAnalyzer.content_types.include?(foi_attachment.file_blob&.content_type) %>
+  <div>
+    <%= button_to 'Re-scan for hidden data',
+                  admin_foi_attachment_scan_path(foi_attachment),
+                  class: 'btn' %>
+    <span class="muted">
+      Re-runs the automated analysis and repopulates the file's metadata.
+    </span>
+  </div>
+<% end %>

--- a/spec/excel_analyzer/controllers/scans_controller_spec.rb
+++ b/spec/excel_analyzer/controllers/scans_controller_spec.rb
@@ -1,0 +1,52 @@
+require_relative '../../spec_helper'
+
+RSpec.describe ExcelAnalyzer::ScansController, type: :controller do
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+
+  before { sign_in(admin_user) }
+
+  let(:info_request) { FactoryBot.create(:info_request, :with_plain_incoming) }
+  let(:incoming_message) { info_request.incoming_messages.first }
+  let!(:attachment) { incoming_message.foi_attachments.first }
+
+  before do
+    attachment.file_blob.update(
+      content_type: ExcelAnalyzer::XlsxAnalyzer::CONTENT_TYPE
+    )
+  end
+
+  describe 'POST #create' do
+    let(:params) { { foi_attachment_id: attachment.id } }
+
+    it 'assigns the attachment' do
+      post :create, params: params
+      expect(assigns[:foi_attachment]).to eq(attachment)
+    end
+
+    it 'queues re-analysis of the attachment blob' do
+      expect { post :create, params: params }.
+        to have_enqueued_job(ActiveStorage::AnalyzeJob)
+    end
+
+    it 'sets a success notice' do
+      post :create, params: params
+      expect(flash[:notice]).to eq('Re-scan queued.')
+    end
+
+    it 'redirects to the attachment edit page' do
+      post :create, params: params
+      expect(response).to redirect_to(
+        edit_admin_foi_attachment_path(attachment)
+      )
+    end
+
+    context 'when the admin cannot access the request' do
+      before { allow(controller).to receive(:can?).and_return(false) }
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect { post :create, params: params }.
+          to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/excel_analyzer/foi_attachment_scan_button_spec.rb
+++ b/spec/excel_analyzer/foi_attachment_scan_button_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../spec_helper'
+
+RSpec.describe Admin::FoiAttachmentsController, type: :controller do
+  render_views
+
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+
+  before { sign_in(admin_user) }
+
+  let(:info_request) { FactoryBot.create(:info_request, :with_plain_incoming) }
+  let(:incoming_message) { info_request.incoming_messages.first }
+  let!(:attachment) { incoming_message.foi_attachments.first }
+
+  describe 'GET edit' do
+    context 'when the attachment is a spreadsheet' do
+      before do
+        attachment.file_blob.update(
+          content_type: ExcelAnalyzer::XlsxAnalyzer::CONTENT_TYPE
+        )
+      end
+
+      it 'shows the re-scan button' do
+        get :edit, params: { id: attachment.id }
+        expect(response.body).to have_button('Re-scan for hidden data')
+      end
+    end
+
+    context 'when the attachment is not a spreadsheet' do
+      it 'does not show the re-scan button' do
+        get :edit, params: { id: attachment.id }
+        expect(response.body).not_to have_button('Re-scan for hidden data')
+      end
+    end
+  end
+end

--- a/spec/excel_analyzer/jobs/pii_badger_job_spec.rb
+++ b/spec/excel_analyzer/jobs/pii_badger_job_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe ExcelAnalyzer::PIIBadgerJob, type: :job do
   end
 
   before do
-    blob.update(metadata: blob.metadata.merge(excel: excel_metadata))
+    # Seed :excel via a separate instance so the job's in-memory blob is stale,
+    # mirroring ActiveStorage persisting the analyzer metadata concurrently.
+    other = ActiveStorage::Blob.find(blob.id)
+    other.update(metadata: other.metadata.merge(excel: excel_metadata))
+
     allow(IO).to receive(:popen).and_return(pii_metadata)
   end
 
@@ -32,6 +36,12 @@ RSpec.describe ExcelAnalyzer::PIIBadgerJob, type: :job do
   it 'updates the blob metadata' do
     expect { perform }.to change(blob, :metadata)
     expect(blob.metadata).to include(pii_badger: pii_metadata)
+  end
+
+  it 'preserves concurrently persisted excel metadata' do
+    perform
+    expect(blob.reload.metadata).
+      to include(excel: excel_metadata, pii_badger: pii_metadata)
   end
 
   it 'queues Republish or Report job' do


### PR DESCRIPTION
## What does this do?

1. Lock blob metadata merge in PIIBadgerJob
2. Add rescan button to the admin UI to re-run the ExcelAnalyzer analysis.

