### PR TITLE
Add DofE unmonitored address to no reply to list

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -294,6 +294,7 @@ Rails.configuration.to_prepare do
     icaseworkinformationrequests@lambeth.gov.uk
     noreply@eastleigh.gov.uk
     FOI@hmpo.gov.uk
+    Unmonitored.ACCOUNT@education.gov.uk
   )
 
   User.content_limits = {


### PR DESCRIPTION
Several requests have received responses from this address. While it does appear that the mailbox is in fact monitored, DofE has requested that emails be sent to a different address.

## Relevant issue(s)
N/A
## What does this do?

## Why was this needed?

See email sent to that address from support mailbox on 14 May 2026 for details.

## Implementation notes

## Screenshots

## Notes to reviewer
