### PR TITLE
Minor language/format/clarification to officers' page

### DIFF
--- a/lib/views/help/officers.html.erb
+++ b/lib/views/help/officers.html.erb
@@ -14,7 +14,7 @@
         mySociety.
       </p>
       <p>
-        WhatDoTheyKnow has processed over 900,000 FOI requests since its launch
+        WhatDoTheyKnow has processed over 1,300,000 FOI requests since its launch
         in 2008, and is the UK’s most widely-known FOI service. We also campaign
         for citizen’s rights to information and for the strengthening of FOI
         laws.
@@ -154,8 +154,8 @@
         Look at it like this - if lots of different people made requests from
         different Hotmail email addresses, then you would not think that Microsoft were
         making vexatious requests. It is exactly the same if lots of requests are made
-        via WhatDoTheyKnow. Moreover, since all requests are public it is much easier
-        for you to see if one of our users is making vexatious requests.
+        via WhatDoTheyKnow. Moreover, since most requests are immediately public, it is 
+        much easier for you to see if one of our users is making vexatious requests.
       </p>
     </dd>
     <dt id="spam_problems">
@@ -177,7 +177,7 @@
         filters” in the IT department of the authority. Authorities can make
         sure this doesn’t happen by asking their IT departments to “whitelist”
         any email from <strong>@whatdotheyknow.com</strong>. If you <a href="<%=
-        help_contact_path %>">ask us</a> we will resend any request, and/or give
+        help_contact_path %>">ask us</a>, we will resend any request, and/or give
         technical details of delivery so an IT department can chase up what
         happened to the message.
       </p>


### PR DESCRIPTION
## Relevant issue(s)
None

## What does this do?
Makes minor changes to punctuation and language on the officers' help page, as well as updating the statistics for number of requests and clarifying that not all requests are immediately public.

## Why was this needed?
To keep the help page up-to-date, clear and comprehensive

## Implementation notes
I've not changed any markup, only the language, so hopefully I haven't broken anything.

## Screenshots
None

## Notes to reviewer
None as yet
