### PR TITLE
Improved rounded corners for correspondence

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -36,7 +36,7 @@ $main_menu-active_link_text: $main_menu-link_bg;
 $submenu-highlight: rgba(0, 0, 0, 0.2);
 
 $incoming-correspondence-color: $color_violet;
-$incoming-correspondence-background: $color_white;
+$incoming-correspondence-background: transparent;
 $outgoing-correspondence-color: $color_orange;
 $outgoing-correspondence-background: $color_white;
 $comment-color: darken($color_light_grey, 10%);
@@ -939,30 +939,6 @@ div.correspondence {
   }
   &::after {
     right: -2px;
-  }
-  .incoming &::before {
-    background-image:
-      linear-gradient(to right, $body-bg 2px, transparent 0),
-      linear-gradient(to bottom, transparent 5px, $incoming-correspondence-color 0),
-      radial-gradient(circle at 7px 5px, $incoming-correspondence-color 5px, $body-bg 0);
-  }
-  .outgoing &::before {
-    background-image:
-      linear-gradient(to right, $body-bg 2px, transparent 0),
-      linear-gradient(to bottom, transparent 5px, $outgoing-correspondence-color 0),
-      radial-gradient(circle at 7px 5px, $outgoing-correspondence-color 5px, $body-bg 0);
-  }
-  .incoming &::after {
-    background-image:
-      linear-gradient(to left, $body-bg 2px, transparent 0),
-      linear-gradient(to bottom, transparent 5px, $incoming-correspondence-color 0),
-      radial-gradient(circle at 0 5px, $incoming-correspondence-color 5px, $body-bg 0);
-  }
-  .outgoing &::after {
-    background-image:
-      linear-gradient(to left, $body-bg 2px, transparent 0),
-      linear-gradient(to bottom, transparent 5px, $outgoing-correspondence-color 0),
-      radial-gradient(circle at 0 5px, $outgoing-correspondence-color 5px, $body-bg 0);
   }
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes part of: https://github.com/mysociety/alaveteli/issues/9294

## What does this do?

- Now that the white background is applied to the correspondence text and event actions, there is no need for the pseudo elements that were creating the rounded corners.

## Why was this needed?

I noticed that the problem was not only happening on the `correspondence--current` that class only made it more obvious because of the box-shadow. I changed the background colour of the body to something darker and you can see the sharp corners for every `correspondence` element

<img width="862" height="906" alt="Screenshot 2026-08-11 at 07 13 20" src="https://github.com/user-attachments/assets/e87121a3-3328-4fd3-a2bf-8beaae24b8ff" />


## Implementation notes

⚠️ This PR is part of an [Alaveteli PR](https://github.com/mysociety/alaveteli/pull/9452)

## Screenshots

### `correspondence--current`
<img width="1089" height="542" alt="Screenshot 2026-08-11 at 07 05 29" src="https://github.com/user-attachments/assets/7fb07da4-e012-4934-a8c3-7015a9f7b9d9" />


<img width="862" height="906" alt="Screenshot 2026-08-11 at 07 32 03" src="https://github.com/user-attachments/assets/ade3b499-56bf-420f-847b-8429ce9fbdb4" />


## Notes to reviewer
